### PR TITLE
Add transport compression support.

### DIFF
--- a/gslib/boto_translation.py
+++ b/gslib/boto_translation.py
@@ -838,8 +838,10 @@ class BotoTranslation(CloudApi):
       self, upload_stream, object_metadata, canned_acl=None, preconditions=None,
       size=None, serialization_data=None, tracker_callback=None,
       progress_callback=None, encryption_tuple=None, provider=None,
-      fields=None):
+      fields=None, gzip_encoded=False):
     """See CloudApi class for function doc strings."""
+    if gzip_encoded:
+      raise NotImplementedError('XML API does not suport gzip-encoded uploads.')
     if self.provider == 's3':
       # Resumable uploads are not supported for s3.
       return self.UploadObject(
@@ -869,8 +871,10 @@ class BotoTranslation(CloudApi):
   def UploadObjectStreaming(self, upload_stream, object_metadata,
                             canned_acl=None, progress_callback=None,
                             preconditions=None, encryption_tuple=None,
-                            provider=None, fields=None):
+                            provider=None, fields=None, gzip_encoded=False):
     """See CloudApi class for function doc strings."""
+    if gzip_encoded:
+      raise NotImplementedError('XML API does not suport gzip-encoded uploads.')
     headers, dst_uri = self._UploadSetup(object_metadata,
                                          preconditions=preconditions)
 
@@ -889,8 +893,12 @@ class BotoTranslation(CloudApi):
 
   def UploadObject(self, upload_stream, object_metadata, canned_acl=None,
                    preconditions=None, size=None, progress_callback=None,
-                   encryption_tuple=None, provider=None, fields=None):
+                   encryption_tuple=None, provider=None, fields=None,
+                   gzip_encoded=False):
     """See CloudApi class for function doc strings."""
+    if gzip_encoded:
+      raise NotImplementedError('XML API does not suport gzip-encoded uploads.')
+
     headers, dst_uri = self._UploadSetup(object_metadata,
                                          preconditions=preconditions)
 

--- a/gslib/cloud_api.py
+++ b/gslib/cloud_api.py
@@ -392,7 +392,8 @@ class CloudApi(object):
 
   def UploadObject(self, upload_stream, object_metadata, canned_acl=None,
                    size=None, preconditions=None, progress_callback=None,
-                   encryption_tuple=None, provider=None, fields=None):
+                   encryption_tuple=None, provider=None, fields=None,
+                   gzip_encoded=False):
     """Uploads object data and metadata.
 
     Args:
@@ -411,6 +412,7 @@ class CloudApi(object):
       provider: Cloud storage provider to connect to.  If not present,
                 class-wide default is used.
       fields: If present, return only these Object metadata fields.
+      gzip_encoded: Whether to use gzip transport encoding for the upload.
 
     Raises:
       ArgumentException for errors during input validation.
@@ -424,7 +426,7 @@ class CloudApi(object):
   def UploadObjectStreaming(self, upload_stream, object_metadata,
                             canned_acl=None, preconditions=None,
                             progress_callback=None, encryption_tuple=None,
-                            provider=None, fields=None):
+                            provider=None, fields=None, gzip_encoded=False):
     """Uploads object data and metadata.
 
     Args:
@@ -443,6 +445,7 @@ class CloudApi(object):
       provider: Cloud storage provider to connect to.  If not present,
                 class-wide default is used.
       fields: If present, return only these Object metadata fields.
+      gzip_encoded: Whether to use gzip transport encoding for the upload.
 
     Raises:
       ArgumentException for errors during input validation.
@@ -457,7 +460,7 @@ class CloudApi(object):
       self, upload_stream, object_metadata, canned_acl=None,
       size=None, preconditions=None, serialization_data=None,
       tracker_callback=None, progress_callback=None, encryption_tuple=None,
-      provider=None, fields=None):
+      provider=None, fields=None, gzip_encoded=False):
     """Uploads object data and metadata using a resumable upload strategy.
 
     Args:
@@ -484,6 +487,7 @@ class CloudApi(object):
                 class-wide default is used.
       fields: If present, return only these Object metadata fields when the
               upload is complete.
+      gzip_encoded: Whether to use gzip transport encoding for the upload.
 
     Raises:
       ArgumentException for errors during input validation.

--- a/gslib/cloud_api_delegator.py
+++ b/gslib/cloud_api_delegator.py
@@ -277,32 +277,36 @@ class CloudApiDelegator(CloudApi):
 
   def UploadObject(self, upload_stream, object_metadata, size=None,
                    canned_acl=None, preconditions=None, progress_callback=None,
-                   encryption_tuple=None, provider=None, fields=None):
+                   encryption_tuple=None, provider=None, fields=None,
+                   gzip_encoded=False):
     return self._GetApi(provider).UploadObject(
         upload_stream, object_metadata, size=size, canned_acl=canned_acl,
         preconditions=preconditions, progress_callback=progress_callback,
-        encryption_tuple=encryption_tuple, fields=fields)
+        encryption_tuple=encryption_tuple, fields=fields,
+        gzip_encoded=gzip_encoded)
 
   def UploadObjectStreaming(self, upload_stream, object_metadata,
                             canned_acl=None, preconditions=None,
                             progress_callback=None, encryption_tuple=None,
-                            provider=None, fields=None):
+                            provider=None, fields=None, gzip_encoded=False):
     return self._GetApi(provider).UploadObjectStreaming(
         upload_stream, object_metadata, canned_acl=canned_acl,
         preconditions=preconditions, progress_callback=progress_callback,
-        encryption_tuple=encryption_tuple, fields=fields)
+        encryption_tuple=encryption_tuple, fields=fields,
+        gzip_encoded=gzip_encoded)
 
   def UploadObjectResumable(
       self, upload_stream, object_metadata, canned_acl=None, preconditions=None,
       size=None, serialization_data=None, tracker_callback=None,
       progress_callback=None, encryption_tuple=None, provider=None,
-      fields=None):
+      fields=None, gzip_encoded=False):
     return self._GetApi(provider).UploadObjectResumable(
         upload_stream, object_metadata, canned_acl=canned_acl,
         preconditions=preconditions, size=size,
         serialization_data=serialization_data,
         tracker_callback=tracker_callback, progress_callback=progress_callback,
-        encryption_tuple=encryption_tuple, fields=fields)
+        encryption_tuple=encryption_tuple, fields=fields,
+        gzip_encoded=gzip_encoded)
 
   def CopyObject(self, src_obj_metadata, dst_obj_metadata, src_generation=None,
                  canned_acl=None, preconditions=None, progress_callback=None,

--- a/gslib/command.py
+++ b/gslib/command.py
@@ -83,6 +83,7 @@ from gslib.ui_controller import UIController
 from gslib.ui_controller import UIThread
 from gslib.util import CheckMultiprocessingAvailableAndInit
 from gslib.util import GetConfigFilePaths
+from gslib.util import GetMaxConcurrentCompressedUploads
 from gslib.util import HaveFileUrls
 from gslib.util import HaveProviderUrls
 from gslib.util import IS_WINDOWS
@@ -220,7 +221,7 @@ global total_tasks, call_completed_map, global_return_values_map
 global need_pool_or_done_cond, caller_id_finished_count, new_pool_needed
 global current_max_recursive_level, shared_vars_map, shared_vars_list_map
 global class_map, worker_checking_level_lock, failure_count, thread_stats
-global glob_status_queue, ui_controller
+global glob_status_queue, ui_controller, concurrent_compressed_upload_lock
 
 
 def InitializeMultiprocessingVariables():
@@ -294,6 +295,7 @@ def InitializeMultiprocessingVariables():
   global need_pool_or_done_cond, caller_id_finished_count, new_pool_needed
   global current_max_recursive_level, shared_vars_map, shared_vars_list_map
   global class_map, worker_checking_level_lock, failure_count, glob_status_queue
+  global concurrent_compressed_upload_lock
 
   manager = multiprocessing.Manager()
 
@@ -366,6 +368,11 @@ def InitializeMultiprocessingVariables():
   # undefined behavior when trying to interact with a non-existent queue.
   glob_status_queue = manager.Queue(MAX_QUEUE_SIZE)
 
+  # Semaphore lock used to prevent resource exhaustion when running many
+  # compressed uploads in parallel.
+  concurrent_compressed_upload_lock = manager.BoundedSemaphore(
+      GetMaxConcurrentCompressedUploads())
+
 
 def TeardownMultiprocessingProcesses():
   """Should be called by signal handlers prior to shut down."""
@@ -393,6 +400,7 @@ def InitializeThreadingVariables():
   global need_pool_or_done_cond, call_completed_map, class_map, thread_stats
   global task_queues, caller_id_lock, caller_id_counter, glob_status_queue
   global worker_checking_level_lock, current_max_recursive_level
+  global concurrent_compressed_upload_lock
   caller_id_counter = ProcessAndThreadSafeInt(False)
   caller_id_finished_count = AtomicDict()
   caller_id_lock = threading.Lock()
@@ -409,6 +417,8 @@ def InitializeThreadingVariables():
   task_queues = []
   total_tasks = AtomicDict()
   worker_checking_level_lock = threading.Lock()
+  concurrent_compressed_upload_lock = threading.BoundedSemaphore(
+      GetMaxConcurrentCompressedUploads())
 
 
 # Each subclass of Command must define a property named 'command_spec' that is

--- a/gslib/commands/config.py
+++ b/gslib/commands/config.py
@@ -203,6 +203,7 @@ _DETAILED_HELP_TEXT = ("""
       disable_analytics_prompt
       encryption_key
       json_api_version
+      max_upload_compression_buffer_size
       parallel_composite_upload_component_size
       parallel_composite_upload_threshold
       sliced_object_download_component_size
@@ -328,6 +329,12 @@ DEFAULT_PARALLEL_COMPOSITE_UPLOAD_COMPONENT_SIZE = '50M'
 DEFAULT_SLICED_OBJECT_DOWNLOAD_THRESHOLD = '150M'
 DEFAULT_SLICED_OBJECT_DOWNLOAD_COMPONENT_SIZE = '200M'
 DEFAULT_SLICED_OBJECT_DOWNLOAD_MAX_COMPONENTS = 4
+
+# Compressed transport encoded uploads buffer chunks of compressed data. When
+# running many uploads in parallel, compression may consume more memory than
+# available. This restricts the number of compressed transport encoded uploads
+# running in parallel such that they don't consume more memory than set here.
+DEFAULT_MAX_UPLOAD_COMPRESSION_BUFFER_SIZE = '2G'
 
 CONFIG_BOTO_SECTION_CONTENT = """
 [Boto]
@@ -490,6 +497,15 @@ CONFIG_INPUTLESS_GSUTIL_SECTION_CONTENT = """
 #sliced_object_download_component_size = %(sliced_object_download_component_size)s
 #sliced_object_download_max_components = %(sliced_object_download_max_components)s
 
+# Compressed transport encoded uploads buffer chunks of compressed data. When
+# running a composite upload and/or many uploads in parallel, compression may
+# consume more memory than available. This setting restricts the number of
+# compressed transport encoded uploads running in parallel such that they
+# don't consume more memory than set here. This is 2GiB by default.
+# Values can be provided either in bytes or as human-readable values
+# (e.g., "2G" to represent 2 gibibytes)
+#max_upload_compression_buffer_size = %(max_upload_compression_buffer_size)s
+
 # 'task_estimation_threshold' controls how many files or objects gsutil
 # processes before it attempts to estimate the total work that will be
 # performed by the command. Estimation makes extra directory listing or API
@@ -585,7 +601,9 @@ content_language = en
        'sliced_object_download_max_components': (
            DEFAULT_SLICED_OBJECT_DOWNLOAD_MAX_COMPONENTS),
        'max_component_count': MAX_COMPONENT_COUNT,
-       'task_estimation_threshold': DEFAULT_TASK_ESTIMATION_THRESHOLD}
+       'task_estimation_threshold': DEFAULT_TASK_ESTIMATION_THRESHOLD,
+       'max_upload_compression_buffer_size': (
+           DEFAULT_MAX_UPLOAD_COMPRESSION_BUFFER_SIZE)}
 
 CONFIG_OAUTH2_CONFIG_CONTENT = """
 [OAuth2]

--- a/gslib/commands/cp.py
+++ b/gslib/commands/cp.py
@@ -580,6 +580,26 @@ _OPTIONS_TEXT = """
                  stdin. This allows you to run a program that generates the list
                  of files to upload/download.
 
+  -j <ext,...>   Applies gzip transport encoding to any file upload whose
+                 extension matches the -j extension list. This is useful when
+                 uploading files with compressible content (such as .js, .css,
+                 or .html files) because it saves network bandwidth while
+                 also leaving the data uncompressed in Google Cloud Storage.
+
+                 When you specify the -j option, files being uploaded are
+                 compressed in-memory and on-the-wire only. Both the local
+                 files and GCS objects remain uncompressed. The uploaded
+                 objects retain the Content-Type and name of the original
+                 files.
+
+  -J             Applies gzip transport encoding to file uploads. This option
+                 works like the -j option described above, but it applies to
+                 all uploaded files, regardless of extension.
+
+                 Warning: If you use this option and some of the source files
+                 don't compress well (e.g., that's often true of binary data),
+                 this option may result in longer uploads.
+
   -L <file>      Outputs a manifest log file with detailed information about
                  each item that was copied. This manifest contains the following
                  information for each item:
@@ -745,7 +765,7 @@ _DETAILED_HELP_TEXT = '\n\n'.join([_SYNOPSIS_TEXT,
                                    _OPTIONS_TEXT])
 
 
-CP_SUB_ARGS = 'a:AcDeIL:MNnpPrRs:tUvz:Z'
+CP_SUB_ARGS = 'a:AcDeIL:MNnpPrRs:tUvz:Zj:J'
 
 
 def _CopyFuncWrapper(cls, args, thread_state=None):
@@ -943,8 +963,8 @@ class CpCommand(Command):
               self.logger, exp_src_url, dst_url, gsutil_api,
               self, _CopyExceptionHandler, src_obj_metadata=src_obj_metadata,
               allow_splitting=True, headers=self.headers,
-              manifest=self.manifest, gzip_exts=self.gzip_exts,
-              preserve_posix=preserve_posix))
+              manifest=self.manifest, gzip_encoded=self.gzip_encoded,
+              gzip_exts=self.gzip_exts, preserve_posix=preserve_posix))
       if copy_helper_opts.use_manifest:
         if md5:
           self.manifest.Set(exp_src_url.url_string, 'md5', md5)
@@ -1195,7 +1215,14 @@ class CpCommand(Command):
 
     self.skip_unsupported_objects = False
 
-    # Files matching these extensions should be gzipped before uploading.
+    # Files matching these extensions should be compressed.
+    # The gzip_encoded flag marks if the files should be compressed during
+    # the upload. The gzip_local flag marks if the files should be compressed
+    # before uploading. Files compressed prior to uploaded are stored
+    # compressed, while files compressed during the upload are stored
+    # uncompressed. These flags cannot be mixed.
+    gzip_encoded = False
+    gzip_local = False
     gzip_arg_exts = None
     gzip_arg_all = None
 
@@ -1224,6 +1251,12 @@ class CpCommand(Command):
           test_callback_file = a
         elif o == '-I':
           read_args_from_stdin = True
+        elif o == '-j':
+          gzip_encoded = True
+          gzip_arg_exts = [x.strip() for x in a.split(',')]
+        elif o == '-J':
+          gzip_encoded = True
+          gzip_arg_all = GZIP_ALL_FILES
         elif o == '-L':
           use_manifest = True
           self.manifest = Manifest(a)
@@ -1249,8 +1282,10 @@ class CpCommand(Command):
         elif o == '-v':
           print_ver = True
         elif o == '-z':
+          gzip_local = True
           gzip_arg_exts = [x.strip() for x in a.split(',')]
         elif o == '-Z':
+          gzip_local = True
           gzip_arg_all = GZIP_ALL_FILES
     if preserve_acl and canned_acl:
       raise CommandException(
@@ -1260,10 +1295,18 @@ class CpCommand(Command):
           'The gsutil -m option is not supported with the cp -A flag, to '
           'ensure that object version ordering is preserved. Please re-run '
           'the command without the -m option.')
-    if gzip_arg_exts and gzip_arg_all:
+    if gzip_encoded and gzip_local:
       raise CommandException(
-          'Specifying both the -z and -Z options together is invalid.')
+          'Specifying both the -j/-J and -z/-Z options together is invalid.')
+    if gzip_arg_exts and gzip_arg_all:
+      if gzip_encoded:
+        raise CommandException(
+            'Specifying both the -j and -J options together is invalid.')
+      else:
+        raise CommandException(
+            'Specifying both the -z and -Z options together is invalid.')
     self.gzip_exts = gzip_arg_exts or gzip_arg_all
+    self.gzip_encoded = gzip_encoded
 
     return CreateCopyHelperOpts(
         perform_mv=perform_mv,

--- a/gslib/tests/test_copy_helper_funcs.py
+++ b/gslib/tests/test_copy_helper_funcs.py
@@ -25,9 +25,12 @@ from gslib.cloud_api import ResumableUploadException
 from gslib.cloud_api import ResumableUploadStartOverException
 from gslib.cloud_api import ServiceException
 from gslib.command import CreateGsutilLogger
+from gslib.copy_helper import _DelegateUploadFileToObject
 from gslib.copy_helper import _GetPartitionInfo
+from gslib.copy_helper import _SelectUploadCompressionStrategy
 from gslib.copy_helper import _SetContentTypeFromFile
 from gslib.copy_helper import FilterExistingComponents
+from gslib.copy_helper import GZIP_ALL_FILES
 from gslib.copy_helper import PerformParallelUploadFileToObjectArgs
 from gslib.copy_helper import WarnIfMvEarlyDeletionChargeApplies
 from gslib.gcs_json_api import GcsJsonApi
@@ -121,7 +124,7 @@ class TestCpFuncs(GsUtilUnitTestCase):
     args_uploaded_correctly = PerformParallelUploadFileToObjectArgs(
         fpath_uploaded_correctly, 0, 1, fpath_uploaded_correctly_url,
         object_uploaded_correctly_url, '', empty_object, tracker_file,
-        tracker_file_lock, None)
+        tracker_file_lock, None, False)
 
     # Not yet uploaded, but needed.
     fpath_not_uploaded = self.CreateTempFile(file_name='foo2', contents='2')
@@ -131,7 +134,7 @@ class TestCpFuncs(GsUtilUnitTestCase):
     args_not_uploaded = PerformParallelUploadFileToObjectArgs(
         fpath_not_uploaded, 0, 1, fpath_not_uploaded_url,
         object_not_uploaded_url, '', empty_object, tracker_file,
-        tracker_file_lock, None)
+        tracker_file_lock, None, False)
 
     # Already uploaded, but contents no longer match. Even though the contents
     # differ, we don't delete this since the bucket is not versioned and it
@@ -151,7 +154,7 @@ class TestCpFuncs(GsUtilUnitTestCase):
     args_wrong_contents = PerformParallelUploadFileToObjectArgs(
         fpath_wrong_contents, 0, 1, fpath_wrong_contents_url,
         object_wrong_contents_url, '', empty_object, tracker_file,
-        tracker_file_lock, None)
+        tracker_file_lock, None, False)
 
     # Exists in tracker file, but component object no longer exists.
     fpath_remote_deleted = self.CreateTempFile(file_name='foo5', contents='5')
@@ -159,7 +162,7 @@ class TestCpFuncs(GsUtilUnitTestCase):
         str(fpath_remote_deleted))
     args_remote_deleted = PerformParallelUploadFileToObjectArgs(
         fpath_remote_deleted, 0, 1, fpath_remote_deleted_url, '', '',
-        empty_object, tracker_file, tracker_file_lock, None)
+        empty_object, tracker_file, tracker_file_lock, None, False)
 
     # Exists in tracker file and already uploaded, but no longer needed.
     fpath_no_longer_used = self.CreateTempFile(file_name='foo6', contents='6')
@@ -228,7 +231,7 @@ class TestCpFuncs(GsUtilUnitTestCase):
     args_uploaded_correctly = PerformParallelUploadFileToObjectArgs(
         fpath_uploaded_correctly, 0, 1, fpath_uploaded_correctly_url,
         object_uploaded_correctly_url, object_uploaded_correctly.generation,
-        empty_object, tracker_file, tracker_file_lock, None)
+        empty_object, tracker_file, tracker_file_lock, None, False)
 
     # Duplicate object name in tracker file, but uploaded correctly.
     fpath_duplicate = fpath_uploaded_correctly
@@ -245,7 +248,7 @@ class TestCpFuncs(GsUtilUnitTestCase):
         fpath_duplicate, 0, 1, fpath_duplicate_url,
         duplicate_uploaded_correctly_url,
         duplicate_uploaded_correctly.generation, empty_object, tracker_file,
-        tracker_file_lock, None)
+        tracker_file_lock, None, False)
 
     # Already uploaded, but contents no longer match.
     fpath_wrong_contents = self.CreateTempFile(file_name='foo4', contents='4')
@@ -263,7 +266,7 @@ class TestCpFuncs(GsUtilUnitTestCase):
     args_wrong_contents = PerformParallelUploadFileToObjectArgs(
         fpath_wrong_contents, 0, 1, fpath_wrong_contents_url,
         wrong_contents_url, '', empty_object, tracker_file,
-        tracker_file_lock, None)
+        tracker_file_lock, None, False)
 
     dst_args = {fpath_uploaded_correctly: args_uploaded_correctly,
                 fpath_wrong_contents: args_wrong_contents}
@@ -363,7 +366,8 @@ class TestCpFuncs(GsUtilUnitTestCase):
     # The file command should detect HTML in the real file.
     with SetBotoConfigForTest([('GSUtil', 'use_magicfile', 'True')]):
       _SetContentTypeFromFile(src_url_stub, dst_obj_metadata_mock)
-    self.assertEqual('text/html; charset=us-ascii', dst_obj_metadata_mock.contentType)
+    self.assertEqual(
+        'text/html; charset=us-ascii', dst_obj_metadata_mock.contentType)
 
     dst_obj_metadata_mock = mock.MagicMock(contentType=None)
     # The mimetypes module should guess based on the real file's extension.
@@ -434,3 +438,99 @@ class TestCpFuncs(GsUtilUnitTestCase):
       WarnIfMvEarlyDeletionChargeApplies(src_url, not_old_enough_nearline_obj,
                                          test_logger)
       mocked_warn.assert_not_called()
+
+  def testSelectUploadCompressionStrategyAll(self):
+    paths = ('file://test', 'test.xml', 'test.py')
+    exts = GZIP_ALL_FILES
+    for path in paths:
+      zipped, gzip_encoded = _SelectUploadCompressionStrategy(
+          path, False, exts, False)
+      self.assertTrue(zipped)
+      self.assertFalse(gzip_encoded)
+      zipped, gzip_encoded = _SelectUploadCompressionStrategy(
+          path, False, exts, True)
+      self.assertFalse(zipped)
+      self.assertTrue(gzip_encoded)
+
+  def testSelectUploadCompressionStrategyFilter(self):
+    zipped, gzip_encoded = _SelectUploadCompressionStrategy(
+        'test.xml', False, ['xml'], False)
+    self.assertTrue(zipped)
+    self.assertFalse(gzip_encoded)
+    zipped, gzip_encoded = _SelectUploadCompressionStrategy(
+        'test.xml', False, ['yaml'], False)
+    self.assertFalse(zipped)
+    self.assertFalse(gzip_encoded)
+
+  def testSelectUploadCompressionStrategyComponent(self):
+    zipped, gzip_encoded = _SelectUploadCompressionStrategy(
+        'test.xml', True, ['not_matching'], True)
+    self.assertFalse(zipped)
+    self.assertTrue(gzip_encoded)
+
+  def testDelegateUploadFileToObjectNormal(self):
+    mock_stream = mock.Mock()
+    mock_stream.close = mock.Mock()
+    def DelegateUpload():
+      return 'a', 'b'
+    elapsed_time, uploaded_object = _DelegateUploadFileToObject(
+        DelegateUpload, 'url', mock_stream, False, False, False, None)
+    # Ensure results are passed through.
+    self.assertEqual(elapsed_time, 'a')
+    self.assertEqual(uploaded_object, 'b')
+    # Ensure close was called.
+    self.assertTrue(mock_stream.close.called)
+
+  @mock.patch('os.unlink')
+  def testDelegateUploadFileToObjectZipped(self, mock_unlink):
+    mock_stream = mock.Mock()
+    mock_stream.close = mock.Mock()
+    mock_upload_url = mock.Mock()
+    mock_upload_url.object_name = 'Sample'
+    def DelegateUpload():
+      return 'a', 'b'
+    elapsed_time, uploaded_object = _DelegateUploadFileToObject(
+        DelegateUpload, mock_upload_url, mock_stream, True, False, False, None)
+    # Ensure results are passed through.
+    self.assertEqual(elapsed_time, 'a')
+    self.assertEqual(uploaded_object, 'b')
+    # Ensure the file was unlinked.
+    self.assertTrue(mock_unlink.called)
+    # Ensure close was called.
+    self.assertTrue(mock_stream.close.called)
+
+  @mock.patch('gslib.command.concurrent_compressed_upload_lock')
+  def testDelegateUploadFileToObjectGzipEncoded(self, mock_lock):
+    mock_stream = mock.Mock()
+    mock_stream.close = mock.Mock()
+    def DelegateUpload():
+      # Ensure the lock was aquired before the delegate was called.
+      self.assertTrue(mock_lock.__enter__.called)
+      return 'a', 'b'
+    elapsed_time, uploaded_object = _DelegateUploadFileToObject(
+        DelegateUpload, 'url', mock_stream, False, True, False, None)
+    # Ensure results are passed through.
+    self.assertEqual(elapsed_time, 'a')
+    self.assertEqual(uploaded_object, 'b')
+    # Ensure close was called.
+    self.assertTrue(mock_stream.close.called)
+    # Ensure the lock was released.
+    self.assertTrue(mock_lock.__exit__.called)
+
+  @mock.patch('gslib.command.concurrent_compressed_upload_lock')
+  def testDelegateUploadFileToObjectGzipEncodedComposite(self, mock_lock):
+    mock_stream = mock.Mock()
+    mock_stream.close = mock.Mock()
+    def DelegateUpload():
+      # Ensure the lock was not aquired before the delegate was called.
+      self.assertFalse(mock_lock.__enter__.called)
+      return 'a', 'b'
+    elapsed_time, uploaded_object = _DelegateUploadFileToObject(
+        DelegateUpload, 'url', mock_stream, False, True, True, None)
+    # Ensure results are passed through.
+    self.assertEqual(elapsed_time, 'a')
+    self.assertEqual(uploaded_object, 'b')
+    # Ensure close was called.
+    self.assertTrue(mock_stream.close.called)
+    # Ensure the lock was released.
+    self.assertFalse(mock_lock.__exit__.called)

--- a/gslib/tests/test_gcs_json_media.py
+++ b/gslib/tests/test_gcs_json_media.py
@@ -1,0 +1,106 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish, dis-
+# tribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the fol-
+# lowing conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABIL-
+# ITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+# SHALL THE AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+"""Tests for media helper functions and classes for GCS JSON API."""
+
+from gslib.gcs_json_media import BytesTransferredContainer
+from gslib.gcs_json_media import UploadCallbackConnectionClassFactory
+import gslib.tests.testcase as testcase
+import mock
+
+
+class TestUploadCallbackConnection(testcase.GsUtilUnitTestCase):
+  """Tests for the upload callback connection."""
+
+  def setUp(self):
+    super(TestUploadCallbackConnection, self).setUp()
+    self.bytes_container = BytesTransferredContainer()
+    self.class_factory = UploadCallbackConnectionClassFactory(
+        self.bytes_container, buffer_size=50, total_size=100,
+        progress_callback='Sample')
+    self.instance = self.class_factory.GetConnectionClass()('host')
+
+  @mock.patch('httplib.HTTPSConnection')
+  def testHeaderDefaultBehavior(self, mock_conn):
+    """Test the size modifier is correct under expected headers."""
+    mock_conn.putheader.return_value = None
+    self.instance.putheader('content-encoding', 'gzip')
+    self.instance.putheader('content-length', '10')
+    self.instance.putheader('content-range', 'bytes 0-104/*')
+    # Ensure the modifier is as expected.
+    self.assertAlmostEqual(self.instance.size_modifier, 10.5)
+
+  @mock.patch('httplib.HTTPSConnection')
+  def testHeaderIgnoreWithoutGzip(self, mock_conn):
+    """Test that the gzip content-encoding is required to modify size."""
+    mock_conn.putheader.return_value = None
+    self.instance.putheader('content-length', '10')
+    self.instance.putheader('content-range', 'bytes 0-99/*')
+    # Ensure the modifier is unchanged.
+    self.assertAlmostEqual(self.instance.size_modifier, 1.0)
+
+  @mock.patch('httplib.HTTPSConnection')
+  def testHeaderAlternativeRangeFormats(self, mock_conn):
+    """Test alternative content-range header formats."""
+    mock_conn.putheader.return_value = None
+    expected_values = [
+        # Test 'bytes %s-%s/*'
+        ('bytes 0-99/*', 10.0),
+        # Test 'bytes */%s'
+        ('bytes */100', 1.0),
+        # Test 'bytes %s-%s/%s'
+        ('bytes 0-99/100', 10.0),]
+    for (header, expected) in expected_values:
+      self.instance = self.class_factory.GetConnectionClass()('host')
+      self.instance.putheader('content-encoding', 'gzip')
+      self.instance.putheader('content-length', '10')
+      self.instance.putheader('content-range', header)
+      # Ensure the modifier is as expected.
+      self.assertAlmostEqual(self.instance.size_modifier, expected)
+
+  @mock.patch('httplib.HTTPSConnection')
+  def testHeaderParseFailure(self, mock_conn):
+    """Test incorrect header values do not raise exceptions."""
+    mock_conn.putheader.return_value = None
+    self.instance.putheader('content-encoding', 'gzip')
+    self.instance.putheader('content-length', 'bytes 10')
+    self.instance.putheader('content-range', 'not a number')
+    # Ensure the modifier is unchanged.
+    self.assertAlmostEqual(self.instance.size_modifier, 1.0)
+
+  @mock.patch('gslib.progress_callback.ProgressCallbackWithTimeout')
+  @mock.patch('httplib2.HTTPSConnectionWithTimeout')
+  def testSendDefaultBehavior(self, mock_conn, mock_callback):
+    mock_conn.send.return_value = None
+    self.instance.size_modifier = 2
+    self.instance.processed_initial_bytes = True
+    self.instance.callback_processor = mock_callback
+    # Send 10 bytes of data.
+    sample_data = b'0123456789'
+    self.instance.send(sample_data)
+    # Ensure the data is fully sent since the buffer size is 50 bytes.
+    self.assertTrue(mock_conn.send.called)
+    (_, sent_data), _ = mock_conn.send.call_args_list[0]
+    self.assertEqual(sent_data, sample_data)
+    # Ensure the progress callback is correctly scaled.
+    self.assertTrue(mock_callback.Progress.called)
+    [sent_bytes], _ = mock_callback.Progress.call_args_list[0]
+    self.assertEqual(sent_bytes, 20)

--- a/gslib/tests/test_perfdiag.py
+++ b/gslib/tests/test_perfdiag.py
@@ -18,15 +18,17 @@ from __future__ import absolute_import
 
 import os
 import socket
+import StringIO
 import sys
 
 import boto
-
+from gslib.commands.perfdiag import _GenerateFileData
 import gslib.tests.testcase as testcase
 from gslib.tests.util import ObjectToURI as suri
 from gslib.tests.util import RUN_S3_TESTS
 from gslib.tests.util import unittest
 from gslib.util import IS_WINDOWS
+import mock
 
 
 class TestPerfDiag(testcase.GsUtilIntegrationTestCase):
@@ -72,27 +74,35 @@ class TestPerfDiag(testcase.GsUtilIntegrationTestCase):
     self.AssertNObjectsInBucket(bucket_uri, 0, versioned=True)
 
   def _run_throughput_test(self, test_name, num_processes, num_threads,
-                           parallelism_strategy=None):
+                           parallelism_strategy=None, compression_ratio=None):
     bucket_uri = self.CreateBucket()
 
     cmd = ['perfdiag', '-n', str(num_processes * num_threads),
            '-s', '1024', '-c', str(num_processes), '-k', str(num_threads),
            '-t', test_name]
-    if parallelism_strategy:
+    if compression_ratio is not None:
+      cmd += ['-j', str(compression_ratio)]
+    if parallelism_strategy is not None:
       cmd += ['-p', parallelism_strategy]
     cmd += [suri(bucket_uri)]
 
-    self.RunGsUtil(cmd)
+    stderr_default = self.RunGsUtil(cmd, return_stderr=True)
+    stderr_custom = None
     if self._should_run_with_custom_endpoints():
-      self.RunGsUtil(self._custom_endpoint_flags + cmd)
+      stderr_custom = self.RunGsUtil(
+          self._custom_endpoint_flags + cmd, return_stderr=True)
     self.AssertNObjectsInBucket(bucket_uri, 0, versioned=True)
+    return (stderr_default, stderr_custom)
 
   def _run_each_parallel_throughput_test(self, test_name, num_processes,
-                                         num_threads):
-    self._run_throughput_test(test_name, num_processes, num_threads, 'fan')
+                                         num_threads, compression_ratio=None):
+    self._run_throughput_test(test_name, num_processes, num_threads, 'fan',
+                              compression_ratio=compression_ratio)
     if not RUN_S3_TESTS:
-      self._run_throughput_test(test_name, num_processes, num_threads, 'slice')
-      self._run_throughput_test(test_name, num_processes, num_threads, 'both')
+      self._run_throughput_test(test_name, num_processes, num_threads, 'slice',
+                                compression_ratio=compression_ratio)
+      self._run_throughput_test(test_name, num_processes, num_threads, 'both',
+                                compression_ratio=compression_ratio)
 
   def test_write_throughput_single_process_single_thread(self):
     self._run_throughput_test('wthru', 1, 1)
@@ -166,6 +176,29 @@ class TestPerfDiag(testcase.GsUtilIntegrationTestCase):
     self.assertIn('Number of listing calls made:', stdout)
     self.AssertNObjectsInBucket(bucket_uri, 0, versioned=True)
 
+  def test_gzip_write_throughput_single_process_single_thread(self):
+    (stderr_default, _) = self._run_throughput_test(
+        'wthru', 1, 1, compression_ratio=50)
+    self.assertIn('Gzip compression ratio: 50', stderr_default)
+    self.assertIn('Gzip transport encoding writes: True', stderr_default)
+    (stderr_default, _) = self._run_throughput_test(
+        'wthru_file', 1, 1, compression_ratio=50)
+    self.assertIn('Gzip compression ratio: 50', stderr_default)
+    self.assertIn('Gzip transport encoding writes: True', stderr_default)
+
+  def test_gzip_write_throughput_single_process_multi_thread(self):
+    self._run_each_parallel_throughput_test(
+        'wthru', 1, 2, compression_ratio=50)
+    self._run_each_parallel_throughput_test(
+        'wthru_file', 1, 2, compression_ratio=50)
+
+  @unittest.skipIf(IS_WINDOWS, 'Multiprocessing is not supported on Windows')
+  def test_gzip_write_throughput_multi_process_multi_thread(self):
+    self._run_each_parallel_throughput_test(
+        'wthru', 2, 2, compression_ratio=50)
+    self._run_each_parallel_throughput_test(
+        'wthru_file', 2, 2, compression_ratio=50)
+
 
 class TestPerfDiagUnitTests(testcase.GsUtilUnitTestCase):
   """Unit tests for perfdiag command."""
@@ -182,3 +215,39 @@ class TestPerfDiagUnitTests(testcase.GsUtilUnitTestCase):
     self.assertNotIn(
         'Listing produced more than the expected %d object(s).' % test_objects,
         mock_log_handler.messages['warning'])
+
+  @mock.patch('os.urandom')
+  def test_generate_file_data(self, mock_urandom):
+    """Test the right amount of random and sequential data is generated."""
+    def urandom(length):
+      return 'a' * length
+    mock_urandom.side_effect = urandom
+
+    fp = StringIO.StringIO()
+    _GenerateFileData(fp, 1000, 100, 1000)
+    self.assertEqual('a' * 1000, fp.getvalue())
+    self.assertEqual(1000, fp.tell())
+
+    fp = StringIO.StringIO()
+    _GenerateFileData(fp, 1000, 50, 1000)
+    self.assertIn('a' * 500, fp.getvalue())
+    self.assertIn('x' * 500, fp.getvalue())
+    self.assertEqual(1000, fp.tell())
+
+    fp = StringIO.StringIO()
+    _GenerateFileData(fp, 1001, 50, 1001)
+    self.assertIn('a' * 501, fp.getvalue())
+    self.assertIn('x' * 500, fp.getvalue())
+    self.assertEqual(1001, fp.tell())
+
+  @mock.patch('os.urandom')
+  def test_generate_file_data_repeat(self, mock_urandom):
+    """Test that random data repeats when exhausted."""
+    def urandom(length):
+      return 'a' * length
+    mock_urandom.side_effect = urandom
+
+    fp = StringIO.StringIO()
+    _GenerateFileData(fp, 8, 50, 4)
+    self.assertEqual('aaxxaaxx', fp.getvalue())
+    self.assertEqual(8, fp.tell())

--- a/gslib/tests/test_perfdiag.py
+++ b/gslib/tests/test_perfdiag.py
@@ -24,6 +24,7 @@ import sys
 import boto
 from gslib.commands.perfdiag import _GenerateFileData
 import gslib.tests.testcase as testcase
+from gslib.tests.testcase.integration_testcase import SkipForXML
 from gslib.tests.util import ObjectToURI as suri
 from gslib.tests.util import RUN_S3_TESTS
 from gslib.tests.util import unittest
@@ -176,6 +177,7 @@ class TestPerfDiag(testcase.GsUtilIntegrationTestCase):
     self.assertIn('Number of listing calls made:', stdout)
     self.AssertNObjectsInBucket(bucket_uri, 0, versioned=True)
 
+  @SkipForXML('No compressed transport encoding support for the XML API.')
   def test_gzip_write_throughput_single_process_single_thread(self):
     (stderr_default, _) = self._run_throughput_test(
         'wthru', 1, 1, compression_ratio=50)
@@ -186,6 +188,7 @@ class TestPerfDiag(testcase.GsUtilIntegrationTestCase):
     self.assertIn('Gzip compression ratio: 50', stderr_default)
     self.assertIn('Gzip transport encoding writes: True', stderr_default)
 
+  @SkipForXML('No compressed transport encoding support for the XML API.')
   def test_gzip_write_throughput_single_process_multi_thread(self):
     self._run_each_parallel_throughput_test(
         'wthru', 1, 2, compression_ratio=50)
@@ -193,6 +196,7 @@ class TestPerfDiag(testcase.GsUtilIntegrationTestCase):
         'wthru_file', 1, 2, compression_ratio=50)
 
   @unittest.skipIf(IS_WINDOWS, 'Multiprocessing is not supported on Windows')
+  @SkipForXML('No compressed transport encoding support for the XML API.')
   def test_gzip_write_throughput_multi_process_multi_thread(self):
     self._run_each_parallel_throughput_test(
         'wthru', 2, 2, compression_ratio=50)

--- a/gslib/tests/test_util.py
+++ b/gslib/tests/test_util.py
@@ -38,7 +38,7 @@ import mock
 class TestUtil(testcase.GsUtilUnitTestCase):
   """Tests for utility functions."""
 
-  def test_MakeHumanReadable(self):
+  def testMakeHumanReadable(self):
     """Tests converting byte counts to human-readable strings."""
     self.assertEqual(util.MakeHumanReadable(0), '0 B')
     self.assertEqual(util.MakeHumanReadable(1023), '1023 B')
@@ -50,7 +50,7 @@ class TestUtil(testcase.GsUtilUnitTestCase):
     self.assertEqual(util.MakeHumanReadable(1024 ** 5), '1 PiB')
     self.assertEqual(util.MakeHumanReadable(1024 ** 6), '1 EiB')
 
-  def test_MakeBitsHumanReadable(self):
+  def testMakeBitsHumanReadable(self):
     """Tests converting bit counts to human-readable strings."""
     self.assertEqual(util.MakeBitsHumanReadable(0), '0 bit')
     self.assertEqual(util.MakeBitsHumanReadable(1023), '1023 bit')
@@ -62,7 +62,7 @@ class TestUtil(testcase.GsUtilUnitTestCase):
     self.assertEqual(util.MakeBitsHumanReadable(1024 ** 5), '1 Pibit')
     self.assertEqual(util.MakeBitsHumanReadable(1024 ** 6), '1 Eibit')
 
-  def test_HumanReadableToBytes(self):
+  def testHumanReadableToBytes(self):
     """Tests converting human-readable strings to byte counts."""
     self.assertEqual(util.HumanReadableToBytes('1'), 1)
     self.assertEqual(util.HumanReadableToBytes('15'), 15)
@@ -96,7 +96,7 @@ class TestUtil(testcase.GsUtilUnitTestCase):
     self.assertEqual(util.HumanReadableToBytes('1EB'), 1024 ** 6)
     self.assertEqual(util.HumanReadableToBytes('1EiB'), 1024 ** 6)
 
-  def test_CompareVersions(self):
+  def testCompareVersions(self):
     """Tests CompareVersions for various use cases."""
     # CompareVersions(first, second) returns (g, m), where
     #   g is True if first known to be greater than second, else False.
@@ -176,7 +176,7 @@ class TestUtil(testcase.GsUtilUnitTestCase):
       line = util.MakeMetadataLine(*(params.args), **(params.kwargs))
       self.assertEqual(line, params.expected)
 
-  def test_ProxyInfoFromEnvironmentVar(self):
+  def testProxyInfoFromEnvironmentVar(self):
     """Tests ProxyInfoFromEnvironmentVar for various cases."""
     valid_variables = ['http_proxy', 'https_proxy']
     if not util.IS_WINDOWS:
@@ -234,7 +234,7 @@ class TestUtil(testcase.GsUtilUnitTestCase):
   @mock.patch.object(util.http_wrapper,
                      'HandleExceptionsAndRebuildHttpConnections')
   @mock.patch.object(util.logging, 'info')
-  def test_WarnAfterManyRetriesHandler(self, mock_log_info_fn, mock_wrapped_fn):
+  def testWarnAfterManyRetriesHandler(self, mock_log_info_fn, mock_wrapped_fn):
     # The only ExceptionRetryArgs attributes that the function cares about are
     # num_retries and total_wait_sec; we can pass None for the other values.
     retry_args_over_threshold = util.http_wrapper.ExceptionRetryArgs(
@@ -252,7 +252,7 @@ class TestUtil(testcase.GsUtilUnitTestCase):
     # Check that we did emit a message.
     self.assertTrue(mock_log_info_fn.called)
 
-  def test_UIDecimalShort(self):
+  def testUIDecimalShort(self):
     """Tests DecimalShort for UI."""
     self.assertEqual('12.3b', DecimalShort(12345678910))
     self.assertEqual('123.5m', DecimalShort(123456789))
@@ -263,7 +263,7 @@ class TestUtil(testcase.GsUtilUnitTestCase):
     self.assertEqual('43.2q', DecimalShort(43.25 * 10**15))
     self.assertEqual('43250.0q', DecimalShort(43.25 * 10**18))
 
-  def test_UIPrettyTime(self):
+  def testUIPrettyTime(self):
     """Tests PrettyTime for UI."""
     self.assertEqual('25:02:10', PrettyTime(90130))
     self.assertEqual('01:00:00', PrettyTime(3600))
@@ -271,7 +271,7 @@ class TestUtil(testcase.GsUtilUnitTestCase):
     self.assertEqual('100+ hrs', PrettyTime(3600*100))
     self.assertEqual('999+ hrs', PrettyTime(3600*10000))
 
-  def test_UIHumanReadableWithDecimalPlaces(self):
+  def testUIHumanReadableWithDecimalPlaces(self):
     """Tests HumanReadableWithDecimalPlaces for UI."""
     self.assertEqual('1.0 GiB', HumanReadableWithDecimalPlaces(1024**3 +
                                                                1024**2 * 10,
@@ -328,3 +328,10 @@ class TestUtil(testcase.GsUtilUnitTestCase):
 
     self.DoTestAddQueryParamToUrl(old_url, param_name, param_val, expected_url)
 
+  @mock.patch.object(util, 'GetMaxUploadCompressionBufferSize')
+  def testGetMaxConcurrentCompressedUploadsMinimum(self, mock_config):
+    """Test GetMaxConcurrentCompressedUploads returns at least 1."""
+    mock_config.return_value = 0
+    self.assertEqual(util.GetMaxConcurrentCompressedUploads(), 1)
+    mock_config.return_value = -1
+    self.assertEqual(util.GetMaxConcurrentCompressedUploads(), 1)

--- a/gslib/tests/testcase/base.py
+++ b/gslib/tests/testcase/base.py
@@ -102,7 +102,7 @@ class GsUtilTestCase(unittest.TestCase):
   def MakeTempUnicodeName(self, kind, prefix=''):
     return self.MakeTempName(kind, prefix=prefix) + '材'
 
-  def CreateTempDir(self, test_files=0):
+  def CreateTempDir(self, test_files=0, contents=None):
     """Creates a temporary directory on disk.
 
     The directory and all of its contents will be deleted after the test.
@@ -110,6 +110,7 @@ class GsUtilTestCase(unittest.TestCase):
     Args:
       test_files: The number of test files to place in the directory or a list
                   of test file names.
+      contents: The contents for each generated test file.
 
     Returns:
       The path to the new temporary directory.
@@ -121,7 +122,10 @@ class GsUtilTestCase(unittest.TestCase):
     except TypeError:
       test_files = [self.MakeTempName('file') for _ in range(test_files)]
     for i, name in enumerate(test_files):
-      self.CreateTempFile(tmpdir=tmpdir, file_name=name, contents='test %d' % i)
+      contents_file = contents
+      if contents_file is None:
+        contents_file = 'test %d' % i
+      self.CreateTempFile(tmpdir=tmpdir, file_name=name, contents=contents_file)
     return tmpdir
 
   def CreateTempFifo(self, tmpdir=None, file_name=None):


### PR DESCRIPTION
gsutil cp currently supports a combined gzip-compressed-and-stored encoding when uploading to Google Cloud Storage (GCS) via the -z/-Z arguments. This PR adds support for gzip-transport-compressed encoding when uploading to GCS.

Included:
- Integration with cp, rsync, and perfdiag commands.
- Resource limiting for parallel, transport compressed uploads.
Transport compressed uploads buffer data into memory to serve in a
chunked manor. For parallel uploads, many chunks may exist in memory
concurrently. To prevent excessive memory consumption, a lock is used
to restrict the number of transport compressed uploads that may be ran
in parallel.
- Dynamic progress printing for transport compressed uploads. To more
accurately represent the progress of a transport compressed upload, the
progress printing is scaled to display the effective upload rate.