### PR TITLE
 Prevent unit tests from failing when no default project id is provided.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ install:
 # command to run tests
 script:
   - gsutil version -l
-  - gsutil -o 'GSUtil:default_project_id=999999999' test -u
+  - gsutil test -u

--- a/gslib/project_id.py
+++ b/gslib/project_id.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Helper module for Google Cloud Storage project IDs."""
+"""Helper module for Google Cloud Storage project ids."""
 
 from __future__ import absolute_import
 
@@ -21,13 +21,24 @@ import boto
 from gslib.cloud_api import ProjectIdException
 
 GOOG_PROJ_ID_HDR = 'x-goog-project-id'
+UNIT_TEST_PROJECT_ID = None  # Set to a string value when running unit tests.
 
 
 def PopulateProjectId(project_id=None):
-  """Fills in a project_id from the boto config file if one is not provided."""
-  if not project_id:
-    default_id = boto.config.get_value('GSUtil', 'default_project_id')
-    if not default_id:
-      raise ProjectIdException('MissingProjectId')
+  """Returns the project_id from the boto config file if one is not provided."""
+  # Provided project_id takes highest precedence.
+  if project_id:
+    return project_id
+
+  # If present, return the default project id supplied in the boto config file.
+  default_id = boto.config.get_value('GSUtil', 'default_project_id')
+  if default_id:
     return default_id
-  return project_id
+
+  # Unit tests shouldn't interact with projects, but some functionality
+  # depends on this method to return a project id. If the default project id
+  # value has been set by the unit test setup, return that id.
+  if UNIT_TEST_PROJECT_ID:
+    return UNIT_TEST_PROJECT_ID
+
+  raise ProjectIdException('MissingProjectId')

--- a/gslib/tests/testcase/unit_testcase.py
+++ b/gslib/tests/testcase/unit_testcase.py
@@ -22,6 +22,7 @@ import sys
 import tempfile
 
 import boto
+from gslib import project_id
 from gslib import wildcard_iterator
 from gslib.boto_translation import BotoTranslation
 from gslib.cloud_api_delegator import CloudApiDelegator
@@ -74,6 +75,9 @@ class GsUtilUnitTestCase(base.GsUtilTestCase):
     cls.command_runner = CommandRunner(
         bucket_storage_uri_class=cls.mock_bucket_storage_uri,
         gsutil_api_class_map_factory=cls.mock_gsutil_api_class_map_factory)
+    # Ensure unit tests don't fail if no default_project_id is defined in the
+    # boto config file.
+    project_id.UNIT_TEST_PROJECT_ID = 'mock-project-id-for-unit-tests'
 
   def setUp(self):
     super(GsUtilUnitTestCase, self).setUp()


### PR DESCRIPTION
Making a pull request to ensure that unit tests still pass after the change to .travis.yml.