### PR TITLE
Fix test using ? glob with ObjectToURI

### DIFF
--- a/gslib/tests/test_naming.py
+++ b/gslib/tests/test_naming.py
@@ -840,7 +840,7 @@ class GsutilNamingTests(testcase.GsUtilUnitTestCase):
     for i, final_dst_char in enumerate(('', '/')):
       # Copy some files into place in dst bucket.
       self.RunCommand(
-          'cp', [suri(src_bucket_uri, 'f%df?' % i),
+          'cp', [suri(src_bucket_uri, 'f%df*' % i),
                  suri(dst_bucket_uri, 'dst_subdir%d' % i) + final_dst_char])
       # Now do the move test.
       self.RunCommand(


### PR DESCRIPTION
Passing a ? wildcard through ObjectToURI does not work because passing
the constructed URI through urlparse.urlparse() interprets ? as a query
and strips it off since there is no query string following it. The *
glob which is actually used in the very next call doesn't have that
problem so just use that instead.
