### PR TITLE
Added continuous build configs

### DIFF
--- a/test/ci/kokoro/linux/continuous.cfg
+++ b/test/ci/kokoro/linux/continuous.cfg
@@ -1,0 +1,29 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "test/ci/kokoro/linux/run_integ_tests.sh"
+timeout_mins: 30
+
+# Get access keys from Keystore
+# go/kokoro-keystore
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "GSUTIL_KOKORO"
+    }
+  }
+}
+

--- a/test/ci/kokoro/linux/continuous.cfg
+++ b/test/ci/kokoro/linux/continuous.cfg
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 build_file: "test/ci/kokoro/linux/run_integ_tests.sh"
-timeout_mins: 30
+timeout_mins: 60
 
 # Get access keys from Keystore
 # go/kokoro-keystore

--- a/test/ci/kokoro/linux/presubmit.cfg
+++ b/test/ci/kokoro/linux/presubmit.cfg
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 build_file: "test/ci/kokoro/linux/run_integ_tests.sh"
-timeout_mins: 30
+timeout_mins: 60
 
 # Get access keys from Keystore
 # go/kokoro-keystore

--- a/test/ci/kokoro/macos/continuous.cfg
+++ b/test/ci/kokoro/macos/continuous.cfg
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 build_file: "test/ci/kokoro/mac/run_integ_tests.sh"
-timeout_mins: 30
+timeout_mins: 60
 
 
 # Get access keys from Keystore

--- a/test/ci/kokoro/macos/continuous.cfg
+++ b/test/ci/kokoro/macos/continuous.cfg
@@ -1,0 +1,30 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "test/ci/kokoro/mac/run_integ_tests.sh"
+timeout_mins: 30
+
+
+# Get access keys from Keystore
+# go/kokoro-keystore
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "GSUTIL_KOKORO"
+    }
+  }
+}
+

--- a/test/ci/kokoro/macos/presubmit.cfg
+++ b/test/ci/kokoro/macos/presubmit.cfg
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 build_file: "test/ci/kokoro/mac/run_integ_tests.sh"
-timeout_mins: 30
+timeout_mins: 60
 
 
 # Get access keys from Keystore

--- a/test/ci/kokoro/windows/continuous.cfg
+++ b/test/ci/kokoro/windows/continuous.cfg
@@ -1,0 +1,42 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "test/ci/kokoro/windows/run_integ_tests.ps1"
+timeout_mins: 40
+
+
+# Get access keys from Keystore
+# go/kokoro-keystore
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "GSUTIL_KOKORO"
+    }
+  }
+}
+
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L15
+build_params {
+  key: "GsutilRepoDir"
+  value: "C:\\keystore\\src\\gsutil"
+}
+
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L19
+build_params {
+  key: "PyExe"
+  value "C:\\python$PYMAJOR$PYMINOR\\python.exe"
+}
+

--- a/test/ci/kokoro/windows/continuous.cfg
+++ b/test/ci/kokoro/windows/continuous.cfg
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 build_file: "test/ci/kokoro/windows/run_integ_tests.ps1"
-timeout_mins: 40
+timeout_mins: 60
 
 
 # Get access keys from Keystore

--- a/test/ci/kokoro/windows/presubmit.cfg
+++ b/test/ci/kokoro/windows/presubmit.cfg
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 build_file: "test/ci/kokoro/windows/run_integ_tests.ps1"
-timeout_mins: 40
+timeout_mins: 60
 
 
 # Get access keys from Keystore


### PR DESCRIPTION
Added Kokoro CI build configs to trigger every time a push happens
on our repository. Although this will largely overlap with the
presubmit tests running on every PR, it may help us in the case of
code being pushed directly to the repo without a PR.