### PR TITLE
Don't run `gcloud compute` commands on CI envs.

### DIFF
--- a/gslib/commands/perfdiag.py
+++ b/gslib/commands/perfdiag.py
@@ -60,6 +60,7 @@ from gslib.utils.system_util import CheckFreeSpace
 from gslib.utils.system_util import GetDiskCounters
 from gslib.utils.system_util import GetFileSize
 from gslib.utils.system_util import IS_LINUX
+from gslib.utils.system_util import IsRunningInCiEnvironment
 from gslib.utils.unit_util import DivideAndCeil
 from gslib.utils.unit_util import HumanReadableToBytes
 from gslib.utils.unit_util import MakeBitsHumanReadable
@@ -1451,7 +1452,11 @@ class PerfDiagCommand(Command):
         hostname = socket.gethostname()
         cmd = ['gcloud', 'compute', 'instances', 'list', '--filter=', hostname]
         try:
-          sysinfo['gce_instance_info'] = self._Exec(cmd, return_output=True)
+          # "gcloud compute" commands will (hopefully) fail on these envs due to
+          # lack of credentials/permissions to access compute resources.
+          mute_stderr = IsRunningInCiEnvironment()
+          sysinfo['gce_instance_info'] = (
+              self._Exec(cmd, return_output=True, mute_stderr=mute_stderr))
         except (CommandException, OSError):
           sysinfo['gce_instance_info'] = ''
 

--- a/gslib/utils/system_util.py
+++ b/gslib/utils/system_util.py
@@ -230,6 +230,15 @@ def InvokedViaCloudSdk():
   return os.environ.get('CLOUDSDK_WRAPPER') == '1'
 
 
+def IsRunningInCiEnvironment():
+  """Returns True if running in a CI environment, e.g. TravisCI."""
+  # TravisCI exports several env vars, the two most obvious ones being CI=true
+  # and TRAVIS=true. We check for the latter.
+  on_travis = 'TRAVIS' in os.environ
+  on_kokoro = 'KOKORO_ROOT' in os.environ
+  return on_travis or on_kokoro
+
+
 def IsRunningInteractively():
   """Returns True if currently running interactively on a TTY."""
   return sys.stdout.isatty() and sys.stderr.isatty() and sys.stdin.isatty()


### PR DESCRIPTION
Perfdiag shouldn't run these commands on CI environments because we
probably (or at least, shouldn't) have permission to read/access
their compute resource metadata.

Also added a check for this to Kokoro - we're not using it yet, but this will
prevent the need for add'l changes once we get it working.