### PR TITLE
Refactoring, encoding fixes, and concat fixes

### DIFF
--- a/gslib/commands/test.py
+++ b/gslib/commands/test.py
@@ -433,7 +433,7 @@ class TestCommand(Command):
           new_stderr = result.stderr.split(b'\n')
           print('Results for failed test %s:' % result.name)
           for line in new_stderr:
-            print(line.decode('utf-8'))
+            print(line.decode('utf-8').strip())
 
     return (num_parallel_failures,
             (process_run_finish_time - parallel_start_time))

--- a/gslib/tests/test_cp.py
+++ b/gslib/tests/test_cp.py
@@ -108,6 +108,7 @@ from gslib.utils.posix_util import ValidateFilePermissionAccess
 from gslib.utils.posix_util import ValidatePOSIXMode
 from gslib.utils.retry_util import Retry
 from gslib.utils.system_util import IS_WINDOWS
+from gslib.utils.text_util import get_random_ascii_chars
 from gslib.utils.unit_util import EIGHT_MIB
 from gslib.utils.unit_util import HumanReadableToBytes
 from gslib.utils.unit_util import MakeHumanReadable
@@ -1810,7 +1811,7 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
     """
     # Setup the bucket and local data.
     bucket_uri = self.CreateBucket()
-    contents = self.get_random_ascii_chars(self.halt_size)
+    contents = get_random_ascii_chars(size=self.halt_size)
     tmpdir = self.CreateTempDir(test_files=10, contents=contents)
     # Upload the data.
     with SetBotoConfigForTest([('GSUtil', 'resumable_threshold',
@@ -2270,7 +2271,7 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
     # Setup the bucket and local data. File contents are randomized to prevent
     # them from compressing below the resumable-threshold and failing the test.
     bucket_uri = self.CreateBucket()
-    contents = self.get_random_ascii_chars(self.halt_size)
+    contents = get_random_ascii_chars(size=self.halt_size)
     local_uri = self.CreateTempFile(file_name='test.txt', contents=contents)
     # Configure boto
     boto_config_for_test = ('GSUtil', 'resumable_threshold', str(ONE_KIB))

--- a/gslib/tests/test_cp.py
+++ b/gslib/tests/test_cp.py
@@ -1756,11 +1756,7 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
     """Test resumable, gzip encoded files upload correctly in parallel."""
     # Setup the bucket and local data.
     bucket_uri = self.CreateBucket()
-    random.seed(0)
-
-    contents = str([random.choice(string.ascii_letters)
-                 for _ in xrange(self.halt_size)]).encode('ascii')
-    random.seed()  # Reset the seed for any other tests.
+    contents = self.get_random_ascii_chars(self.halt_size)
     tmpdir = self.CreateTempDir(test_files=10, contents=contents)
     # Upload the data.
     with SetBotoConfigForTest([('GSUtil', 'resumable_threshold',
@@ -2220,10 +2216,7 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
     # Setup the bucket and local data. File contents are randomized to prevent
     # them from compressing below the resumable-threshold and failing the test.
     bucket_uri = self.CreateBucket()
-    random.seed(0)
-    contents = str([random.choice(string.ascii_letters)
-                    for _ in xrange(self.halt_size)]).encode('ascii')
-    random.seed()  # Reset the seed for any other tests.
+    contents = self.get_random_ascii_chars(self.halt_size)
     local_uri = self.CreateTempFile(file_name='test.txt', contents=contents)
     # Configure boto
     boto_config_for_test = ('GSUtil', 'resumable_threshold', str(ONE_KIB))

--- a/gslib/tests/test_cp.py
+++ b/gslib/tests/test_cp.py
@@ -1509,8 +1509,8 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
                    'Unicode handling on Windows requires mods to site-packages')
   @SequentialAndParallelTransfer
   def test_cp_manifest_upload_unicode(self):
-    return self._ManifestUpload('foo-unicöde', 'bar-unicöde',
-                                'manifest-unicöde')
+    return self._ManifestUpload('foo-unicöde'.encode('utf-8'), 'bar-unicöde'.encode('utf-8'),
+                                'manifest-unicöde'.encode('utf-8'))
 
   @SequentialAndParallelTransfer
   def test_cp_manifest_upload(self):

--- a/gslib/tests/test_cp.py
+++ b/gslib/tests/test_cp.py
@@ -1776,7 +1776,12 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
   @SkipForXML('No compressed transport encoding support for the XML API.')
   @SequentialAndParallelTransfer
   def test_gzip_transport_encoded_parallel_upload_non_resumable(self):
-    """Test non resumable, gzip encoded files upload correctly in parallel."""
+    """Test non resumable, gzip encoded files upload correctly in parallel.
+    
+    This test generates a small amount of data (e.g. 100 chars) to upload.
+    Due to the small size, it will be below the resumable threshold,
+    and test the behavior of non-resumable uploads.
+    """
     # Setup the bucket and local data.
     bucket_uri = self.CreateBucket()
     contents = b'x' * 100
@@ -1797,7 +1802,12 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
   @SkipForXML('No compressed transport encoding support for the XML API.')
   @SequentialAndParallelTransfer
   def test_gzip_transport_encoded_parallel_upload_resumable(self):
-    """Test resumable, gzip encoded files upload correctly in parallel."""
+    """Test resumable, gzip encoded files upload correctly in parallel.
+    
+    This test generates a large amount of data (e.g. halt_size amount of chars)
+    to upload. Due to the large size, it will be above the resumable threshold,
+    and test the behavior of resumable uploads.
+    """
     # Setup the bucket and local data.
     bucket_uri = self.CreateBucket()
     contents = self.get_random_ascii_chars(self.halt_size)

--- a/gslib/tests/testcase/integration_testcase.py
+++ b/gslib/tests/testcase/integration_testcase.py
@@ -276,25 +276,6 @@ class GsUtilIntegrationTestCase(base.GsUtilTestCase):
       self.xml_api.PatchObjectMetadata(bucket_name, object_name, obj_metadata,
                                        provider=provider)
 
-  def get_random_ascii_chars(self, size, seed=None):
-    """Generates random ASCII characters up to a given size.
-
-    Args:
-      size: Integer quantity of characters to generate.
-      seed: A seed may be specified for deterministic behavior.
-            None is used as the default value.
-
-    Returns:
-      String of length equal to size argument.
-    """
-    random.seed(seed)
-    charset = string.printable.encode('ascii')
-
-    contents = ''.join([random.choice(charset) for _ in range(size)]
-                        ).encode('ascii')
-
-    random.seed()  # Reset the seed for any other tests.
-    return contents
 
   def SetPOSIXMetadata(self, provider, bucket_name, object_name, atime=None,
                        mtime=None, uid=None, gid=None, mode=None):

--- a/gslib/tests/testcase/integration_testcase.py
+++ b/gslib/tests/testcase/integration_testcase.py
@@ -25,12 +25,15 @@ import datetime
 import locale
 import logging
 import os
+import random
+import string
 import subprocess
 import sys
 import tempfile
 import time
 
 import six
+from six.moves import range
 
 import boto
 from boto import config
@@ -272,6 +275,26 @@ class GsUtilIntegrationTestCase(base.GsUtilTestCase):
     else:
       self.xml_api.PatchObjectMetadata(bucket_name, object_name, obj_metadata,
                                        provider=provider)
+
+  def get_random_ascii_chars(self, size, seed=None):
+    """Generates random ASCII characters up to a given size.
+
+    Args:
+      size: Integer quantity of characters to generate.
+      seed: A seed may be specified for deterministic behavior.
+            None is used as the default value.
+
+    Returns:
+      String of length equal to size argument.
+    """
+    random.seed(seed)
+    charset = string.printable.encode('ascii')
+
+    contents = ''.join([random.choice(charset) for _ in range(size)]
+                        ).encode('ascii')
+
+    random.seed()  # Reset the seed for any other tests.
+    return contents
 
   def SetPOSIXMetadata(self, provider, bucket_name, object_name, atime=None,
                        mtime=None, uid=None, gid=None, mode=None):

--- a/gslib/tests/testcase/integration_testcase.py
+++ b/gslib/tests/testcase/integration_testcase.py
@@ -916,6 +916,7 @@ class GsUtilIntegrationTestCase(base.GsUtilTestCase):
     status = p.returncode
 
     if expected_status is not None:
+      cmd = [six.ensure_text(item) for item in cmd]
       self.assertEqual(
         status, expected_status,
         msg='Expected status {}, got {}.\nCommand:\n{}\n\nstderr:\n{}'.format(

--- a/gslib/tests/testcase/unit_testcase.py
+++ b/gslib/tests/testcase/unit_testcase.py
@@ -139,18 +139,19 @@ class GsUtilUnitTestCase(base.GsUtilTestCase):
     os.unlink(self.stdout_file)
     os.unlink(self.stderr_file)
 
+    _id = six.ensure_text(self.id())
     if self.is_debugging and stdout:
-      sys.stderr.write(b'==== stdout %s ====\n' % self.id())
+      sys.stderr.write('==== stdout {} ====\n'.format(_id))
       sys.stderr.write(stdout)
-      sys.stderr.write(b'==== end stdout ====\n')
+      sys.stderr.write('==== end stdout ====\n')
     if self.is_debugging and stderr:
-      sys.stderr.write(b'==== stderr %s ====\n' % self.id())
+      sys.stderr.write('==== stderr {} ====\n'.format(_id))
       sys.stderr.write(stderr)
-      sys.stderr.write(b'==== end stderr ====\n')
+      sys.stderr.write('==== end stderr ====\n')
     if self.is_debugging and log_output:
-      sys.stderr.write(b'==== log output %s ====\n' % self.id())
+      sys.stderr.write('==== log output {} ====\n'.format(_id))
       sys.stderr.write(log_output)
-      sys.stderr.write(b'==== end log output ====\n')
+      sys.stderr.write('==== end log output ====\n')
 
   def RunCommand(self, command_name, args=None, headers=None, debug=0,
                  return_stdout=False, return_stderr=False,
@@ -235,19 +236,21 @@ class GsUtilUnitTestCase(base.GsUtilTestCase):
           '%s:\n  ' % level + '\n  '.join(records)
           for level, records in six.iteritems(mock_log_handler.messages)
           if records)
+
+      _id = six.ensure_text(self.id())
       if self.is_debugging and log_output:
         self.stderr_save.write(
-            '==== logging RunCommand %s %s ====\n' % (self.id(), command_line))
+            '==== logging RunCommand {} {} ====\n'.format(_id, command_line))
         self.stderr_save.write(log_output)
         self.stderr_save.write('\n==== end logging ====\n')
       if self.is_debugging and stdout:
         self.stderr_save.write(
-            '==== stdout RunCommand %s %s ====\n' % (self.id(), command_line))
+            '==== stdout RunCommand {} {} ====\n'.format(_id, command_line))
         self.stderr_save.write(stdout)
         self.stderr_save.write('==== end stdout ====\n')
       if self.is_debugging and stderr:
         self.stderr_save.write(
-            '==== stderr RunCommand %s %s ====\n' % (self.id(), command_line))
+            '==== stderr RunCommand {} {} ====\n'.format(_id, command_line))
         self.stderr_save.write(stderr)
         self.stderr_save.write('==== end stderr ====\n')
 

--- a/gslib/utils/text_util.py
+++ b/gslib/utils/text_util.py
@@ -25,8 +25,9 @@ import io
 import re
 import locale
 import collections
-
+import random
 import six
+import string
 from six.moves import urllib
 
 from gslib.exception import CommandException
@@ -333,6 +334,30 @@ def ttywrite(fp, data):
       # data is not bytes, and fp is text
       fp.write(data)
 
+
 def RemoveCRLFFromString(input_str):
   r"""Returns the input string with all \n and \r removed."""
   return re.sub(r'[\r\n]', '', input_str)
+
+
+def get_random_ascii_chars(size, seed=None):
+  """Generates random ASCII characters up to a given size.
+
+  Args:
+    size: Integer quantity of characters to generate.
+    seed: A seed may be specified for deterministic behavior.
+          None is used as the default value.
+
+  Returns:
+    ASCII encoded bytestring of length equal to size argument.
+    Please note Python 2 strings are bytes by default, while
+    Python 3 string are Unicode by default.
+  """
+  random.seed(seed)
+  charset = string.printable.encode('ascii')
+
+  contents = ''.join([random.choice(charset) for _ in range(size)]
+                      ).encode('ascii')
+
+  random.seed()  # Reset the seed for any other tests.
+  return contents


### PR DESCRIPTION
- 4faf087 Refactored; make get_random_ascii_chars method
> Made a new method get_random_ascii_chars as part of a small
> refactor. There was some minor redundant behavior. This method
> was made to follow DRY practices, and to increase readability.
 
- a194cc1 Unicode fix for Python 2
> One of the Unicode tests gets upset in Python 2.7 after recent
> commits. Explicitly specifying encoding makes it compatible
> across versions.

- 11e90c6 Unit test printer now safely concats strings
> Now using six.ensure_text to wrap test IDs before printing them
> in order to ensure compatibility between Python 2 and 3.

- 9921822 Refactored integ test for readability.
> While working with the integ test test_gzip_transport_encoded_upload_and_download
> I refactored it into several sub-methods, added docstrings, and did
> some general cleanup.

- 604712c Wrapping `cmd` list elements in six.ensure_text
> This is to prevent issues with unicode in the command text when
> running in Python 2.7.

- e81f693 Expanded docstrings for two tests.
> Docstrings were made more verbose, explaining two integ tests:
> - test_gzip_transport_encoded_parallel_upload_resumable
> - test_gzip_transport_encoded_parallel_upload_non_resumable
>
> This was based on feedback given in the following bug:
> - http://issuetracker.google.com/123027395