### PR TITLE
Added param configs for Kokoro Windows jobs

### DIFF
--- a/test/ci/kokoro/windows/presubmit.cfg
+++ b/test/ci/kokoro/windows/presubmit.cfg
@@ -28,3 +28,15 @@ before_action {
   }
 }
 
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L15
+build_params {
+  key: "GsutilRepoDir"
+  value: "C:\\keystore\\src\\gsutil"
+}
+
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L19
+build_params {
+  key: "PyExe"
+  value "C:\\python$PYMAJOR$PYMINOR\\python.exe"
+}
+


### PR DESCRIPTION
Testing powershell script needs the Python path and gsutil directory
specified in its parameters. We're doing this in the build config
for Windows.

Build params kokoro doc: go/kokoro-build-params