### PR TITLE
Use proxy settings from .boto config when calling httplib2.Http()

### DIFF
--- a/gslib/util.py
+++ b/gslib/util.py
@@ -320,10 +320,16 @@ def GetCleanupFiles():
 def GetNewHttp():
   # Some installers don't package a certs file with httplib2, so use the
   # one included with gsutil.
+  proxy_info=httplib2.ProxyInfo(
+      proxy_type=3,
+      proxy_host=boto.config.get('Boto', 'proxy', None),
+      proxy_port=boto.config.getint('Boto', 'proxy_port', 0),
+      proxy_user=boto.config.get('Boto', 'proxy_user', None),
+      proxy_pass=boto.config.get('Boto', 'proxy_pass', None))
   if GetCertsFile():
-    return httplib2.Http(ca_certs=GetCertsFile())
+    return httplib2.Http(proxy_info=proxy_info, ca_certs=GetCertsFile())
   else:
-    return httplib2.Http()
+    return httplib2.Http(proxy_info=proxy_info)
 
 
 def _RoundToNearestExponent(num):


### PR DESCRIPTION
gsutil unsets the http_proxy environment variable yet calls to httplib2.Http() use the default arguments which looks for proxy information from the environment.

Calls to httplib2.Http() where modified to use the proxy settings (if any) that
were obtained from the .boto configuration file.
