### PR TITLE
address install issue for "default" tar archive

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -85,8 +85,13 @@ def PlaceNeededFiles(self, target_dir):
       mock_storage_src1
       if os.path.isfile(mock_storage_src1) else mock_storage_src2)
   if not os.path.isfile(mock_storage_src):
-    raise Exception('Unable to find required boto test source file at %s or %s.'
-                    % (mock_storage_src1, mock_storage_src2))
+    msg = 'WARNING Unable to find required boto test source file at '
+    msg += mock_storage_src1
+    msg += ' or '
+    msg += mock_storage_src2
+    msg += '. Unit tests requiering storage will not execute properly.'
+    print(msg)
+    return
   with open(mock_storage_src, 'r') as f:
     mock_storage_contents = f.read()
   with open(mock_storage_dst, 'w') as f:


### PR DESCRIPTION
- Do not error out of install for tests
  - For the tar archive created by SCM system does not contain the
    source for the subprojects, such as boto. Therefore,
    third_party/boto is empty by default. We should not error out of
    the installation due to a missing file in the default archive,
    issue a warning instead about the unit test failure issue
