### PR TITLE
Python 3.x compat changes - encode_chunked stubbed, syntax fixes, encoding, and skipped test printing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ gsutil_*.zip
 .metadata/*
 .idea/*
 .vscode/*
+venv*/*

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ gsutil_*.zip
 .settings/*
 .coverage*
 .metadata/*
+.idea/*
+.vscode/*

--- a/gslib/command_runner.py
+++ b/gslib/command_runner.py
@@ -60,6 +60,7 @@ from gslib.utils.text_util import InsistAsciiHeader
 from gslib.utils.text_util import InsistAsciiHeaderValue
 from gslib.utils.unit_util import SECONDS_PER_DAY
 from gslib.utils.update_util import LookUpGsutilVersion
+from gslib.tests.util import HAS_NON_DEFAULT_GS_HOST
 
 
 def HandleHeaderCoding(headers):
@@ -433,13 +434,10 @@ class CommandRunner(object):
     # - user is using a Cloud SDK install (which should only be updated via
     #   gcloud components update)
     logger = logging.getLogger()
-    gs_host = boto.config.get('Credentials', 'gs_host', None)
-    gs_host_is_not_default = (
-        gs_host != boto.gs.connection.GSConnection.DefaultHost)
     if (not system_util.IsRunningInteractively()
         or command_name in ('config', 'update', 'ver', 'version')
         or not logger.isEnabledFor(logging.INFO)
-        or gs_host_is_not_default
+        or HAS_NON_DEFAULT_GS_HOST
         or system_util.InvokedViaCloudSdk()):
       return False
 

--- a/gslib/commands/retention.py
+++ b/gslib/commands/retention.py
@@ -485,7 +485,7 @@ class RetentionCommand(Command):
     """Get Retention Policy for a single bucket."""
     bucket_url, bucket_metadata = self.GetSingleBucketUrlFromArg(
         self.args[0], bucket_fields=['retentionPolicy'])
-    print RetentionPolicyToString(bucket_metadata.retentionPolicy, bucket_url)
+    print(RetentionPolicyToString(bucket_metadata.retentionPolicy, bucket_url))
     return 0
 
   def _LockRetention(self):

--- a/gslib/commands/test.py
+++ b/gslib/commands/test.py
@@ -677,6 +677,7 @@ class TestCommand(Command):
       if not num_parallel_tests:
         pass
       else:
+        sequential_success = sequential_skipped = []
         num_processes = min(max_parallel_tests, num_parallel_tests)
         if num_parallel_tests > 1 and max_parallel_tests > 1:
           message = 'Running %d tests in parallel mode (%d processes).'

--- a/gslib/commands/test.py
+++ b/gslib/commands/test.py
@@ -439,7 +439,7 @@ class TestCommand(Command):
             (process_run_finish_time - parallel_start_time))
 
   def PrintTestResults(self, num_sequential_tests, sequential_success,
-                       sequential_time_elapsed,
+                       sequential_skipped, sequential_time_elapsed,
                        num_parallel_tests, num_parallel_failures,
                        parallel_time_elapsed):
     """Prints test results for parallel and sequential tests."""
@@ -454,6 +454,7 @@ class TestCommand(Command):
            float(sequential_time_elapsed),
            num_parallel_tests,
            float(parallel_time_elapsed))))
+    self.PrintSkippedTests(sequential_skipped)
     print()
 
     if not num_parallel_failures and sequential_success:
@@ -463,6 +464,30 @@ class TestCommand(Command):
         print('FAILED (parallel tests)')
       if not sequential_success:
         print('FAILED (sequential tests)')
+
+  # TODO: Parallel skipped tests are never gathered anywhere, this needs implementation in RunParallelTests
+  def PrintSkippedTests(self, sequential_skipped=set(), parallel_skipped=set()):
+    """Prints all skipped tests, and the reasons they  were skipped.
+
+    Takes the union of sequentual_skipped and parallel_skipped,
+    and pretty-prints the resulting methods and reasons. Note that these two
+    arguments are lists of tuples from TestResult.skipped as described here:
+    https://docs.python.org/2/library/unittest.html#unittest.TestResult.skipped
+
+    Args:
+        sequentual_skipped: An instance of TestResult.skipped.
+        parallel_skipped: An instance of TestResult.skipped.
+    """
+    if len(sequential_skipped) > 0 or len(parallel_skipped) > 0:
+      sequential_skipped = set(sequential_skipped)
+      parallel_skipped = set(parallel_skipped)
+      all_skipped = sequential_skipped.union(parallel_skipped)
+
+      print('Tests skipped:')
+      for method, reason in all_skipped:
+        print('  ' + method.id())
+        print('    Reason: ' + reason)
+
 
   def RunCommand(self):
     """Command entry point for the test command."""
@@ -638,6 +663,7 @@ class TestCommand(Command):
 
         ret = runner.run(suite)
         sequential_success = ret.wasSuccessful()
+        sequential_skipped = ret.skipped
       else:
         num_sequential_tests = 0
         sequential_success = True
@@ -670,7 +696,7 @@ class TestCommand(Command):
             coverage_controller.data_files.filename if perform_coverage
             else None)
         self.PrintTestResults(
-            num_sequential_tests, sequential_success,
+            num_sequential_tests, sequential_success, sequential_skipped,
             sequential_time_elapsed,
             num_parallel_tests, num_parallel_failures,
             parallel_time_elapsed)

--- a/gslib/gcs_json_api.py
+++ b/gslib/gcs_json_api.py
@@ -387,7 +387,7 @@ class GcsJsonApi(CloudApi):
       request = apitools_messages.StorageBucketAccessControlsListRequest(
           bucket=bucket_name)
       return self.api_client.bucketAccessControls.List(request)
-    except TRANSLATABLE_APITOOLS_EXCEPTIONS, e:
+    except TRANSLATABLE_APITOOLS_EXCEPTIONS as e:
       self._TranslateExceptionAndRaise(e, bucket_name=bucket_name)
 
   def ListObjectAccessControls(self, bucket_name, object_name):
@@ -396,7 +396,7 @@ class GcsJsonApi(CloudApi):
       request = apitools_messages.StorageObjectAccessControlsListRequest(
           bucket=bucket_name, object=object_name)
       return self.api_client.objectAccessControls.List(request)
-    except TRANSLATABLE_APITOOLS_EXCEPTIONS, e:
+    except TRANSLATABLE_APITOOLS_EXCEPTIONS as e:
       self._TranslateExceptionAndRaise(e, bucket_name=bucket_name,
                                        object_name=object_name)
 
@@ -490,7 +490,7 @@ class GcsJsonApi(CloudApi):
     try:
       return self.api_client.buckets.LockRetentionPolicy(
           apitools_request, global_params=global_params)
-    except TRANSLATABLE_APITOOLS_EXCEPTIONS, e:
+    except TRANSLATABLE_APITOOLS_EXCEPTIONS as e:
       self._TranslateExceptionAndRaise(e, bucket_name=bucket_name)
 
   def CreateBucket(self, bucket_name, project_id=None, metadata=None,

--- a/gslib/gcs_json_media.py
+++ b/gslib/gcs_json_media.py
@@ -124,7 +124,7 @@ class UploadCallbackConnectionClassFactory(object):
       # Override httplib.HTTPConnection._send_output for debug logging.
       # Because the distinction between headers and message body occurs
       # only in this httplib function, we can only differentiate them here.
-      def _send_output(self, message_body=None):
+      def _send_output(self, message_body=None, encode_chunked=False):
         r"""Send the currently buffered request and clear the buffer.
 
         Appends an extra \r\n to the buffer.

--- a/gslib/tests/test_cp.py
+++ b/gslib/tests/test_cp.py
@@ -482,17 +482,17 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
 
   @SequentialAndParallelTransfer
   def test_noclobber_different_size(self):
-    key_uri = self.CreateObject(contents='foo')
-    fpath = self.CreateTempFile(contents='quux')
+    key_uri = self.CreateObject(contents=b'foo')
+    fpath = self.CreateTempFile(contents=b'quux')
     stderr = self.RunGsUtil(['cp', '-n', fpath, suri(key_uri)],
                             return_stderr=True)
     self.assertIn('Skipping existing item: %s' % suri(key_uri), stderr)
-    self.assertEqual(key_uri.get_contents_as_string(), 'foo')
+    self.assertEqual(key_uri.get_contents_as_string(), b'foo')
     stderr = self.RunGsUtil(['cp', '-n', suri(key_uri), fpath],
                             return_stderr=True)
     with open(fpath, 'r') as f:
       self.assertIn('Skipping existing item: %s' % suri(f), stderr)
-      self.assertEqual(f.read(), 'quux')
+      self.assertEqual(f.read(), b'quux')
 
   def test_dest_bucket_not_exist(self):
     fpath = self.CreateTempFile(contents=b'foo')

--- a/gslib/tests/testcase/integration_testcase.py
+++ b/gslib/tests/testcase/integration_testcase.py
@@ -21,7 +21,6 @@ from __future__ import unicode_literals
 
 from contextlib import contextmanager
 from six.moves import cStringIO
-import cStringIO
 import datetime
 import locale
 import logging

--- a/gslib/tests/util.py
+++ b/gslib/tests/util.py
@@ -193,10 +193,31 @@ HAS_S3_CREDS = _HasS3Credentials()
 def _HasGSHost():
   return boto.config.get('Credentials', 'gs_host', None) is not None
 
+
+def string_compare(a, b, encoding='utf-8'):
+  """Function to compare two strings, regardless of their encoding.
+
+  Added as a helper for Python 2 to 3 conversion, since there are some
+  instances where we will want to compare u'string' to b'string'.
+  Credit for this function goes to StackOverflow:
+  https://stackoverflow.com/a/37869996
+
+  Args:
+      a: String to be compared, either bytes or unicode.
+      b: String to be compared, either bytes or unicode.
+
+  Returns:
+      Boolean, representing if strings a and b are equal.
+  """
+  if isinstance(a, bytes):
+    a = a.decode(encoding)
+  if isinstance(b, bytes):
+    b = b.decode(encoding)
+  return a == b
+
+
 HAS_GS_HOST = _HasGSHost()
-HAS_NON_DEFAULT_GS_HOST = (
-    boto.gs.connection.GSConnection.DefaultHost != boto.config.get(
-        'Credentials', 'gs_host', None))
+HAS_NON_DEFAULT_GS_HOST = string_compare(boto.gs.connection.GSConnection.DefaultHost, boto.config.get('Credentials', 'gs_host', None))
 
 
 def _HasGSPort():

--- a/gslib/utils/retention_util.py
+++ b/gslib/utils/retention_util.py
@@ -65,7 +65,7 @@ def _ConfirmWithUserPrompt(question, default_response):
     if not response:
       return default_response
     if response not in ['y', 'yes', 'n', 'no']:
-      print '\tPlease respond with \'yes\'/\'y\' or \'no\'/\'n\'.'
+      print('\tPlease respond with \'yes\'/\'y\' or \'no\'/\'n\'.')
       continue
     if response == 'yes' or response == 'y':
       return True


### PR DESCRIPTION
Cherry picked in 8 more commits, mostly small syntax changes. Most of the commits have a decent amount of context in their commit messages, but please feel free to ask for additional context. :smiley:

Changes include:
- Stubbed value for `encode_chunked` kwarg introduced in  3.6
- Added a (incomplete) skipped test printer for sequential tests
- Syntax fixes
- Encoding fixes
- String comparison method added for comparing possibly dissimilar types of strings (bytes vs unicode)
- `.gitignore` goodies