### PR TITLE
Changed hashing filename to avoid invalid filename

### DIFF
--- a/gslib/copy_helper.py
+++ b/gslib/copy_helper.py
@@ -2491,7 +2491,7 @@ def _HashFilename(filename):
   else:
     filename = unicode(filename, UTF8).encode(UTF8)
   m = hashlib.sha1(filename)
-  return 'TRACKER_' + m.hexdigest() + '.' + filename[-16:]
+  return 'TRACKER_' + m.hexdigest() + '.' + base64.b64encode(filename[-16:])
 
 
 def _DivideAndCeil(dividend, divisor):


### PR DESCRIPTION
I'm using MS Windows Korean version. And I can't upload some files including korean characters in some cases. "Couldn't read upload tracker file" happen because filename is invalid by filename[-16:]. This commit changed filename to base64 characters to avoid this.
