### PR TITLE
Fix #591: Don't clobber local files with differing size

### DIFF
--- a/gslib/tests/test_cp.py
+++ b/gslib/tests/test_cp.py
@@ -466,6 +466,20 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
       self.assertIn('Skipping existing item: %s' % suri(f), stderr)
       self.assertEqual(f.read(), 'bar')
 
+  @SequentialAndParallelTransfer
+  def test_noclobber_different_size(self):
+    key_uri = self.CreateObject(contents='foo')
+    fpath = self.CreateTempFile(contents='quux')
+    stderr = self.RunGsUtil(['cp', '-n', fpath, suri(key_uri)],
+                            return_stderr=True)
+    self.assertIn('Skipping existing item: %s' % suri(key_uri), stderr)
+    self.assertEqual(key_uri.get_contents_as_string(), 'foo')
+    stderr = self.RunGsUtil(['cp', '-n', suri(key_uri), fpath],
+                            return_stderr=True)
+    with open(fpath, 'r') as f:
+      self.assertIn('Skipping existing item: %s' % suri(f), stderr)
+      self.assertEqual(f.read(), 'quux')
+
   def test_dest_bucket_not_exist(self):
     fpath = self.CreateTempFile(contents='foo')
     invalid_bucket_uri = (

--- a/gslib/utils/copy_helper.py
+++ b/gslib/utils/copy_helper.py
@@ -3434,9 +3434,7 @@ def PerformCopy(
     else:
       preconditions.gen_match = 0
     if dst_url.IsFileUrl() and os.path.exists(dst_url.object_name):
-      # The local file may be a partial. Check the file sizes.
-      if src_obj_size == os.path.getsize(dst_url.object_name):
-        raise ItemExistsError()
+      raise ItemExistsError()
     elif dst_url.IsCloudUrl():
       try:
         dst_object = gsutil_api.GetObjectMetadata(


### PR DESCRIPTION
As discussed in #591, `gsutil cp -n` will overwrite an existing local file if its size differs from the size of the source file.  This behavior is contrary to user expectations, POSIX convention, and the documentation.

Remove the special case for files with differing size, which was added in a768a58 to support resuming partial downloads.  This code has not been useful since 3e3d6dc, which started using temporary files (named with `_.gstmp`) for all downloads.

Fixes: #591
CC: @houglum
CC: @thobrla

Thanks for considering,
Kevin

P.S.:  To get any of the integration tests to run I had to apply boto/boto#3843.  I'm not sure why this apparently isn't affecting others.  Feel free to comment on that issue if you have any insights.