### PR TITLE
update references to Mac OS X

### DIFF
--- a/gslib/addlhelp/crc32c.py
+++ b/gslib/addlhelp/crc32c.py
@@ -36,7 +36,7 @@ _DETAILED_HELP_TEXT = ("""
   The crcmod module contains a pure-Python implementation of CRC32C, but using
   it results in very poor performance. A Python C extension is also provided by
   crcmod, which requires compiling into a binary module for use. gsutil ships
-  with a precompiled crcmod C extension for Mac OS X; for other platforms, see
+  with a precompiled crcmod C extension for macOS; for other platforms, see
   the installation instructions below.
 
   At the end of each copy operation, the gsutil cp and rsync commands validate
@@ -87,15 +87,15 @@ _DETAILED_HELP_TEXT = ("""
     sudo pip uninstall crcmod
     sudo pip install -U crcmod
 
-  Mac OS X
-  --------
+  macOS
+  -----
 
-  gsutil distributes a pre-compiled version of crcmod for OS X, so you shouldn't
+  gsutil distributes a pre-compiled version of crcmod for macOS, so you shouldn't
   need to compile and install it yourself. If for some reason the pre-compiled
   version is not being detected, please let the Google Cloud Storage team know
   (see "gsutil help support").
 
-  To compile manually on OS X, you will first need to install
+  To compile manually on macOS, you will first need to install
   `XCode <https://developer.apple.com/xcode/>`_ and then run:
 
     sudo easy_install -U pip

--- a/gslib/addlhelp/encoding.py
+++ b/gslib/addlhelp/encoding.py
@@ -84,25 +84,25 @@ _DETAILED_HELP_TEXT = ("""
   names while listing buckets). However, because gsutil must perform
   translation, it is likely there are other erroneous edge cases when using
   Windows with Unicode. If you encounter problems, you might consider instead
-  using cygwin (on Windows) or Linux or MacOS - all of which support Unicode.
+  using cygwin (on Windows) or Linux or macOS - all of which support Unicode.
 
 
-<B>USING UNICODE FILENAMES ON MAC OS</B>
-  MacOS stores filenames in decomposed form (also known as
+<B>USING UNICODE FILENAMES ON MACOS</B>
+  macOS stores filenames in decomposed form (also known as
   `NFD normalization <https://en.wikipedia.org/wiki/Unicode_equivalence>`_).
   For example, if a filename contains an accented "e" character, that character
   will be converted to an "e" followed by an accent before being saved to the
   filesystem. As a consequence, it's possible to have different name strings
   for files uploaded from an operating system that doesn't enforce decomposed
-  form (like Ubuntu) from one that does (like MacOS).
+  form (like Ubuntu) from one that does (like macOS).
 
   The following example shows how this behavior could lead to unexpected
   results. Say you create a file with non-ASCII characters on Ubuntu. Ubuntu
   stores that filename in its composed form. When you upload the file to the
   cloud, it is stored as named. But if you use gsutil rysnc to bring the file to
-  a MacOS machine and edit the file, then when you use gsutil rsync to bring
+  a macOS machine and edit the file, then when you use gsutil rsync to bring
   this version back to the cloud, you end up with two different objects, instead
-  of overwriting the original. This is because MacOS converted the filename to
+  of overwriting the original. This is because macOS converted the filename to
   a decomposed form, and Cloud Storage sees this as a different object name.
 
 

--- a/gslib/addlhelp/metadata.py
+++ b/gslib/addlhelp/metadata.py
@@ -51,7 +51,7 @@ _DETAILED_HELP_TEXT = ("""
   which allows browsers to render the object properly. gsutil sets the
   Content-Type automatically at upload time, based on each filename extension.
   For example, uploading files with names ending in .txt will set Content-Type
-  to text/plain. If you're running gsutil on Linux or MacOS and would prefer to
+  to text/plain. If you're running gsutil on Linux or macOS and would prefer to
   have content type set based on naming plus content examination, see the
   use_magicfile configuration variable in the .boto configuration file (See
   also "gsutil help config"). In general, using use_magicfile is more robust

--- a/gslib/addlhelp/throttling.py
+++ b/gslib/addlhelp/throttling.py
@@ -26,7 +26,7 @@ _DETAILED_HELP_TEXT = ("""
   network link that's also used by a number of other important jobs.
 
   While gsutil has no built-in support for throttling requests, there are
-  various tools available on Linux and MacOS that can be used to throttle
+  various tools available on Linux and macOS that can be used to throttle
   gsutil requests.
 
   One tool is `trickle <https://github.com/mariusae/trickle>`_ (available via

--- a/gslib/commands/config.py
+++ b/gslib/commands/config.py
@@ -344,7 +344,7 @@ CONFIG_PRELUDE_CONTENT = """
 # exceptions in Python's multiprocessing.Manager. More processes are
 # probably not needed to saturate most networks.
 #
-# On Windows and Mac systems parallel multi-processing and multi-threading
+# On Windows and macOS systems, parallel multi-processing and multi-threading
 # in Python presents various challenges so we retain compatibility with
 # the established parallel mode operation, i.e. one process and 24 threads.
 if platform.system() == 'Linux':
@@ -479,7 +479,7 @@ CONFIG_INPUTLESS_GSUTIL_SECTION_CONTENT = """
 # however, to enhance performance for transfers involving large numbers of
 # files, you may experiment with hand tuning these values to optimize
 # performance for your particular system configuration.
-# MacOS and Windows users should see
+# Windows and macOS users should see
 # https://github.com/GoogleCloudPlatform/gsutil/issues/77 before attempting
 # to experiment with these values.
 #parallel_process_count = %(parallel_process_count)d
@@ -553,7 +553,7 @@ CONFIG_INPUTLESS_GSUTIL_SECTION_CONTENT = """
 
 # 'use_magicfile' specifies if the 'file --mime <filename>' command should be
 # used to guess content types instead of the default filename extension-based
-# mechanism. Available on UNIX and MacOS (and possibly on Windows, if you're
+# mechanism. Available on UNIX and macOS (and possibly on Windows, if you're
 # running Cygwin or some other package that provides implementations of
 # UNIX-like commands). When available and enabled use_magicfile should be more
 # robust because it analyzes file contents in addition to extensions.

--- a/gslib/commands/cp.py
+++ b/gslib/commands/cp.py
@@ -161,7 +161,7 @@ _NAME_CONSTRUCTION_TEXT = """
   to create folders, it does so by creating a "placeholder" object that ends
   with a "/" character. gsutil skips these objects when downloading from the
   cloud to the local file system, because attempting to create a file that
-  ends with a "/" is not allowed on Linux and MacOS. Because of this, it is
+  ends with a "/" is not allowed on Linux and macOS. Because of this, it is
   recommended that you not create objects that end with "/" (unless you don't
   need to be able to download such objects using gsutil).
 """
@@ -423,7 +423,7 @@ _PARALLEL_COMPOSITE_UPLOADS_TEXT = """
   downloaded by gsutil or other Python applications. Note that for such uploads,
   crcmod is required for downloading regardless of whether the parallel
   composite upload option is on or not. For some distributions this is easy
-  (e.g., it comes pre-installed on MacOS), but in other cases some users have
+  (e.g., it comes pre-installed on macOS), but in other cases some users have
   found it difficult. Because of this, at present parallel composite uploads are
   disabled by default. Google is actively working with a number of the Linux
   distributions to get crcmod included with the stock distribution. Once that is
@@ -515,7 +515,7 @@ _CHANGING_TEMP_DIRECTORIES_TEXT = """
   space during one of these operations (e.g., raising
   "CommandException: Inadequate temp space available to compress <your file>"
   during a gsutil cp -z operation), you can change where it writes these
-  temp files by setting the TMPDIR environment variable. On Linux and MacOS
+  temp files by setting the TMPDIR environment variable. On Linux and macOS
   you can do this either by running gsutil this way:
 
     TMPDIR=/some/directory gsutil cp ...
@@ -528,7 +528,7 @@ _CHANGING_TEMP_DIRECTORIES_TEXT = """
   On Windows 7 you can change the TMPDIR environment variable from Start ->
   Computer -> System -> Advanced System Settings -> Environment Variables.
   You need to reboot after making this change for it to take effect. (Rebooting
-  is not necessary after running the export command on Linux and MacOS.)
+  is not necessary after running the export command on Linux and macOS.)
 """
 
 _COPYING_SPECIAL_FILES_TEXT = """

--- a/gslib/tests/test_cp.py
+++ b/gslib/tests/test_cp.py
@@ -1578,7 +1578,7 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
 
   # Note: We originally one time implemented a test
   # (test_copy_invalid_unicode_filename) that invalid unicode filenames were
-  # skipped, but it turns out os.walk() on MacOS doesn't have problems with
+  # skipped, but it turns out os.walk() on macOS doesn't have problems with
   # such files (so, failed that test). Given that, we decided to remove the
   # test.
 

--- a/gslib/utils/parallelism_framework_util.py
+++ b/gslib/utils/parallelism_framework_util.py
@@ -330,7 +330,7 @@ Your max number of open files, %s, is too low to allow safe multiprocessing.
 On Linux you can fix this by adding something like "ulimit -n 10000" to your
 ~/.bashrc or equivalent file and opening a new terminal.
 
-On MacOS, you may also need to run a command like this once (in addition to the
+On macOS, you may also need to run a command like this once (in addition to the
 above instructions), which might require a restart of your system to take
 effect:
   launchctl limit maxfiles 10000


### PR DESCRIPTION
Apple rebranded Mac OS X as macOS. When referring to the operating system in general, we use macOS now.
https://developers.google.com/style/word-list#letter-M

This change is being made throughout our documents.