### PR TITLE
Propagate project ID configuration option to child test processes

### DIFF
--- a/gslib/commands/test.py
+++ b/gslib/commands/test.py
@@ -29,6 +29,7 @@ import gslib
 from gslib.command import Command
 from gslib.command import ResetFailureCount
 from gslib.exception import CommandException
+from gslib.project_id import PopulateProjectId
 import gslib.tests as tests
 from gslib.util import IS_WINDOWS
 from gslib.util import NO_MAX
@@ -297,7 +298,9 @@ def CreateTestProcesses(parallel_tests, test_index, process_list, process_done,
     if root_coverage_file:
       env['GSUTIL_COVERAGE_OUTPUT_FILE'] = root_coverage_file
     process_list.append(subprocess.Popen(
-        executable_prefix + [gslib.GSUTIL_PATH] + ['test'] + s3_argument +
+        executable_prefix + [gslib.GSUTIL_PATH] +
+        ['-o', 'GSUtil:default_project_id=' + PopulateProjectId()] +
+        ['test'] + s3_argument +
         ['--' + _SEQUENTIAL_ISOLATION_FLAG] +
         [parallel_tests[test_index][len('gslib.tests.test_'):]],
         stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env))

--- a/gslib/tests/testcase/integration_testcase.py
+++ b/gslib/tests/testcase/integration_testcase.py
@@ -389,7 +389,9 @@ class GsUtilIntegrationTestCase(base.GsUtilTestCase):
       A tuple containing the desired return values specified by the return_*
       arguments.
     """
-    cmd = [gslib.GSUTIL_PATH] + ['--testexceptiontraces'] + cmd
+    cmd = ([gslib.GSUTIL_PATH] + ['--testexceptiontraces'] +
+          ['-o', 'GSUtil:default_project_id=' + PopulateProjectId()] +
+          cmd)
     if IS_WINDOWS:
       cmd = [sys.executable] + cmd
     p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,


### PR DESCRIPTION
When ```gsutil test``` is executed as part of Cloud SDK installation, it gets the configured project ID as a ```-o GSUtil:default_project_id``` command line option.  It should pass the project ID down to the child test processes so that the child processes get this setting.

Tested as follows:
* Removed ```~/.boto``` file.  Modified my local Cloud SDK installation to make ```platform/gsutil``` point to the modified gsutil location.  Ran ```gcloud auth login``` and ```gcloud config set project <Project ID>``` in Cloud SDK environment with subsequent ```gsutil test -p16``` to test the wrapper flow.
* Ran ```./gsutil config``` to configure gsutil's credentials and project ID.  Ran ```./gsutil test -p16``` to verify that the tests still pass in this flow.