### PR TITLE
fix the daisy_chain_wrapper when file is bigger than _DEFAULT_DOWNLOAD_CHUNK_SIZE

### DIFF
--- a/gslib/daisy_chain_wrapper.py
+++ b/gslib/daisy_chain_wrapper.py
@@ -298,6 +298,7 @@ class DaisyChainWrapper(object):
           self.bytes_buffered = 0
           self.last_position = 0
           self.last_data = None
+        self.stop_download.clear()
         self.StartDownloadThread(start_byte=offset,
                                  progress_callback=self.progress_callback)
     else:


### PR DESCRIPTION
The goal of the PR is to fix the file transfert between gs and aws. For me any copy with file bigger than 100Mo was hanging indefinitely.
When transfering file bigger than _DEFAULT_DOWNLOAD_CHUNK_SIZE, the second download for the checksum hangs because the stop_download threading event isn't reset correctly.

I was unable to use the upload.py specified in the contributing guidelines. But I did the first part(CLA) given the size/complexity of the contribution it didn't want to waste to much time on it.