### PR TITLE
Fix link to storage 'locations' page (2)

### DIFF
--- a/gslib/commands/mb.py
+++ b/gslib/commands/mb.py
@@ -82,7 +82,7 @@ _DETAILED_HELP_TEXT = ("""
 
 <B>BUCKET LOCATIONS</B>
   You can specify one of the `available locations
-  <https://cloud.google.com/storage/docs/bucket-locations>`_ for a bucket
+  <https://cloud.google.com/storage/docs/locations>`_ for a bucket
   with the -l option.
 
   Examples:


### PR DESCRIPTION
Former link:
https://cloud.google.com/storage/docs/bucket-locations
New link
https://cloud.google.com/storage/docs/locations