### PR TITLE
Fixes suggested commands in gsutil update

### DIFF
--- a/gslib/commands/update.py
+++ b/gslib/commands/update.py
@@ -184,8 +184,8 @@ class UpdateCommand(Command):
         'to update using the following commands. You will be prompted for your '
         'password, and the install will run as "root". If you\'re unsure what '
         'this means please ask your system administrator for help:')) + (
-            '\n\tchmod 644 %s\n\tsudo env BOTO_CONFIG=%s gsutil update'
-            '\n\tchmod 600 %s') % (config_files, config_files, config_files),
+            '\n\tsudo chmod 644 %s\n\tsudo env BOTO_CONFIG="%s" gsutil update'
+            '\n\tsudo chmod 600 %s') % (config_files, config_files, config_files),
                            informational=True)
 
   # This list is checked during gsutil update by doing a lowercased


### PR DESCRIPTION
Without this change, I get an error:

Would you like to update [Y/n]? y
Since it was installed by a different user previously, you will need
to update using the following commands. You will be prompted for your
password, and the install will run as "root". If you're unsure what
this means please ask your system administrator for help:
  chmod 644 /etc/boto.cfg /home/kirpichov/.boto
  sudo env BOTO_CONFIG=/etc/boto.cfg /home/kirpichov/.boto gsutil update
  chmod 600 /etc/boto.cfg /home/kirpichov/.boto
kirpichov@instance1:~$ chmod 644 /etc/boto.cfg /home/kirpichov/.boto
chmod: changing permissions of `/etc/boto.cfg': Operation not permitted
kirpichov@instance1:~$ sudo chmod 644 /etc/boto.cfg /home/kirpichov/.boto
kirpichov@instance1:~$ sudo env BOTO_CONFIG=/etc/boto.cfg /home/kirpichov/.boto gsutil update
env: /home/kirpichov/.boto: Permission denied

With this change, it becomes:

sudo chmod 644 /etc/boto.cfg /home/kirpichov/.boto
sudo env BOTO_CONFIG="/etc/boto.cfg /home/kirpichov/.boto" gsutil update
sudo chmod 600 /etc/boto.cfg /home/kirpichov/.boto

which works correctly.
