### PR TITLE
Don't retry on HTTP 401 errors but fail immediately.

### DIFF
--- a/gslib/third_party/storage_apitools/http_wrapper.py
+++ b/gslib/third_party/storage_apitools/http_wrapper.py
@@ -251,7 +251,8 @@ def HandleExceptionsAndRebuildHttpConnections(retry_args):
   elif isinstance(retry_args.exc, exceptions.RequestError):
     logging.debug('Request returned no response, retrying')
   # API-level failures
-  elif isinstance(retry_args.exc, exceptions.BadStatusCodeError):
+  elif (isinstance(retry_args.exc, exceptions.BadStatusCodeError) and
+        retry_args.exc.status_code != httplib.UNAUTHORIZED):
     logging.debug('Response returned status %s, retrying',
                   retry_args.exc.status_code)
   elif isinstance(retry_args.exc, exceptions.RetryAfterError):


### PR DESCRIPTION
Under some rare circumstances (details below) gsutil can end up
spending long times retrying on HTTP 401 (Unauthorized) errors. There
is no point retrying when the request auth fails. In such case gsutil
should just bail out immediately.

Description of the problem:
Not sure what triggered this problem in the first place, but my gsutil
ended up in a state where the SSO cookie was still in place (so gsutil
did NOT bail out with the "No handler was ready to authenticate" msg)
but the server was rejecting the cookie and returning 401 requests.
Under the hoods the code in http_wrapper was retrying the request with
backoff as if there was no tomorrow.