### PR TITLE
Correct info log messages for computing checksums

### DIFF
--- a/gslib/commands/rsync.py
+++ b/gslib/commands/rsync.py
@@ -541,7 +541,7 @@ def _ComputeNeededFileChecksums(logger, src_url_str, src_size, src_crc32c,
   if src_url.IsFileUrl():
     if dst_crc32c != _NA or dst_url.IsFileUrl():
       if src_size > TEN_MIB:
-        logger.info('Computing MD5 for %s...', src_url_str)
+        logger.info('Computing CRC32C for %s...', src_url_str)
       with open(src_url.object_name, 'rb') as fp:
         src_crc32c = CalculateB64EncodedCrc32cFromContents(fp)
     elif dst_md5 != _NA or dst_url.IsFileUrl():
@@ -557,7 +557,7 @@ def _ComputeNeededFileChecksums(logger, src_url_str, src_size, src_crc32c,
         dst_crc32c = CalculateB64EncodedCrc32cFromContents(fp)
     elif src_md5 != _NA:
       if dst_size > TEN_MIB:
-        logger.info('Computing CRC32C for %s...', dst_url_str)
+        logger.info('Computing MD5 for %s...', dst_url_str)
       with open(dst_url.object_name, 'rb') as fp:
         dst_md5 = CalculateB64EncodedMd5FromContents(fp)
   return (src_crc32c, src_md5, dst_crc32c, dst_md5)

--- a/gslib/commands/rsync.py
+++ b/gslib/commands/rsync.py
@@ -546,13 +546,13 @@ def _ComputeNeededFileChecksums(logger, src_url_str, src_size, src_crc32c,
         src_crc32c = CalculateB64EncodedCrc32cFromContents(fp)
     elif dst_md5 != _NA or dst_url.IsFileUrl():
       if dst_size > TEN_MIB:
-        logger.info('Computing MD5 for %s...', dst_url_str)
+        logger.info('Computing MD5 for %s...', src_url_str)
       with open(src_url.object_name, 'rb') as fp:
         src_md5 = CalculateB64EncodedMd5FromContents(fp)
   if dst_url.IsFileUrl():
     if src_crc32c != _NA:
       if src_size > TEN_MIB:
-        logger.info('Computing CRC32C for %s...', src_url_str)
+        logger.info('Computing CRC32C for %s...', dst_url_str)
       with open(dst_url.object_name, 'rb') as fp:
         dst_crc32c = CalculateB64EncodedCrc32cFromContents(fp)
     elif src_md5 != _NA:


### PR DESCRIPTION
When computing the MD5 or CRC32C of a file, we logger.info() to tell the user what's going on. The algorithm is mixed up on a couple of these messages, indicating MD5 when we're actually computing CRC32C, or vice versa.