### PR TITLE
Spacing fixes for docs, based on last release.

### DIFF
--- a/gslib/addlhelp/encoding.py
+++ b/gslib/addlhelp/encoding.py
@@ -114,12 +114,12 @@ _DETAILED_HELP_TEXT = ("""
   gsutil. For example:
 
   - Windows filenames are case-insensitive, while Google Cloud Storage, Linux,
-    and MacOS are not. Thus, for example, if you have two filenames on Linux
+    and macOS are not. Thus, for example, if you have two filenames on Linux
     differing only in case and upload both to Google Cloud Storage and then
     subsequently download them to Windows, you will end up with just one file
     whose contents came from the last of these files to be written to the
     filesystem.
-  - Mac OS performs character encoding decomposition based on tables stored in
+  - macOS performs character encoding decomposition based on tables stored in
     the OS, and the tables change between Unicode versions. Thus the encoding
     used by an external library may not match that performed by the OS. It is
     possible that two object names may translate to a single local filename.
@@ -130,7 +130,7 @@ _DETAILED_HELP_TEXT = ("""
 
   These problems mostly arise when sharing data across platforms (e.g.,
   uploading data from a Windows machine to Google Cloud Storage, and then
-  downloading from Google Cloud Storage to a machine running MacOS).
+  downloading from Google Cloud Storage to a machine running macOS).
   Unfortunately these problems are a consequence of the lack of a filename
   encoding standard, and users need to be aware of the kinds of problems that
   can arise when copying filenames across platforms.

--- a/gslib/addlhelp/wildcards.py
+++ b/gslib/addlhelp/wildcards.py
@@ -102,39 +102,38 @@ _DETAILED_HELP_TEXT = ("""
   There are a couple of ways that using wildcards can result in surprising
   behavior:
 
-    1. Shells (like bash and zsh) can attempt to expand wildcards before passing
-       the arguments to gsutil. If the wildcard was supposed to refer to a cloud
-       object, this can result in surprising "Not found" errors (e.g., if the
-       shell tries to expand the wildcard "gs://my-bucket/*" on the local
-       machine, matching no local files, and failing the command).
+  1. Shells (like bash and zsh) can attempt to expand wildcards before passing
+     the arguments to gsutil. If the wildcard was supposed to refer to a cloud
+     object, this can result in surprising "Not found" errors (e.g., if the
+     shell tries to expand the wildcard "gs://my-bucket/*" on the local
+     machine, matching no local files, and failing the command).
 
-       Note that some shells include additional characters in their wildcard
-       character sets. For example, if you use zsh with the extendedglob option
-       enabled it will treat "#" as a special character, which conflicts with
-       that character's use in referencing versioned objects (see
-       "gsutil help versions" for details).
+     Note that some shells include additional characters in their wildcard
+     character sets. For example, if you use zsh with the extendedglob option
+     enabled it will treat "#" as a special character, which conflicts with
+     that character's use in referencing versioned objects (see
+     "gsutil help versions" for details).
 
-       To avoid these problems, surround the wildcarded expression with single
-       quotes (on Linux) or double quotes (on Windows).
+     To avoid these problems, surround the wildcarded expression with single
+     quotes (on Linux) or double quotes (on Windows).
 
-    2. Attempting to specify a filename that contains wildcard characters won't
-       work, because gsutil will try to expand the wildcard characters rather
-       than using them as literal characters. For example, running the command:
+  2. Attempting to specify a filename that contains wildcard characters won't
+     work, because gsutil will try to expand the wildcard characters rather
+     than using them as literal characters. For example, running the command:
 
-             gsutil cp './file[1]' gs://my-bucket
+       gsutil cp './file[1]' gs://my-bucket
 
-       will cause gsutil to try to match the '[1]' part as a wildcard.
+     will cause gsutil to try to match the '[1]' part as a wildcard.
 
-       There's an open issue to support a "raw" mode for gsutil to provide a
-       way to work with file names that contain wildcard characters, but until /
-       unless that support is implemented there's no really good way to use
-       gsutil with such file names. You could use a wildcard to name such files,
-       for example replacing the above command with:
+     There's an open issue to support a "raw" mode for gsutil to provide a
+     way to work with file names that contain wildcard characters, but until /
+     unless that support is implemented there's no really good way to use
+     gsutil with such file names. You could use a wildcard to name such files,
+     for example replacing the above command with:
 
-             gsutil cp './file*1*' gs://my-bucket
+       gsutil cp './file*1*' gs://my-bucket
 
-       but that approach may be difficult to use in general.
-
+     but that approach may be difficult to use in general.
 
 
 <B>DIFFERENT BEHAVIOR FOR "DOT" FILES IN LOCAL FILE SYSTEM</B>

--- a/gslib/commands/mb.py
+++ b/gslib/commands/mb.py
@@ -35,7 +35,7 @@ from gslib.utils.text_util import NormalizeStorageClass
 
 
 _SYNOPSIS = """
-  gsutil mb [-b bucket_policy_only] [-c class] [-l location] [-p proj_id]
+  gsutil mb [-b [on|off]] [-c class] [-l location] [-p proj_id]
             [--retention time] url...
 """
 

--- a/gslib/commands/notification.py
+++ b/gslib/commands/notification.py
@@ -87,7 +87,7 @@ _LIST_DESCRIPTION = """
     gsutil notification list gs://example-bucket
 
   The same as above, but for Object Change Notifications instead of Cloud
-  Pub/Sub notification subscription configs.
+  Pub/Sub notification subscription configs:
 
     gsutil notification list -o gs://example-bucket
 

--- a/gslib/commands/rsync.py
+++ b/gslib/commands/rsync.py
@@ -219,16 +219,16 @@ _DETAILED_HELP_TEXT = ("""
   my-bucket containing the data from the files to which the symlinks point. This
   can cause various problems:
 
-    * If you use gsutil rsync as a simple way to backup a directory to a bucket,
-      restoring from that bucket will result in files where the symlinks used
-      to be. At best this is wasteful of space, and at worst it can result in
-      outdated data or broken applications -- depending on what is consuming
-      the symlinks.
+  * If you use gsutil rsync as a simple way to backup a directory to a bucket,
+    restoring from that bucket will result in files where the symlinks used
+    to be. At best this is wasteful of space, and at worst it can result in
+    outdated data or broken applications -- depending on what is consuming
+    the symlinks.
 
-    * If you use gsutil rsync over directories containing broken symlinks,
-      gsutil rsync will abort (unless you pass the -e option).
+  * If you use gsutil rsync over directories containing broken symlinks,
+    gsutil rsync will abort (unless you pass the -e option).
 
-    * gsutil rsync skips symlinks that point to directories.
+  * gsutil rsync skips symlinks that point to directories.
 
   Since gsutil rsync is intended to support data operations (like moving a data
   set to the cloud for computational processing) and it needs to be compatible
@@ -252,7 +252,7 @@ _DETAILED_HELP_TEXT = ("""
   synchronizes using stale listing data when working with these other cloud
   providers. For example, if you run rsync immediately after uploading an
   object to an eventually consistent cloud provider, the added object may not
-  yet appear in the provider’s listing. Consequently, rsync will miss adding
+  yet appear in the provider's listing. Consequently, rsync will miss adding
   the object to the destination. If this happens you can rerun the rsync
   operation again later (after the object listing has "caught up").
 


### PR DESCRIPTION
These fixes allow us to *correctly* generate web docs from the source
documentation.