### PR TITLE
Fix setmeta command for S3 objects.

### DIFF
--- a/gslib/commands/setmeta.py
+++ b/gslib/commands/setmeta.py
@@ -169,8 +169,8 @@ class SetMetaCommand(Command):
       self.logger.info('Setting metadata on %s...', exp_src_uri)
 
       key = exp_src_uri.get_key()
-      metageneration = key.metageneration
-      generation = key.generation
+      metageneration = getattr(key, 'metageneration', None)
+      generation = getattr(key, 'generation', None)
 
       headers = {}
       if generation:


### PR DESCRIPTION
After this patch, I was able to run a gsutil `setmeta -h Content-Type:foo/jeff` command, followed by `ls -L` and see my change as:

```
s3://....
...
    Content-Type:       foo/jeff
...
TOTAL: 1 objects, 5 bytes (5 B)
```
