### PR TITLE
Kokoro builds now fetch keys from Keystore

### DIFF
--- a/test/ci/kokoro/linux/presubmit.cfg
+++ b/test/ci/kokoro/linux/presubmit.cfg
@@ -16,3 +16,14 @@
 build_file: "gsutil/ci/kokoro/linux/run_integ_tests.sh"
 timeout_mins: 30
 
+# Get access keys from Keystore
+# go/kokoro-keystore
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "GSUTIL_KOKORO"
+    }
+  }
+}
+

--- a/test/ci/kokoro/macos/presubmit.cfg
+++ b/test/ci/kokoro/macos/presubmit.cfg
@@ -16,3 +16,15 @@
 build_file: "gsutil/ci/kokoro/mac/run_integ_tests.sh"
 timeout_mins: 30
 
+
+# Get access keys from Keystore
+# go/kokoro-keystore
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "GSUTIL_KOKORO"
+    }
+  }
+}
+

--- a/test/ci/kokoro/windows/presubmit.cfg
+++ b/test/ci/kokoro/windows/presubmit.cfg
@@ -16,3 +16,15 @@
 build_file: "gsutil/test/ci/kokoro/windows/run_integ_tests.ps1"
 timeout_mins: 40
 
+
+# Get access keys from Keystore
+# go/kokoro-keystore
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "GSUTIL_KOKORO"
+    }
+  }
+}
+


### PR DESCRIPTION
Before executing build scripts, Kokoro will now fetch keys from
keystore. Keys are stored in /src/keystore and should include a
key to access bigstore-gsutil-testing GCP account for access to
our testing infra, and a GitHub access key for Kokoro to monitor
and comment on our gsutil repository.

Docs: go/kokoro-keystore
ACLs: cl/236744745
Bug:  b/127358637