### PR TITLE
Added config generator for CI test scripts.

### DIFF
--- a/test/ci/kokoro/config_generator.sh
+++ b/test/ci/kokoro/config_generator.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2018 Google LLC
+# Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/ci/kokoro/config_generator.sh
+++ b/test/ci/kokoro/config_generator.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Create a config file for gsutil to use in Kokoro tests.
+# https://cloud.google.com/storage/docs/gsutil/commands/config
+
+GSUTIL_KEY=$1
+API=$2
+
+cat  << EOF
+[Credentials]
+gs_service_key_file = "$GSUTIL_KEY"
+
+[GSUtil]
+test_notification_url = https://bigstore-test-notify.appspot.com/notify
+default_project_id = bigstore-gsutil-testing
+prefer_api = "$2"
+
+[OAuth2]
+client_id = 909320924072.apps.googleusercontent.com
+client_secret = p3RlpR10xMFh9ZXBS/ZNLYUu
+EOF

--- a/test/ci/kokoro/config_generator.sh
+++ b/test/ci/kokoro/config_generator.sh
@@ -27,7 +27,7 @@ gs_service_key_file = "$GSUTIL_KEY"
 [GSUtil]
 test_notification_url = https://bigstore-test-notify.appspot.com/notify
 default_project_id = bigstore-gsutil-testing
-prefer_api = "$2"
+prefer_api = "$API"
 
 [OAuth2]
 client_id = 909320924072.apps.googleusercontent.com


### PR DESCRIPTION
Added a shell script to be called by Kokoro when running
integration tests. It generates a config file allowing access
to the bigstore-gsutil-testing account.

Like the integ test shell scripts, this was pulled from Google3
due to GCP Kokoro VMs being unable to access Piper.