### PR TITLE
Bump apitools version to 0.5.25.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ requires = [
     'crcmod>=1.7',
     'fasteners>=0.14.1',
     'gcs-oauth2-boto-plugin>=2.2',
-    'google-apitools>=0.5.24',
+    'google-apitools>=0.5.25',
     'httplib2>=0.11.3',
     'google-reauth>=0.1.0',
     # TODO: Sync submodule with tag referenced here once #339 is fixed in mock.


### PR DESCRIPTION
This is a follow-up to
https://github.com/GoogleCloudPlatform/gsutil/commit/19b55f9b7bb8c8daa1124ee17cb72a932475357e.