### PR TITLE
Updated keystore key name

### DIFF
--- a/test/ci/kokoro/linux/continuous.cfg
+++ b/test/ci/kokoro/linux/continuous.cfg
@@ -22,7 +22,7 @@ before_action {
   fetch_keystore {
     keystore_resource {
       keystore_config_id: 74008
-      keyname: "GSUTIL_KOKORO"
+      keyname: "gsutil_kokoro_service_key"
     }
   }
 }

--- a/test/ci/kokoro/linux/presubmit.cfg
+++ b/test/ci/kokoro/linux/presubmit.cfg
@@ -22,7 +22,7 @@ before_action {
   fetch_keystore {
     keystore_resource {
       keystore_config_id: 74008
-      keyname: "GSUTIL_KOKORO"
+      keyname: "gsutil_kokoro_service_key"
     }
   }
 }

--- a/test/ci/kokoro/macos/continuous.cfg
+++ b/test/ci/kokoro/macos/continuous.cfg
@@ -23,7 +23,7 @@ before_action {
   fetch_keystore {
     keystore_resource {
       keystore_config_id: 74008
-      keyname: "GSUTIL_KOKORO"
+      keyname: "gsutil_kokoro_service_key"
     }
   }
 }

--- a/test/ci/kokoro/macos/presubmit.cfg
+++ b/test/ci/kokoro/macos/presubmit.cfg
@@ -23,7 +23,7 @@ before_action {
   fetch_keystore {
     keystore_resource {
       keystore_config_id: 74008
-      keyname: "GSUTIL_KOKORO"
+      keyname: "gsutil_kokoro_service_key"
     }
   }
 }

--- a/test/ci/kokoro/windows/continuous.cfg
+++ b/test/ci/kokoro/windows/continuous.cfg
@@ -23,7 +23,7 @@ before_action {
   fetch_keystore {
     keystore_resource {
       keystore_config_id: 74008
-      keyname: "GSUTIL_KOKORO"
+      keyname: "gsutil_kokoro_service_key"
     }
   }
 }

--- a/test/ci/kokoro/windows/presubmit.cfg
+++ b/test/ci/kokoro/windows/presubmit.cfg
@@ -23,7 +23,7 @@ before_action {
   fetch_keystore {
     keystore_resource {
       keystore_config_id: 74008
-      keyname: "GSUTIL_KOKORO"
+      keyname: "gsutil_kokoro_service_key"
     }
   }
 }


### PR DESCRIPTION
In configs, fetching the GCP account key is mistakenly referencing
the keystore config name rather than the key name.

Our keystore keys can be found at go/gsutil-keystore-keyname