### PR TITLE
storage_url: Remove a trailing dot in an exception message

### DIFF
--- a/gslib/storage_url.py
+++ b/gslib/storage_url.py
@@ -202,7 +202,7 @@ class _CloudUrl(StorageUrl):
         self.object_name = object_match.group('object')
         if self.object_name == '.' or self.object_name == '..':
           raise InvalidUrlError(
-              '%s is an invalid root-level object name.' % self.object_name)
+              '%s is an invalid root-level object name' % self.object_name)
         if self.scheme == 'gs':
           generation_match = GS_GENERATION_REGEX.match(self.object_name)
           if generation_match:


### PR DESCRIPTION
This is consistent with other exception messages.

Because a dot is appended [when the exception is printed to the user](https://github.com/GoogleCloudPlatform/gsutil/blob/adf221296/gslib/__main__.py#L576), this prints two dots instead of one:

    InvalidUrlError: . is an invalid root-level object name..

----
I’m submitting this PR directly because when I try to use Rietveld as [per your instructions](https://cloud.google.com/storage/docs/gsutil/addlhelp/ContributingCodetogsutil) it somehow doesn’t work:

```
$ ../rietveld/upload.py 
Upload server: codereview.appspot.com (change with -s/--server)
New issue subject: storage_url: Remove a trailing dot in an exception message
Email (login for uploading to codereview.appspot.com) [baptiste.fontaine@oscaro.com]: 
Password for baptiste.fontaine@oscaro.com: 
Traceback (most recent call last):
  File "../rietveld/upload.py", line 2721, in <module>
    main()
  File "../rietveld/upload.py", line 2713, in main
    RealMain(sys.argv)
  File "../rietveld/upload.py", line 2669, in RealMain
    response_body = rpc_server.Send("/upload", body, content_type=ctype)
  File "../rietveld/upload.py", line 447, in Send
    self._Authenticate()
  File "../rietveld/upload.py", line 502, in _Authenticate
    super(HttpRpcServer, self)._Authenticate()
  File "../rietveld/upload.py", line 382, in _Authenticate
    auth_token = self._GetAuthToken(credentials[0], credentials[1])
  File "../rietveld/upload.py", line 326, in _GetAuthToken
    response = self.opener.open(req)
  File "/usr/lib/python2.7/urllib2.py", line 410, in open
    response = meth(req, response)
  File "/usr/lib/python2.7/urllib2.py", line 523, in http_response
    'http', request, response, code, msg, hdrs)
  File "/usr/lib/python2.7/urllib2.py", line 448, in error
    return self._call_chain(*args)
  File "/usr/lib/python2.7/urllib2.py", line 382, in _call_chain
    result = func(*args)
  File "/usr/lib/python2.7/urllib2.py", line 531, in http_error_default
    raise HTTPError(req.get_full_url(), code, msg, hdrs, fp)
urllib2.HTTPError: HTTP Error 404: Not Found
```