### PR TITLE
Added details for Bucket Policy Only for defacl get.

### DIFF
--- a/gslib/command.py
+++ b/gslib/command.py
@@ -1075,7 +1075,11 @@ class Command(HelpProvider):
               'created in this bucket will be readable only by their '
               'creators. It could also mean you do not have OWNER permission '
               'on %s and therefore do not have permission to read the '
-              'default object ACL.', url_str, url_str)
+              'default object ACL. It could also mean that %s has Bucket '
+              'Policy Only enabled and therefore object ACLs and default '
+              'object ACLs are disabled (See '
+              'https://cloud.google.com/storage/docs/bucket-policy-only).',
+              url_str, url_str, url_str)
       else:
         acl = blr.root_object.acl
         # Use the access controls api to check if the acl is actually empty or

--- a/gslib/command.py
+++ b/gslib/command.py
@@ -1077,7 +1077,7 @@ class Command(HelpProvider):
               'on %s and therefore do not have permission to read the '
               'default object ACL. It could also mean that %s has Bucket '
               'Policy Only enabled and therefore object ACLs and default '
-              'object ACLs are disabled (See '
+              'object ACLs are disabled (see '
               'https://cloud.google.com/storage/docs/bucket-policy-only).',
               url_str, url_str, url_str)
       else:


### PR DESCRIPTION
https://codereview.appspot.com/344170043/

Currently, when getting the default object ACL, the description only suggesting either the caller doesn't have OWNER permission or if the bucket has private ACL. 

This add information about Bucket Policy Only as one of the possible reason that default object ACL is empty.