### PR TITLE
NameExpansionResults handle has_plurality better.

### DIFF
--- a/gslib/commands/cp.py
+++ b/gslib/commands/cp.py
@@ -1565,7 +1565,7 @@ class CpCommand(Command):
     else:
       if len(self.args) < 2:
         raise CommandException('Wrong number of arguments for "cp" command.')
-      uri_strs = self.args[0:len(self.args)-1]
+      uri_strs = self.args[:-1]
 
     (exp_dst_uri, have_existing_dst_container) = self._ExpandDstUri(
          self.args[-1])

--- a/gslib/name_expansion.py
+++ b/gslib/name_expansion.py
@@ -203,6 +203,7 @@ class _NameExpansionIterator(object):
     self.have_existing_dst_container = have_existing_dst_container
     self.flat = flat
     self.all_versions = all_versions
+    self.ever_had_plurality = self.uri_strs.has_plurality()
 
     # Map holding wildcard strings to use for flat vs subdir-by-subdir listings.
     # (A flat listing means show all objects expanded all the way down.)
@@ -243,7 +244,7 @@ class _NameExpansionIterator(object):
       wc = self._flatness_wildcard[self.flat]
       src_uri_expands_to_multi = (post_step1_iter.has_plurality()
                                   or post_step2_iter.has_plurality())
-      is_multi_src_request = (self.uri_strs.has_plurality()
+      is_multi_src_request = (self.ever_had_plurality
                               or src_uri_expands_to_multi)
 
       if post_step2_iter.is_empty():


### PR DESCRIPTION
This addresses #131.  I suspect this is happening because, in `cp.py`, each `name_expansion_result` in `_CopyFunc` isn't correctly being marked as having "plurality", which causes the copy to assume that the remote key is intended to be a file and not a directory.
