### PR TITLE
Only use proxy settings from boto if they are valid.

### DIFF
--- a/gslib/util.py
+++ b/gslib/util.py
@@ -415,7 +415,11 @@ def GetNewHttp(http_class=httplib2.Http, **kwargs):
   kwargs['ca_certs'] = GetCertsFile()
   # Use a non-infinite SSL timeout to avoid hangs during network flakiness.
   kwargs['timeout'] = SSL_TIMEOUT
-  http = http_class(proxy_info=proxy_info, **kwargs)
+  # If boto's proxy settings cannot be used, let Http determine the proxy
+  # information on its own (see crbug.com/443523).
+  if proxy_info.isgood():
+    kwargs['proxy_info'] = proxy_info
+  http = http_class(**kwargs)
   http.disable_ssl_certificate_validation = (not config.getbool(
       'Boto', 'https_validate_certificates'))
   return http


### PR DESCRIPTION
Do not assume .boto always has proper proxy settings. For example, this
is not the case for Chromium+depot_tools users, which are not even
required to have a boto configuration file around.

If the `ProxyInfo` object created by using the settings from boto is not
valid, do not pass `proxy_info` to `httplib2.Http` and instead rely on it
figuring out the proxy settings on its own (at present, it will look at
the user's proxy environment variables).

BUG=chromium:443523