### PR TITLE
Bump six version from 1.9.0 to 1.12.0.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ requires = [
     'pyOpenSSL>=0.13',
     'python-gflags>=3.1.2',
     'retry_decorator>=1.0.0',
-    'six>=1.9.0',
+    'six>=1.12.0',
     # Not using 1.02 because of:
     #   https://code.google.com/p/socksipy-branch/issues/detail?id=3
     'SocksiPy-branch==1.01',


### PR DESCRIPTION
This allows us to pick up `ensure_text`, `ensure_binary`, etc. functions,
which will be helpful for the Python 2 -> "six" (2 and 3) migration
we're currently working on.

Bumped the version in setup.py and checked out the 1.12.0 tag from our
mirror, via `cd third_party/six; git fetch --tags origin; git checkout
1.12.0`.