### PR TITLE
Updated Travis config to unit test Python >= 3.5, allowing errors from 3.x versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: python
 python:
   - "2.7"
+  - "3.5"
+  - "3.6"
+  - "3.7"
   - "pypy"
 before_install:
   - sudo rm -f /etc/boto.cfg
@@ -11,3 +14,9 @@ install:
 script:
   - gsutil version -l
   - gsutil test -u
+matrix:
+    fast_finish: true
+    allow_failures:
+        - python: "3.5"
+        - python: "3.6"
+        - python: "3.7"


### PR DESCRIPTION
In anticipation of our upcoming Python 3.x support, this commit
adds support to have Travis run unit tests for versions of Python
greater than or equal to 3.5.

These versions are allowed to fail since we don't yet have full
support for Python 3.x. This file may be updated after we release
compatibility to the main branch.

`fail_fast` attribute was added so that Travis won't block PR
approval during allowed failures.