### PR TITLE
Add Generation and Metageneration to gsutil stat output.

### DIFF
--- a/gslib/commands/ls.py
+++ b/gslib/commands/ls.py
@@ -143,7 +143,9 @@ _detailed_help_text = ("""
             Size:               2276224
             Cache-Control:      private, max-age=0
             Content-Type:       application/x-executable
-            ETag:       5ca6796417570a586723b7344afffc81
+            ETag:               5ca6796417570a586723b7344afffc81
+            Generation:         1378862725952000
+            Metageneration:     1
             ACL:        <Owner:00b4903a97163d99003117abe64d292561d2b4074fc90ce5c0e35ac45f66ad70, <<UserById: 00b4903a97163d99003117abe64d292561d2b4074fc90ce5c0e35ac45f66ad70>: u'FULL_CONTROL'>>
     TOTAL: 1 objects, 2276224 bytes (2.17 MB)
 

--- a/gslib/tests/test_stat.py
+++ b/gslib/tests/test_stat.py
@@ -39,6 +39,8 @@ class TestStat(testcase.GsUtilIntegrationTestCase):
     self.assertIn('Hash (crc32c):', stdout)
     self.assertIn('Hash (md5):', stdout)
     self.assertIn('ETag:', stdout)
+    self.assertIn('Generation:', stdout)
+    self.assertIn('Metageneration:', stdout)
 
   def test_minus_q_stat(self):
     object_uri = self.CreateObject(contents='z')

--- a/gslib/util.py
+++ b/gslib/util.py
@@ -439,6 +439,10 @@ def PrintFullInfoAboutUri(uri, incl_acl, headers):
         print '\tHash (%s):\t\t%s' % (
             alg, binascii.b2a_hex(obj.cloud_hashes[alg]))
     print '\tETag:\t\t\t%s' % obj.etag.strip('"\'')
+    if hasattr(obj, 'generation'):
+      print '\tGeneration:\t\t%s' % obj.generation
+    if hasattr(obj, 'metageneration'):
+      print '\tMetageneration:\t\t%s' % obj.metageneration
     if incl_acl:
       print '\tACL:\t\t%s' % (uri.get_acl(False, headers))
     return (1, obj.size)


### PR DESCRIPTION
Right now, it is not possible for developers to atomically get
the generation or metageneration, since gsutil ls -la is not
atomic. Add this info to gsutil stat output to resolve this problem.

This change has the side effect of adding the same output
to gsutil ls -L output.
