### PR TITLE
Updated Kokoro build script paths.

### DIFF
--- a/test/ci/kokoro/linux/presubmit.cfg
+++ b/test/ci/kokoro/linux/presubmit.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "gsutil/ci/kokoro/linux/run_integ_tests.sh"
+build_file: "test/ci/kokoro/linux/run_integ_tests.sh"
 timeout_mins: 30
 
 # Get access keys from Keystore

--- a/test/ci/kokoro/macos/presubmit.cfg
+++ b/test/ci/kokoro/macos/presubmit.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "gsutil/ci/kokoro/mac/run_integ_tests.sh"
+build_file: "test/ci/kokoro/mac/run_integ_tests.sh"
 timeout_mins: 30
 
 

--- a/test/ci/kokoro/windows/presubmit.cfg
+++ b/test/ci/kokoro/windows/presubmit.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "gsutil/test/ci/kokoro/windows/run_integ_tests.ps1"
+build_file: "test/ci/kokoro/windows/run_integ_tests.ps1"
 timeout_mins: 40
 
 


### PR DESCRIPTION
Build paths all have a typo, per b/127678469#comment7. This is
preventing Kokoro builds.