### PR TITLE
Update bucketpolicyonly set impl to not fetch bucket metadata before patching

### DIFF
--- a/gslib/commands/bucketpolicyonly.py
+++ b/gslib/commands/bucketpolicyonly.py
@@ -154,15 +154,12 @@ class BucketPolicyOnlyCommand(Command):
     self._ValidateBucketListingRefAndReturnBucketName(blr)
     bucket_url = blr.storage_url
 
-    bucket_metadata = self.gsutil_api.GetBucket(
-        bucket_url.bucket_name,
-        fields=[],
-        provider=bucket_url.scheme)
-
-    bucket_metadata.iamConfiguration = IamConfigurationValue()
-    iam_config = bucket_metadata.iamConfiguration
+    iam_config = IamConfigurationValue()
     iam_config.bucketPolicyOnly = BucketPolicyOnlyValue()
     iam_config.bucketPolicyOnly.enabled = (setting_arg == 'on')
+
+    bucket_metadata = apitools_messages.Bucket(
+        iamConfiguration=iam_config)
 
     setting_verb = 'Enabling' if setting_arg == 'on' else 'Disabling'
     print('%s Bucket Policy Only for %s...'


### PR DESCRIPTION
Sending the extra bucket metadata causes more issues than it's worth and this is much closer to how versioning.py is implemented anyways.

Internal Issuetracker link: b/124315853