### PR TITLE
Fix link to storage 'locations' page

### DIFF
--- a/gslib/commands/signurl.py
+++ b/gslib/commands/signurl.py
@@ -139,7 +139,7 @@ _DETAILED_HELP_TEXT = ("""
   -p           Specify the keystore password instead of prompting.
 
   -r <region>  Specifies the `region
-               <https://cloud.google.com/storage/docs/bucket-locations>`_ in
+               <https://cloud.google.com/storage/docs/locations>`_ in
                which the resources for which you are creating signed URLs are
                stored.
 


### PR DESCRIPTION
Former link:
https://cloud.google.com/storage/docs/bucket-locations
New link
https://cloud.google.com/storage/docs/locations