### PR TITLE
Fixes #606 - use SNI for boto cxns if possible

### DIFF
--- a/gslib/utils/boto_util.py
+++ b/gslib/utils/boto_util.py
@@ -348,6 +348,8 @@ def JsonResumableChunkSizeDefined():
 def MonkeyPatchBoto():
   """Apply gsutil-specific patches to Boto.
 
+  Here be dragons. Sorry.
+
   Note that this method should not be used as a replacement for contributing
   fixes to the upstream Boto library. However, the Boto library has historically
   not been consistent about release cadence, so upstream fixes may not be
@@ -358,13 +360,16 @@ def MonkeyPatchBoto():
   method should be invoked after all other Boto-related initialization has been
   completed.
   """
-  # pylint: disable=g-import-not-at-top
+  # We have to do all sorts of gross things here (dynamic imports, invalid names
+  # to resolve symbols in copy/pasted methods, invalid spacing from copy/pasted
+  # methods, etc.), so we just disable pylint warnings for this whole method.
+  # pylint: disable=all
+
   # This should have already been imported if this method was called in the
   # correct place, but we need to perform the import within this method for
   # this module to recognize it.  We don't import this at module level because
   # its import timing is important and is managed elsewhere.
   import gcs_oauth2_boto_plugin
-  # pylint: enable=g-import-not-at-top
 
   # TODO(https://github.com/boto/boto/issues/3831): Remove this if the GitHub
   # issue is ever addressed.
@@ -386,6 +391,66 @@ def MonkeyPatchBoto():
     return new_result
 
   boto.plugin.get_plugin = _PatchedGetPluginMethod
+
+  #########################################################################
+
+  # TODO(boto>2.49.0): Remove this.
+  # Fixes SSL issue where SNI was not being used for OpenSSL 1.1.1+
+  # https://github.com/boto/boto/pull/3843/files
+
+  # Import modules and resolve symbols used by our patch method.
+  import socket
+  import ssl
+  InvalidCertificateException = (
+      boto.https_connection.InvalidCertificateException)
+  ValidateCertificateHostname = (
+      boto.https_connection.ValidateCertificateHostname)
+
+  def _PatchedConnectMethod(self):
+    # The lines below were copied directly from the Boto file, so we don't lint
+    # or otherwise alter them.
+    if hasattr(self, "timeout"):
+        sock = socket.create_connection((self.host, self.port), self.timeout)
+    else:
+        sock = socket.create_connection((self.host, self.port))
+    msg = "wrapping ssl socket; "
+    if self.ca_certs:
+        msg += "CA certificate file=%s" % self.ca_certs
+    else:
+        msg += "using system provided SSL certs"
+    boto.log.debug(msg)
+    if hasattr(ssl, 'SSLContext') and getattr(ssl, 'HAS_SNI', False):
+        # Use SSLContext so we can specify server_hostname for SNI
+        # (Required for connections to storage.googleapis.com)
+        context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
+        context.verify_mode = ssl.CERT_REQUIRED
+        if self.ca_certs:
+            context.load_verify_locations(self.ca_certs)
+        if self.cert_file:
+            context.load_cert_chain(self.cert_file, self.key_file)
+        self.sock = context.wrap_socket(sock, server_hostname=self.host)
+        # Add attributes only set in SSLSocket constructor without context:
+        self.sock.keyfile = self.key_file
+        self.sock.certfile = self.cert_file
+        self.sock.cert_reqs = context.verify_mode
+        self.sock.ssl_version = ssl.PROTOCOL_SSLv23
+        self.sock.ca_certs = self.ca_certs
+        self.sock.ciphers = None
+    else:
+        self.sock = ssl.wrap_socket(sock, keyfile=self.key_file,
+                                    certfile=self.cert_file,
+                                    cert_reqs=ssl.CERT_REQUIRED,
+                                    ca_certs=self.ca_certs)
+    cert = self.sock.getpeercert()
+    hostname = self.host.split(':', 0)[0]
+    if not ValidateCertificateHostname(cert, hostname):
+        raise InvalidCertificateException(hostname,
+                                          cert,
+                                          'remote hostname "%s" does not match '
+                                          'certificate' % hostname)
+    # End `_PatchedConnectMethod` declaration.
+  boto.https_connection.CertValidatingHTTPSConnection.connect = (
+      _PatchedConnectMethod)
 
 
 def ProxyInfoFromEnvironmentVar(proxy_env_var):


### PR DESCRIPTION
Boto https connections weren't using SNI before. With the recent-ish
introduction of OpenSSL 1.1.1, we start to see SSL errors when making
requests to storage.googleapis.com (GCS's XML API) where the server
hostname was not specified. This pulls in
https://github.com/boto/boto/pull/3843 as a hotfix into gsutil, since
there isn't a released version of Boto where this PR is included yet,
and we'd like to have it sooner rather than later.