### PR TITLE
Adding the python executable path

### DIFF
--- a/gslib/commands/test.py
+++ b/gslib/commands/test.py
@@ -292,7 +292,7 @@ def CreateTestProcesses(parallel_tests, test_index, process_list, process_done,
     Index of last created test.
   """
   orig_test_index = test_index
-  executable_prefix = [sys.executable] if sys.executable and IS_WINDOWS else []
+  executable_prefix = [sys.executable] if sys.executable else []
   s3_argument = ['-s'] if tests.util.RUN_S3_TESTS else []
   multiregional_buckets = ['-b'] if tests.util.USE_MULTIREGIONAL_BUCKETS else []
   project_id_arg = []

--- a/gslib/commands/test.py
+++ b/gslib/commands/test.py
@@ -41,6 +41,7 @@ from gslib.exception import CommandException
 from gslib.project_id import PopulateProjectId
 import gslib.tests as tests
 from gslib.tests.util import GetTestNames
+from gslib.tests.util import InvokedFromParFile
 from gslib.tests.util import unittest
 from gslib.utils.constants import NO_MAX
 from gslib.utils.system_util import IS_WINDOWS
@@ -292,7 +293,10 @@ def CreateTestProcesses(parallel_tests, test_index, process_list, process_done,
     Index of last created test.
   """
   orig_test_index = test_index
-  executable_prefix = [sys.executable] if sys.executable else []
+  # checking to see if test was invoked from a par file (bundled archive)
+  # if not, add python executable path to ensure correct version of python
+  # is used for testing
+  executable_prefix = [sys.executable] if not InvokedFromParFile() else []
   s3_argument = ['-s'] if tests.util.RUN_S3_TESTS else []
   multiregional_buckets = ['-b'] if tests.util.USE_MULTIREGIONAL_BUCKETS else []
   project_id_arg = []

--- a/gslib/tests/testcase/integration_testcase.py
+++ b/gslib/tests/testcase/integration_testcase.py
@@ -877,8 +877,7 @@ class GsUtilIntegrationTestCase(base.GsUtilTestCase):
           stdin = (stdin + os.linesep).encode('utf-8')
       else:
           stdin = (stdin + os.linesep).encode('utf-8')
-    if IS_WINDOWS:
-      cmd = [sys.executable] + cmd
+    cmd = [sys.executable] + cmd
     env = os.environ.copy()
     if env_vars:
       env.update(env_vars)

--- a/gslib/tests/testcase/integration_testcase.py
+++ b/gslib/tests/testcase/integration_testcase.py
@@ -51,6 +51,7 @@ from gslib.project_id import GOOG_PROJ_ID_HDR
 from gslib.project_id import PopulateProjectId
 from gslib.tests.testcase import base
 import gslib.tests.util as util
+from gslib.tests.util import InvokedFromParFile
 from gslib.tests.util import ObjectToURI as suri
 from gslib.tests.util import RUN_S3_TESTS
 from gslib.tests.util import SetBotoConfigForTest
@@ -877,7 +878,10 @@ class GsUtilIntegrationTestCase(base.GsUtilTestCase):
           stdin = (stdin + os.linesep).encode('utf-8')
       else:
           stdin = (stdin + os.linesep).encode('utf-8')
-    cmd = [sys.executable] + cmd
+    # checking to see if test was invoked from a par file (bundled archive)
+    # if not, add python executable path to ensure correct version of python
+    # is used for testing
+    cmd = [sys.executable] + cmd if not InvokedFromParFile() else cmd
     env = os.environ.copy()
     if env_vars:
       env.update(env_vars)

--- a/gslib/tests/util.py
+++ b/gslib/tests/util.py
@@ -618,6 +618,13 @@ def WorkingDirectory(new_working_directory):
       os.chdir(prev_working_directory)
 
 
+def InvokedFromParFile():
+  loader = globals().get('__loader__', None)
+  if not loader:
+    return False
+  return 'zipimport' in loader.__class__.__module__
+
+
 # Custom test callbacks must be pickleable, and therefore at global scope.
 class HaltingCopyCallbackHandler(object):
   """Test callback handler for intentionally stopping a resumable transfer."""


### PR DESCRIPTION
Commit cherry-picked: 779903967a1e2964a004665e4a3f7f285a62de25 by @walkerjoe 

The full python executable path was not propagating through to the test
processes and it was defaulting to Python2.7 even when the test was
started with python 3.x. Adding the path to the beginning of the cmd
sent to Popen forces the tests to use the correct python version.