### PR TITLE
Update compose docs to be consistent with web docs

### DIFF
--- a/gslib/commands/compose.py
+++ b/gslib/commands/compose.py
@@ -29,9 +29,8 @@ from gslib.third_party.storage_apitools import storage_v1_messages as apitools_m
 from gslib.utils.encryption_helper import GetEncryptionKeyWrapper
 from gslib.utils.translation_helper import PreconditionsFromHeaders
 
-MAX_COMPONENT_COUNT = 1024
 MAX_COMPOSE_ARITY = 32
-MAX_COMPONENT_RATE = 200
+MAX_COMPONENT_RATE = 1000
 
 _SYNOPSIS = """
   gsutil compose gs://bucket/obj1 [gs://bucket/obj2 ...] gs://bucket/composite
@@ -70,16 +69,9 @@ _DETAILED_HELP_TEXT = ("""
   Note that there is a limit (currently %d) to the number of components that can
   be composed in a single operation.
 
-  There is a limit (currently %d) to the total number of components
-  for a given composite object. This means you can append to each object at most
-  %d times.
-
-  There is a per-project rate limit (currently %d) to the number of components
-  you can compose per second. This rate counts both the components being
-  appended to a composite object as well as the components being copied when
-  the composite object of which they are a part is copied.
-""" % (MAX_COMPOSE_ARITY, MAX_COMPONENT_COUNT, MAX_COMPONENT_COUNT - 1,
-       MAX_COMPONENT_RATE))
+  There is a per-project rate limit (currently %d) to the number of source objects
+  you can compose per second.
+""" % (MAX_COMPOSE_ARITY, MAX_COMPONENT_RATE))
 
 
 class ComposeCommand(Command):


### PR DESCRIPTION
The gsutil docs have been updated to remove the compose max component limit and update the compose rate limit. This makes them consistent with https://cloud.google.com/storage/docs/gsutil/commands/compose.