### PR TITLE
Update storage_v1_* apitools generated modules.

### DIFF
--- a/gslib/third_party/storage_apitools/storage_v1_client.py
+++ b/gslib/third_party/storage_apitools/storage_v1_client.py
@@ -54,7 +54,8 @@ class StorageV1(base_api.BaseApiClient):
                get_credentials=True, http=None, model=None,
                log_request=False, log_response=False,
                credentials_args=None, default_global_params=None,
-               version=_VERSION, additional_http_headers=None):
+               version=_VERSION,
+               additional_http_headers=None, response_encoding=None):
     """Create a new storage handle."""
     url = url or self.BASE_URL
     super(StorageV1, self).__init__(
@@ -63,7 +64,8 @@ class StorageV1(base_api.BaseApiClient):
         log_request=log_request, log_response=log_response,
         credentials_args=credentials_args,
         default_global_params=default_global_params,
-        additional_http_headers=additional_http_headers)
+        additional_http_headers=additional_http_headers,
+        response_encoding=response_encoding)
     self._version = version
     self.bucketAccessControls = self.BucketAccessControlsService(self)
     self.buckets = self.BucketsService(self)
@@ -86,7 +88,7 @@ class StorageV1(base_api.BaseApiClient):
           }
 
     def Delete(self, request, global_params=None):
-      """Permanently deletes the ACL entry for the specified entity on the specified bucket.
+      r"""Permanently deletes the ACL entry for the specified entity on the specified bucket.
 
       Args:
         request: (StorageBucketAccessControlsDeleteRequest) input message
@@ -112,7 +114,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def Get(self, request, global_params=None):
-      """Returns the ACL entry for the specified entity on the specified bucket.
+      r"""Returns the ACL entry for the specified entity on the specified bucket.
 
       Args:
         request: (StorageBucketAccessControlsGetRequest) input message
@@ -138,7 +140,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def Insert(self, request, global_params=None):
-      """Creates a new ACL entry on the specified bucket.
+      r"""Creates a new ACL entry on the specified bucket.
 
       Args:
         request: (StorageBucketAccessControlsInsertRequest) input message
@@ -164,7 +166,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def List(self, request, global_params=None):
-      """Retrieves ACL entries on the specified bucket.
+      r"""Retrieves ACL entries on the specified bucket.
 
       Args:
         request: (StorageBucketAccessControlsListRequest) input message
@@ -190,7 +192,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def Patch(self, request, global_params=None):
-      """Updates an ACL entry on the specified bucket. This method supports patch semantics.
+      r"""Patches an ACL entry on the specified bucket.
 
       Args:
         request: (StorageBucketAccessControlsPatchRequest) input message
@@ -216,7 +218,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def Update(self, request, global_params=None):
-      """Updates an ACL entry on the specified bucket.
+      r"""Updates an ACL entry on the specified bucket.
 
       Args:
         request: (StorageBucketAccessControlsUpdateRequest) input message
@@ -252,7 +254,7 @@ class StorageV1(base_api.BaseApiClient):
           }
 
     def Delete(self, request, global_params=None):
-      """Permanently deletes an empty bucket.
+      r"""Permanently deletes an empty bucket.
 
       Args:
         request: (StorageBucketsDeleteRequest) input message
@@ -278,7 +280,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def Get(self, request, global_params=None):
-      """Returns metadata for the specified bucket.
+      r"""Returns metadata for the specified bucket.
 
       Args:
         request: (StorageBucketsGetRequest) input message
@@ -304,7 +306,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def GetIamPolicy(self, request, global_params=None):
-      """Returns an IAM policy for the specified bucket.
+      r"""Returns an IAM policy for the specified bucket.
 
       Args:
         request: (StorageBucketsGetIamPolicyRequest) input message
@@ -330,7 +332,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def Insert(self, request, global_params=None):
-      """Creates a new bucket.
+      r"""Creates a new bucket.
 
       Args:
         request: (StorageBucketsInsertRequest) input message
@@ -356,7 +358,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def List(self, request, global_params=None):
-      """Retrieves a list of buckets for a given project.
+      r"""Retrieves a list of buckets for a given project.
 
       Args:
         request: (StorageBucketsListRequest) input message
@@ -408,7 +410,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def LockRetentionPolicy(self, request, global_params=None):
-      """Locks retention policy on a bucket.
+      r"""Locks retention policy on a bucket.
 
       Args:
         request: (StorageBucketsLockRetentionPolicyRequest) input message
@@ -434,7 +436,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def Patch(self, request, global_params=None):
-      """Updates a bucket. Changes to the bucket will be readable immediately after writing, but configuration changes may take time to propagate. This method supports patch semantics.
+      r"""Patches a bucket. Changes to the bucket will be readable immediately after writing, but configuration changes may take time to propagate.
 
       Args:
         request: (StorageBucketsPatchRequest) input message
@@ -460,7 +462,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def SetIamPolicy(self, request, global_params=None):
-      """Updates an IAM policy for the specified bucket.
+      r"""Updates an IAM policy for the specified bucket.
 
       Args:
         request: (StorageBucketsSetIamPolicyRequest) input message
@@ -486,7 +488,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def TestIamPermissions(self, request, global_params=None):
-      """Tests a set of permissions on the given bucket to see which, if any, are held by the caller.
+      r"""Tests a set of permissions on the given bucket to see which, if any, are held by the caller.
 
       Args:
         request: (StorageBucketsTestIamPermissionsRequest) input message
@@ -512,7 +514,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def Update(self, request, global_params=None):
-      """Updates a bucket. Changes to the bucket will be readable immediately after writing, but configuration changes may take time to propagate.
+      r"""Updates a bucket. Changes to the bucket will be readable immediately after writing, but configuration changes may take time to propagate.
 
       Args:
         request: (StorageBucketsUpdateRequest) input message
@@ -548,7 +550,7 @@ class StorageV1(base_api.BaseApiClient):
           }
 
     def Stop(self, request, global_params=None):
-      """Stop watching resources through this channel.
+      r"""Stop watching resources through this channel.
 
       Args:
         request: (Channel) input message
@@ -584,7 +586,7 @@ class StorageV1(base_api.BaseApiClient):
           }
 
     def Delete(self, request, global_params=None):
-      """Permanently deletes the default object ACL entry for the specified entity on the specified bucket.
+      r"""Permanently deletes the default object ACL entry for the specified entity on the specified bucket.
 
       Args:
         request: (StorageDefaultObjectAccessControlsDeleteRequest) input message
@@ -610,7 +612,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def Get(self, request, global_params=None):
-      """Returns the default object ACL entry for the specified entity on the specified bucket.
+      r"""Returns the default object ACL entry for the specified entity on the specified bucket.
 
       Args:
         request: (StorageDefaultObjectAccessControlsGetRequest) input message
@@ -636,7 +638,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def Insert(self, request, global_params=None):
-      """Creates a new default object ACL entry on the specified bucket.
+      r"""Creates a new default object ACL entry on the specified bucket.
 
       Args:
         request: (StorageDefaultObjectAccessControlsInsertRequest) input message
@@ -662,7 +664,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def List(self, request, global_params=None):
-      """Retrieves default object ACL entries on the specified bucket.
+      r"""Retrieves default object ACL entries on the specified bucket.
 
       Args:
         request: (StorageDefaultObjectAccessControlsListRequest) input message
@@ -688,7 +690,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def Patch(self, request, global_params=None):
-      """Updates a default object ACL entry on the specified bucket. This method supports patch semantics.
+      r"""Patches a default object ACL entry on the specified bucket.
 
       Args:
         request: (StorageDefaultObjectAccessControlsPatchRequest) input message
@@ -714,7 +716,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def Update(self, request, global_params=None):
-      """Updates a default object ACL entry on the specified bucket.
+      r"""Updates a default object ACL entry on the specified bucket.
 
       Args:
         request: (StorageDefaultObjectAccessControlsUpdateRequest) input message
@@ -750,7 +752,7 @@ class StorageV1(base_api.BaseApiClient):
           }
 
     def Delete(self, request, global_params=None):
-      """Permanently deletes a notification subscription.
+      r"""Permanently deletes a notification subscription.
 
       Args:
         request: (StorageNotificationsDeleteRequest) input message
@@ -776,7 +778,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def Get(self, request, global_params=None):
-      """View a notification configuration.
+      r"""View a notification configuration.
 
       Args:
         request: (StorageNotificationsGetRequest) input message
@@ -802,7 +804,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def Insert(self, request, global_params=None):
-      """Creates a notification subscription for a given bucket.
+      r"""Creates a notification subscription for a given bucket.
 
       Args:
         request: (StorageNotificationsInsertRequest) input message
@@ -828,7 +830,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def List(self, request, global_params=None):
-      """Retrieves a list of notification subscriptions for a given bucket.
+      r"""Retrieves a list of notification subscriptions for a given bucket.
 
       Args:
         request: (StorageNotificationsListRequest) input message
@@ -864,7 +866,7 @@ class StorageV1(base_api.BaseApiClient):
           }
 
     def Delete(self, request, global_params=None):
-      """Permanently deletes the ACL entry for the specified entity on the specified object.
+      r"""Permanently deletes the ACL entry for the specified entity on the specified object.
 
       Args:
         request: (StorageObjectAccessControlsDeleteRequest) input message
@@ -890,7 +892,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def Get(self, request, global_params=None):
-      """Returns the ACL entry for the specified entity on the specified object.
+      r"""Returns the ACL entry for the specified entity on the specified object.
 
       Args:
         request: (StorageObjectAccessControlsGetRequest) input message
@@ -916,7 +918,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def Insert(self, request, global_params=None):
-      """Creates a new ACL entry on the specified object.
+      r"""Creates a new ACL entry on the specified object.
 
       Args:
         request: (StorageObjectAccessControlsInsertRequest) input message
@@ -942,7 +944,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def List(self, request, global_params=None):
-      """Retrieves ACL entries on the specified object.
+      r"""Retrieves ACL entries on the specified object.
 
       Args:
         request: (StorageObjectAccessControlsListRequest) input message
@@ -968,7 +970,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def Patch(self, request, global_params=None):
-      """Updates an ACL entry on the specified object. This method supports patch semantics.
+      r"""Patches an ACL entry on the specified object.
 
       Args:
         request: (StorageObjectAccessControlsPatchRequest) input message
@@ -994,7 +996,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def Update(self, request, global_params=None):
-      """Updates an ACL entry on the specified object.
+      r"""Updates an ACL entry on the specified object.
 
       Args:
         request: (StorageObjectAccessControlsUpdateRequest) input message
@@ -1037,21 +1039,18 @@ class StorageV1(base_api.BaseApiClient):
           ),
           }
 
-    def Compose(self, request, global_params=None, download=None):
-      """Concatenates a list of existing objects into a new object in the same bucket.
+    def Compose(self, request, global_params=None):
+      r"""Concatenates a list of existing objects into a new object in the same bucket.
 
       Args:
         request: (StorageObjectsComposeRequest) input message
         global_params: (StandardQueryParameters, default: None) global arguments
-        download: (Download, default: None) If present, download
-            data from the request via this stream.
       Returns:
         (Object) The response message.
       """
       config = self.GetMethodConfig('Compose')
       return self._RunMethod(
-          config, request, global_params=global_params,
-          download=download)
+          config, request, global_params=global_params)
 
     Compose.method_config = lambda: base_api.ApiMethodInfo(
         http_method=u'POST',
@@ -1063,24 +1062,21 @@ class StorageV1(base_api.BaseApiClient):
         request_field=u'composeRequest',
         request_type_name=u'StorageObjectsComposeRequest',
         response_type_name=u'Object',
-        supports_download=True,
+        supports_download=False,
     )
 
-    def Copy(self, request, global_params=None, download=None):
-      """Copies a source object to a destination object. Optionally overrides metadata.
+    def Copy(self, request, global_params=None):
+      r"""Copies a source object to a destination object. Optionally overrides metadata.
 
       Args:
         request: (StorageObjectsCopyRequest) input message
         global_params: (StandardQueryParameters, default: None) global arguments
-        download: (Download, default: None) If present, download
-            data from the request via this stream.
       Returns:
         (Object) The response message.
       """
       config = self.GetMethodConfig('Copy')
       return self._RunMethod(
-          config, request, global_params=global_params,
-          download=download)
+          config, request, global_params=global_params)
 
     Copy.method_config = lambda: base_api.ApiMethodInfo(
         http_method=u'POST',
@@ -1092,11 +1088,11 @@ class StorageV1(base_api.BaseApiClient):
         request_field=u'object',
         request_type_name=u'StorageObjectsCopyRequest',
         response_type_name=u'Object',
-        supports_download=True,
+        supports_download=False,
     )
 
     def Delete(self, request, global_params=None):
-      """Deletes an object and its metadata. Deletions are permanent if versioning is not enabled for the bucket, or if the generation parameter is used.
+      r"""Deletes an object and its metadata. Deletions are permanent if versioning is not enabled for the bucket, or if the generation parameter is used.
 
       Args:
         request: (StorageObjectsDeleteRequest) input message
@@ -1122,7 +1118,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def Get(self, request, global_params=None, download=None):
-      """Retrieves an object or its metadata.
+      r"""Retrieves an object or its metadata.
 
       Args:
         request: (StorageObjectsGetRequest) input message
@@ -1151,7 +1147,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def GetIamPolicy(self, request, global_params=None):
-      """Returns an IAM policy for the specified object.
+      r"""Returns an IAM policy for the specified object.
 
       Args:
         request: (StorageObjectsGetIamPolicyRequest) input message
@@ -1176,16 +1172,14 @@ class StorageV1(base_api.BaseApiClient):
         supports_download=False,
     )
 
-    def Insert(self, request, global_params=None, upload=None, download=None):
-      """Stores a new object and metadata.
+    def Insert(self, request, global_params=None, upload=None):
+      r"""Stores a new object and metadata.
 
       Args:
         request: (StorageObjectsInsertRequest) input message
         global_params: (StandardQueryParameters, default: None) global arguments
         upload: (Upload, default: None) If present, upload
             this stream with the request.
-        download: (Download, default: None) If present, download
-            data from the request via this stream.
       Returns:
         (Object) The response message.
       """
@@ -1193,8 +1187,7 @@ class StorageV1(base_api.BaseApiClient):
       upload_config = self.GetUploadConfig('Insert')
       return self._RunMethod(
           config, request, global_params=global_params,
-          upload=upload, upload_config=upload_config,
-          download=download)
+          upload=upload, upload_config=upload_config)
 
     Insert.method_config = lambda: base_api.ApiMethodInfo(
         http_method=u'POST',
@@ -1206,11 +1199,11 @@ class StorageV1(base_api.BaseApiClient):
         request_field=u'object',
         request_type_name=u'StorageObjectsInsertRequest',
         response_type_name=u'Object',
-        supports_download=True,
+        supports_download=False,
     )
 
     def List(self, request, global_params=None):
-      """Retrieves a list of objects matching the criteria.
+      r"""Retrieves a list of objects matching the criteria.
 
       Args:
         request: (StorageObjectsListRequest) input message
@@ -1227,7 +1220,7 @@ class StorageV1(base_api.BaseApiClient):
         method_id=u'storage.objects.list',
         ordered_params=[u'bucket'],
         path_params=[u'bucket'],
-        query_params=[u'delimiter', u'maxResults', u'pageToken', u'prefix', u'projection', u'userProject', u'versions'],
+        query_params=[u'delimiter', u'includeTrailingDelimiter', u'maxResults', u'pageToken', u'prefix', u'projection', u'userProject', u'versions'],
         relative_path=u'b/{bucket}/o',
         request_field='',
         request_type_name=u'StorageObjectsListRequest',
@@ -1236,7 +1229,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def Patch(self, request, global_params=None):
-      """Updates an object's metadata. This method supports patch semantics.
+      r"""Patches an object's metadata.
 
       Args:
         request: (StorageObjectsPatchRequest) input message
@@ -1262,7 +1255,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def Rewrite(self, request, global_params=None):
-      """Rewrites a source object to a destination object. Optionally overrides metadata.
+      r"""Rewrites a source object to a destination object. Optionally overrides metadata.
 
       Args:
         request: (StorageObjectsRewriteRequest) input message
@@ -1288,7 +1281,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def SetIamPolicy(self, request, global_params=None):
-      """Updates an IAM policy for the specified object.
+      r"""Updates an IAM policy for the specified object.
 
       Args:
         request: (StorageObjectsSetIamPolicyRequest) input message
@@ -1314,7 +1307,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def TestIamPermissions(self, request, global_params=None):
-      """Tests a set of permissions on the given object to see which, if any, are held by the caller.
+      r"""Tests a set of permissions on the given object to see which, if any, are held by the caller.
 
       Args:
         request: (StorageObjectsTestIamPermissionsRequest) input message
@@ -1339,21 +1332,18 @@ class StorageV1(base_api.BaseApiClient):
         supports_download=False,
     )
 
-    def Update(self, request, global_params=None, download=None):
-      """Updates an object's metadata.
+    def Update(self, request, global_params=None):
+      r"""Updates an object's metadata.
 
       Args:
         request: (StorageObjectsUpdateRequest) input message
         global_params: (StandardQueryParameters, default: None) global arguments
-        download: (Download, default: None) If present, download
-            data from the request via this stream.
       Returns:
         (Object) The response message.
       """
       config = self.GetMethodConfig('Update')
       return self._RunMethod(
-          config, request, global_params=global_params,
-          download=download)
+          config, request, global_params=global_params)
 
     Update.method_config = lambda: base_api.ApiMethodInfo(
         http_method=u'PUT',
@@ -1365,11 +1355,11 @@ class StorageV1(base_api.BaseApiClient):
         request_field=u'objectResource',
         request_type_name=u'StorageObjectsUpdateRequest',
         response_type_name=u'Object',
-        supports_download=True,
+        supports_download=False,
     )
 
     def WatchAll(self, request, global_params=None):
-      """Watch for changes on all objects in a bucket.
+      r"""Watch for changes on all objects in a bucket.
 
       Args:
         request: (StorageObjectsWatchAllRequest) input message
@@ -1386,7 +1376,7 @@ class StorageV1(base_api.BaseApiClient):
         method_id=u'storage.objects.watchAll',
         ordered_params=[u'bucket'],
         path_params=[u'bucket'],
-        query_params=[u'delimiter', u'maxResults', u'pageToken', u'prefix', u'projection', u'userProject', u'versions'],
+        query_params=[u'delimiter', u'includeTrailingDelimiter', u'maxResults', u'pageToken', u'prefix', u'projection', u'userProject', u'versions'],
         relative_path=u'b/{bucket}/o/watch',
         request_field=u'channel',
         request_type_name=u'StorageObjectsWatchAllRequest',
@@ -1405,7 +1395,7 @@ class StorageV1(base_api.BaseApiClient):
           }
 
     def Get(self, request, global_params=None):
-      """Get the email address of this project's Google Cloud Storage service account.
+      r"""Get the email address of this project's Google Cloud Storage service account.
 
       Args:
         request: (StorageProjectsServiceAccountGetRequest) input message

--- a/gslib/third_party/storage_apitools/storage_v1_messages.py
+++ b/gslib/third_party/storage_apitools/storage_v1_messages.py
@@ -27,14 +27,13 @@ package = 'storage'
 
 
 class Bucket(_messages.Message):
-  """A bucket.
+  r"""A bucket.
 
   Messages:
     BillingValue: The bucket's billing configuration.
     CorsValueListEntry: A CorsValueListEntry object.
-    EncryptionValue: Encryption configuration used by default for newly
-      inserted objects, when no encryption config is specified.
-    IamConfigurationValue: The bucket's IAM features configuration.
+    EncryptionValue: Encryption configuration for a bucket.
+    IamConfigurationValue: The bucket's IAM configuration.
     LabelsValue: User-provided labels, in key/value pairs.
     LifecycleValue: The bucket's lifecycle configuration. See lifecycle
       management for more information.
@@ -43,14 +42,14 @@ class Bucket(_messages.Message):
       logs.
     OwnerValue: The owner of the bucket. This is always the project team's
       owner group.
-    RetentionPolicyValue: Defines the retention policy for a bucket. The
-      Retention policy enforces a minimum retention time for all objects
-      contained in the bucket, based on their creation time. Any attempt to
-      overwrite or delete objects younger than the retention period will
-      result in a PERMISSION_DENIED error. An unlocked retention policy can be
-      modified or removed from the bucket via the UpdateBucketMetadata RPC. A
-      locked retention policy cannot be removed or shortened in duration for
-      the lifetime of the bucket. Attempting to remove or decrease period of a
+    RetentionPolicyValue: The bucket's retention policy. The retention policy
+      enforces a minimum retention time for all objects contained in the
+      bucket, based on their creation time. Any attempt to overwrite or delete
+      objects younger than the retention period will result in a
+      PERMISSION_DENIED error. An unlocked retention policy can be modified or
+      removed from the bucket via a storage.buckets.update operation. A locked
+      retention policy cannot be removed or shortened in duration for the
+      lifetime of the bucket. Attempting to remove or decrease period of a
       locked retention policy will result in a PERMISSION_DENIED error.
     VersioningValue: The bucket's versioning configuration.
     WebsiteValue: The bucket's website configuration, controlling how the
@@ -61,23 +60,24 @@ class Bucket(_messages.Message):
     acl: Access controls on the bucket.
     billing: The bucket's billing configuration.
     cors: The bucket's Cross-Origin Resource Sharing (CORS) configuration.
-    defaultEventBasedHold: Defines the default value for Event-Based hold on
-      newly created objects in this bucket. Event-Based hold is a way to
-      retain objects indefinitely until an event occurs, signified by the
-      hold's release. After being released, such objects will be subject to
-      bucket-level retention (if any). One sample use case of this flag is for
-      banks to hold loan documents for at least 3 years after loan is paid in
-      full. Here bucket-level retention is 3 years and the event is loan being
-      paid in full. In this example these objects will be held intact for any
-      number of years until the event has occurred (hold is released) and then
-      3 more years after that. Objects under Event-Based hold cannot be
-      deleted, overwritten or archived until the hold is removed.
+    defaultEventBasedHold: The default value for event-based hold on newly
+      created objects in this bucket. Event-based hold is a way to retain
+      objects indefinitely until an event occurs, signified by the hold's
+      release. After being released, such objects will be subject to bucket-
+      level retention (if any). One sample use case of this flag is for banks
+      to hold loan documents for at least 3 years after loan is paid in full.
+      Here, bucket-level retention is 3 years and the event is loan being paid
+      in full. In this example, these objects will be held intact for any
+      number of years until the event has occurred (event-based hold on the
+      object is released) and then 3 more years after that. That means
+      retention duration of the objects begins from the moment event-based
+      hold transitioned from true to false. Objects under event-based hold
+      cannot be deleted, overwritten or archived until the hold is removed.
     defaultObjectAcl: Default access controls to apply to new objects when no
       ACL is provided.
-    encryption: Encryption configuration used by default for newly inserted
-      objects, when no encryption config is specified.
+    encryption: Encryption configuration for a bucket.
     etag: HTTP 1.1 Entity tag for the bucket.
-    iamConfiguration: The bucket's IAM features configuration.
+    iamConfiguration: The bucket's IAM configuration.
     id: The ID of the bucket. For buckets, the id and name properties are the
       same.
     kind: The kind of item this is. For buckets, this is always
@@ -95,12 +95,12 @@ class Bucket(_messages.Message):
     owner: The owner of the bucket. This is always the project team's owner
       group.
     projectNumber: The project number of the project the bucket belongs to.
-    retentionPolicy: Defines the retention policy for a bucket. The Retention
-      policy enforces a minimum retention time for all objects contained in
-      the bucket, based on their creation time. Any attempt to overwrite or
-      delete objects younger than the retention period will result in a
+    retentionPolicy: The bucket's retention policy. The retention policy
+      enforces a minimum retention time for all objects contained in the
+      bucket, based on their creation time. Any attempt to overwrite or delete
+      objects younger than the retention period will result in a
       PERMISSION_DENIED error. An unlocked retention policy can be modified or
-      removed from the bucket via the UpdateBucketMetadata RPC. A locked
+      removed from the bucket via a storage.buckets.update operation. A locked
       retention policy cannot be removed or shortened in duration for the
       lifetime of the bucket. Attempting to remove or decrease period of a
       locked retention policy will result in a PERMISSION_DENIED error.
@@ -121,16 +121,17 @@ class Bucket(_messages.Message):
   """
 
   class BillingValue(_messages.Message):
-    """The bucket's billing configuration.
+    r"""The bucket's billing configuration.
 
     Fields:
-      requesterPays: When set to true, bucket is requester pays.
+      requesterPays: When set to true, Requester Pays is enabled for this
+        bucket.
     """
 
     requesterPays = _messages.BooleanField(1)
 
   class CorsValueListEntry(_messages.Message):
-    """A CorsValueListEntry object.
+    r"""A CorsValueListEntry object.
 
     Fields:
       maxAgeSeconds: The value, in seconds, to return in the  Access-Control-
@@ -150,27 +151,27 @@ class Bucket(_messages.Message):
     responseHeader = _messages.StringField(4, repeated=True)
 
   class EncryptionValue(_messages.Message):
-    """Encryption configuration used by default for newly inserted objects,
-    when no encryption config is specified.
+    r"""Encryption configuration for a bucket.
 
     Fields:
-      defaultKmsKeyName: A string attribute.
+      defaultKmsKeyName: A Cloud KMS key that will be used to encrypt objects
+        inserted into this bucket, if no encryption method is specified.
     """
 
     defaultKmsKeyName = _messages.StringField(1)
 
   class IamConfigurationValue(_messages.Message):
-    r"""The bucket's IAM features configuration.
+    r"""The bucket's IAM configuration.
 
     Messages:
-      BucketPolicyOnlyValue: A BucketPolicyOnlyValue object.
+      BucketPolicyOnlyValue: The bucket's Bucket Policy Only configuration.
 
     Fields:
-      bucketPolicyOnly: A BucketPolicyOnlyValue attribute.
+      bucketPolicyOnly: The bucket's Bucket Policy Only configuration.
     """
 
     class BucketPolicyOnlyValue(_messages.Message):
-      r"""A BucketPolicyOnlyValue object.
+      r"""The bucket's Bucket Policy Only configuration.
 
       Fields:
         enabled: If set, access checks only use bucket-level IAM policies or
@@ -189,7 +190,7 @@ class Bucket(_messages.Message):
 
   @encoding.MapUnrecognizedFields('additionalProperties')
   class LabelsValue(_messages.Message):
-    """User-provided labels, in key/value pairs.
+    r"""User-provided labels, in key/value pairs.
 
     Messages:
       AdditionalProperty: An additional property for a LabelsValue object.
@@ -199,7 +200,7 @@ class Bucket(_messages.Message):
     """
 
     class AdditionalProperty(_messages.Message):
-      """An additional property for a LabelsValue object.
+      r"""An additional property for a LabelsValue object.
 
       Fields:
         key: Name of the additional property.
@@ -212,8 +213,8 @@ class Bucket(_messages.Message):
     additionalProperties = _messages.MessageField('AdditionalProperty', 1, repeated=True)
 
   class LifecycleValue(_messages.Message):
-    """The bucket's lifecycle configuration. See lifecycle management for more
-    information.
+    r"""The bucket's lifecycle configuration. See lifecycle management for
+    more information.
 
     Messages:
       RuleValueListEntry: A RuleValueListEntry object.
@@ -224,7 +225,7 @@ class Bucket(_messages.Message):
     """
 
     class RuleValueListEntry(_messages.Message):
-      """A RuleValueListEntry object.
+      r"""A RuleValueListEntry object.
 
       Messages:
         ActionValue: The action to take.
@@ -236,7 +237,7 @@ class Bucket(_messages.Message):
       """
 
       class ActionValue(_messages.Message):
-        """The action to take.
+        r"""The action to take.
 
         Fields:
           storageClass: Target storage class. Required iff the type of the
@@ -249,7 +250,7 @@ class Bucket(_messages.Message):
         type = _messages.StringField(2)
 
       class ConditionValue(_messages.Message):
-        """The condition(s) under which the action will be taken.
+        r"""The condition(s) under which the action will be taken.
 
         Fields:
           age: Age of an object (in days). This condition is satisfied when an
@@ -282,7 +283,7 @@ class Bucket(_messages.Message):
     rule = _messages.MessageField('RuleValueListEntry', 1, repeated=True)
 
   class LoggingValue(_messages.Message):
-    """The bucket's logging configuration, which defines the destination
+    r"""The bucket's logging configuration, which defines the destination
     bucket and optional name prefix for the current bucket's logs.
 
     Fields:
@@ -295,7 +296,8 @@ class Bucket(_messages.Message):
     logObjectPrefix = _messages.StringField(2)
 
   class OwnerValue(_messages.Message):
-    """The owner of the bucket. This is always the project team's owner group.
+    r"""The owner of the bucket. This is always the project team's owner
+    group.
 
     Fields:
       entity: The entity, in the form project-owner-projectId.
@@ -306,21 +308,22 @@ class Bucket(_messages.Message):
     entityId = _messages.StringField(2)
 
   class RetentionPolicyValue(_messages.Message):
-    """Defines the retention policy for a bucket. The Retention policy
-    enforces a minimum retention time for all objects contained in the bucket,
-    based on their creation time. Any attempt to overwrite or delete objects
-    younger than the retention period will result in a PERMISSION_DENIED
-    error. An unlocked retention policy can be modified or removed from the
-    bucket via the UpdateBucketMetadata RPC. A locked retention policy cannot
-    be removed or shortened in duration for the lifetime of the bucket.
+    r"""The bucket's retention policy. The retention policy enforces a minimum
+    retention time for all objects contained in the bucket, based on their
+    creation time. Any attempt to overwrite or delete objects younger than the
+    retention period will result in a PERMISSION_DENIED error. An unlocked
+    retention policy can be modified or removed from the bucket via a
+    storage.buckets.update operation. A locked retention policy cannot be
+    removed or shortened in duration for the lifetime of the bucket.
     Attempting to remove or decrease period of a locked retention policy will
     result in a PERMISSION_DENIED error.
 
     Fields:
-      effectiveTime: The time from which policy was enforced and effective.
-        RFC 3339 format.
+      effectiveTime: Server-determined value that indicates the time from
+        which policy was enforced and effective. This value is in RFC 3339
+        format.
       isLocked: Once locked, an object retention policy cannot be modified.
-      retentionPeriod: Specifies the duration that objects need to be
+      retentionPeriod: The duration in seconds that objects need to be
         retained. Retention duration must be greater than zero and less than
         100 years. Note that enforcement of retention periods less than a day
         is not guaranteed. Such periods should only be used for testing
@@ -332,7 +335,7 @@ class Bucket(_messages.Message):
     retentionPeriod = _messages.IntegerField(3)
 
   class VersioningValue(_messages.Message):
-    """The bucket's versioning configuration.
+    r"""The bucket's versioning configuration.
 
     Fields:
       enabled: While set to true, versioning is fully enabled for this bucket.
@@ -341,9 +344,9 @@ class Bucket(_messages.Message):
     enabled = _messages.BooleanField(1)
 
   class WebsiteValue(_messages.Message):
-    """The bucket's website configuration, controlling how the service behaves
-    when accessing bucket contents as a web site. See the Static Website
-    Examples for more information.
+    r"""The bucket's website configuration, controlling how the service
+    behaves when accessing bucket contents as a web site. See the Static
+    Website Examples for more information.
 
     Fields:
       mainPageSuffix: If the requested object path is missing, the service
@@ -387,7 +390,7 @@ class Bucket(_messages.Message):
 
 
 class BucketAccessControl(_messages.Message):
-  """An access-control entry.
+  r"""An access-control entry.
 
   Messages:
     ProjectTeamValue: The project team associated with the entity, if any.
@@ -414,7 +417,7 @@ class BucketAccessControl(_messages.Message):
   """
 
   class ProjectTeamValue(_messages.Message):
-    """The project team associated with the entity, if any.
+    r"""The project team associated with the entity, if any.
 
     Fields:
       projectNumber: The project number.
@@ -438,7 +441,7 @@ class BucketAccessControl(_messages.Message):
 
 
 class BucketAccessControls(_messages.Message):
-  """An access-control list.
+  r"""An access-control list.
 
   Fields:
     items: The list of items.
@@ -451,7 +454,7 @@ class BucketAccessControls(_messages.Message):
 
 
 class Buckets(_messages.Message):
-  """A list of buckets.
+  r"""A list of buckets.
 
   Fields:
     items: The list of items.
@@ -468,7 +471,7 @@ class Buckets(_messages.Message):
 
 
 class Channel(_messages.Message):
-  """An notification channel used to watch for resource changes.
+  r"""An notification channel used to watch for resource changes.
 
   Messages:
     ParamsValue: Additional parameters controlling delivery channel behavior.
@@ -494,7 +497,7 @@ class Channel(_messages.Message):
 
   @encoding.MapUnrecognizedFields('additionalProperties')
   class ParamsValue(_messages.Message):
-    """Additional parameters controlling delivery channel behavior. Optional.
+    r"""Additional parameters controlling delivery channel behavior. Optional.
 
     Messages:
       AdditionalProperty: An additional property for a ParamsValue object.
@@ -504,7 +507,7 @@ class Channel(_messages.Message):
     """
 
     class AdditionalProperty(_messages.Message):
-      """An additional property for a ParamsValue object.
+      r"""An additional property for a ParamsValue object.
 
       Fields:
         key: Name of the additional property.
@@ -561,7 +564,7 @@ class Channels(_messages.Message):
   kind = _messages.StringField(2, default=u'storage#channels')
 
 class ComposeRequest(_messages.Message):
-  """A Compose request.
+  r"""A Compose request.
 
   Messages:
     SourceObjectsValueListEntry: A SourceObjectsValueListEntry object.
@@ -576,7 +579,7 @@ class ComposeRequest(_messages.Message):
   """
 
   class SourceObjectsValueListEntry(_messages.Message):
-    """A SourceObjectsValueListEntry object.
+    r"""A SourceObjectsValueListEntry object.
 
     Messages:
       ObjectPreconditionsValue: Conditions that must be met for this operation
@@ -584,14 +587,14 @@ class ComposeRequest(_messages.Message):
 
     Fields:
       generation: The generation of this object to use as the source.
-      name: The source object's name. The source object's bucket is implicitly
-        the destination bucket.
+      name: The source object's name. All source objects must reside in the
+        same bucket.
       objectPreconditions: Conditions that must be met for this operation to
         execute.
     """
 
     class ObjectPreconditionsValue(_messages.Message):
-      """Conditions that must be met for this operation to execute.
+      r"""Conditions that must be met for this operation to execute.
 
       Fields:
         ifGenerationMatch: Only perform the composition if the generation of
@@ -613,7 +616,7 @@ class ComposeRequest(_messages.Message):
 
 
 class Notification(_messages.Message):
-  """A subscription to receive Google PubSub notifications.
+  r"""A subscription to receive Google PubSub notifications.
 
   Messages:
     CustomAttributesValue: An optional list of additional attributes to attach
@@ -640,7 +643,7 @@ class Notification(_messages.Message):
 
   @encoding.MapUnrecognizedFields('additionalProperties')
   class CustomAttributesValue(_messages.Message):
-    """An optional list of additional attributes to attach to each Cloud
+    r"""An optional list of additional attributes to attach to each Cloud
     PubSub message published for this notification subscription.
 
     Messages:
@@ -653,7 +656,7 @@ class Notification(_messages.Message):
     """
 
     class AdditionalProperty(_messages.Message):
-      """An additional property for a CustomAttributesValue object.
+      r"""An additional property for a CustomAttributesValue object.
 
       Fields:
         key: Name of the additional property.
@@ -677,7 +680,7 @@ class Notification(_messages.Message):
 
 
 class Notifications(_messages.Message):
-  """A list of notification subscriptions.
+  r"""A list of notification subscriptions.
 
   Fields:
     items: The list of items.
@@ -690,7 +693,7 @@ class Notifications(_messages.Message):
 
 
 class Object(_messages.Message):
-  """An object.
+  r"""An object.
 
   Messages:
     CustomerEncryptionValue: Metadata of customer-supplied encryption key, if
@@ -718,15 +721,18 @@ class Object(_messages.Message):
     customerEncryption: Metadata of customer-supplied encryption key, if the
       object is encrypted by such a key.
     etag: HTTP 1.1 Entity tag for the object.
-    eventBasedHold: Defines the Event-Based hold for an object. Event-Based
-      hold is a way to retain objects indefinitely until an event occurs,
-      signified by the hold's release. After being released, such objects will
-      be subject to bucket-level retention (if any). One sample use case of
-      this flag is for banks to hold loan documents for at least 3 years after
-      loan is paid in full. Here bucket-level retention is 3 years and the
-      event is loan being paid in full. In this example these objects will be
-      held intact for any number of years until the event has occurred (hold
-      is released) and then 3 more years after that.
+    eventBasedHold: Whether an object is under event-based hold. Event-based
+      hold is a way to retain objects until an event occurs, which is
+      signified by the hold's release (i.e. this value is set to false). After
+      being released (set to false), such objects will be subject to bucket-
+      level retention (if any). One sample use case of this flag is for banks
+      to hold loan documents for at least 3 years after loan is paid in full.
+      Here, bucket-level retention is 3 years and the event is the loan being
+      paid in full. In this example, these objects will be held intact for any
+      number of years until the event has occurred (event-based hold on the
+      object is released) and then 3 more years after that. That means
+      retention duration of the objects begins from the moment event-based
+      hold transitioned from true to false.
     generation: The content generation of this object. Used for object
       versioning.
     id: The ID of the object, including the bucket name, object name, and
@@ -746,21 +752,22 @@ class Object(_messages.Message):
     name: The name of the object. Required if not specified by URL parameter.
     owner: The owner of the object. This will always be the uploader of the
       object.
-    retentionExpirationTime: Specifies the earliest time that the object's
-      retention period expires. This value is server-determined and is in RFC
-      3339 format. Note 1: This field is not provided for objects with an
-      active Event-Based hold, since retention expiration is unknown until the
-      hold is removed. Note 2: This value can be provided even when
-      TemporaryHold is set (so that the user can reason about policy without
-      having to first unset the TemporaryHold).
+    retentionExpirationTime: A server-determined value that specifies the
+      earliest time that the object's retention period expires. This value is
+      in RFC 3339 format. Note 1: This field is not provided for objects with
+      an active event-based hold, since retention expiration is unknown until
+      the hold is removed. Note 2: This value can be provided even when
+      temporary hold is set (so that the user can reason about policy without
+      having to first unset the temporary hold).
     selfLink: The link to this object.
     size: Content-Length of the data in bytes.
     storageClass: Storage class of the object.
-    temporaryHold: Defines the temporary hold for an object. This flag is used
-      to enforce a temporary hold on an object. While it is set to true, the
-      object is protected against deletion and overwrites. A common use case
-      of this flag is regulatory investigations where objects need to be
-      retained while the investigation is undergoing.
+    temporaryHold: Whether an object is under temporary hold. While this flag
+      is set to true, the object is protected against deletion and overwrites.
+      A common use case of this flag is regulatory investigations where
+      objects need to be retained while the investigation is ongoing. Note
+      that unlike event-based hold, temporary hold does not impact retention
+      expiration time of an object.
     timeCreated: The creation time of the object in RFC 3339 format.
     timeDeleted: The deletion time of the object in RFC 3339 format. Will be
       returned if and only if this version of the object has been deleted.
@@ -771,7 +778,7 @@ class Object(_messages.Message):
   """
 
   class CustomerEncryptionValue(_messages.Message):
-    """Metadata of customer-supplied encryption key, if the object is
+    r"""Metadata of customer-supplied encryption key, if the object is
     encrypted by such a key.
 
     Fields:
@@ -784,7 +791,7 @@ class Object(_messages.Message):
 
   @encoding.MapUnrecognizedFields('additionalProperties')
   class MetadataValue(_messages.Message):
-    """User-provided metadata, in key/value pairs.
+    r"""User-provided metadata, in key/value pairs.
 
     Messages:
       AdditionalProperty: An additional property for a MetadataValue object.
@@ -794,7 +801,7 @@ class Object(_messages.Message):
     """
 
     class AdditionalProperty(_messages.Message):
-      """An additional property for a MetadataValue object.
+      r"""An additional property for a MetadataValue object.
 
       Fields:
         key: Name of the additional property.
@@ -807,7 +814,7 @@ class Object(_messages.Message):
     additionalProperties = _messages.MessageField('AdditionalProperty', 1, repeated=True)
 
   class OwnerValue(_messages.Message):
-    """The owner of the object. This will always be the uploader of the
+    r"""The owner of the object. This will always be the uploader of the
     object.
 
     Fields:
@@ -852,7 +859,7 @@ class Object(_messages.Message):
 
 
 class ObjectAccessControl(_messages.Message):
-  """An access-control entry.
+  r"""An access-control entry.
 
   Messages:
     ProjectTeamValue: The project team associated with the entity, if any.
@@ -881,7 +888,7 @@ class ObjectAccessControl(_messages.Message):
   """
 
   class ProjectTeamValue(_messages.Message):
-    """The project team associated with the entity, if any.
+    r"""The project team associated with the entity, if any.
 
     Fields:
       projectNumber: The project number.
@@ -907,7 +914,7 @@ class ObjectAccessControl(_messages.Message):
 
 
 class ObjectAccessControls(_messages.Message):
-  """An access-control list.
+  r"""An access-control list.
 
   Fields:
     items: The list of items.
@@ -920,7 +927,7 @@ class ObjectAccessControls(_messages.Message):
 
 
 class Objects(_messages.Message):
-  """A list of objects.
+  r"""A list of objects.
 
   Fields:
     items: The list of items.
@@ -940,7 +947,7 @@ class Objects(_messages.Message):
 
 
 class Policy(_messages.Message):
-  """A bucket/object IAM policy.
+  r"""A bucket/object IAM policy.
 
   Messages:
     BindingsValueListEntry: A BindingsValueListEntry object.
@@ -961,56 +968,54 @@ class Policy(_messages.Message):
   """
 
   class BindingsValueListEntry(_messages.Message):
-    """A BindingsValueListEntry object.
+    r"""A BindingsValueListEntry object.
 
     Fields:
-      condition: A extra_types.JsonValue attribute.
       members: A collection of identifiers for members who may assume the
-        provided role. Recognized identifiers are as follows:   - allUsers \u2014 A
+        provided role. Recognized identifiers are as follows:   - allUsers - A
         special identifier that represents anyone on the internet; with or
-        without a Google account.   - allAuthenticatedUsers \u2014 A special
+        without a Google account.   - allAuthenticatedUsers - A special
         identifier that represents anyone who is authenticated with a Google
-        account or a service account.   - user:emailid \u2014 An email address that
+        account or a service account.   - user:emailid - An email address that
         represents a specific account. For example, user:alice@gmail.com or
-        user:joe@example.com.   - serviceAccount:emailid \u2014 An email address
+        user:joe@example.com.   - serviceAccount:emailid - An email address
         that represents a service account. For example,  serviceAccount:my-
-        other-app@appspot.gserviceaccount.com .   - group:emailid \u2014 An email
+        other-app@appspot.gserviceaccount.com .   - group:emailid - An email
         address that represents a Google group. For example,
-        group:admins@example.com.   - domain:domain \u2014 A Google Apps domain
+        group:admins@example.com.   - domain:domain - A Google Apps domain
         name that represents all the users of that domain. For example,
-        domain:google.com or domain:example.com.   - projectOwner:projectid \u2014
+        domain:google.com or domain:example.com.   - projectOwner:projectid -
         Owners of the given project. For example, projectOwner:my-example-
-        project   - projectEditor:projectid \u2014 Editors of the given project.
+        project   - projectEditor:projectid - Editors of the given project.
         For example, projectEditor:my-example-project   -
-        projectViewer:projectid \u2014 Viewers of the given project. For example,
+        projectViewer:projectid - Viewers of the given project. For example,
         projectViewer:my-example-project
       role: The role to which members belong. Two types of roles are
         supported: new IAM roles, which grant permissions that do not map
         directly to those provided by ACLs, and legacy IAM roles, which do map
         directly to ACL permissions. All roles are of the format
         roles/storage.specificRole. The new IAM roles are:   -
-        roles/storage.admin \u2014 Full control of Google Cloud Storage resources.
-        - roles/storage.objectViewer \u2014 Read-Only access to Google Cloud
-        Storage objects.   - roles/storage.objectCreator \u2014 Access to create
-        objects in Google Cloud Storage.   - roles/storage.objectAdmin \u2014 Full
+        roles/storage.admin - Full control of Google Cloud Storage resources.
+        - roles/storage.objectViewer - Read-Only access to Google Cloud
+        Storage objects.   - roles/storage.objectCreator - Access to create
+        objects in Google Cloud Storage.   - roles/storage.objectAdmin - Full
         control of Google Cloud Storage objects.   The legacy IAM roles are:
-        - roles/storage.legacyObjectReader \u2014 Read-only access to objects
+        - roles/storage.legacyObjectReader - Read-only access to objects
         without listing. Equivalent to an ACL entry on an object with the
-        READER role.   - roles/storage.legacyObjectOwner \u2014 Read/write access
+        READER role.   - roles/storage.legacyObjectOwner - Read/write access
         to existing objects without listing. Equivalent to an ACL entry on an
-        object with the OWNER role.   - roles/storage.legacyBucketReader \u2014
+        object with the OWNER role.   - roles/storage.legacyBucketReader -
         Read access to buckets with object listing. Equivalent to an ACL entry
         on a bucket with the READER role.   - roles/storage.legacyBucketWriter
-        \u2014 Read access to buckets with object listing/creation/deletion.
+        - Read access to buckets with object listing/creation/deletion.
         Equivalent to an ACL entry on a bucket with the WRITER role.   -
-        roles/storage.legacyBucketOwner \u2014 Read and write access to existing
+        roles/storage.legacyBucketOwner - Read and write access to existing
         buckets with object listing/creation/deletion. Equivalent to an ACL
         entry on a bucket with the OWNER role.
     """
 
-    condition = _messages.MessageField('extra_types.JsonValue', 1)
-    members = _messages.StringField(2, repeated=True)
-    role = _messages.StringField(3)
+    members = _messages.StringField(1, repeated=True)
+    role = _messages.StringField(2)
 
   bindings = _messages.MessageField('BindingsValueListEntry', 1, repeated=True)
   etag = _messages.BytesField(2)
@@ -1019,7 +1024,7 @@ class Policy(_messages.Message):
 
 
 class RewriteResponse(_messages.Message):
-  """A rewrite response.
+  r"""A rewrite response.
 
   Fields:
     done: true if the copy is finished; otherwise, false if the copy is in
@@ -1039,14 +1044,14 @@ class RewriteResponse(_messages.Message):
 
   done = _messages.BooleanField(1)
   kind = _messages.StringField(2, default=u'storage#rewriteResponse')
-  objectSize = _messages.IntegerField(3, variant=_messages.Variant.UINT64)
+  objectSize = _messages.IntegerField(3)
   resource = _messages.MessageField('Object', 4)
   rewriteToken = _messages.StringField(5)
-  totalBytesRewritten = _messages.IntegerField(6, variant=_messages.Variant.UINT64)
+  totalBytesRewritten = _messages.IntegerField(6)
 
 
 class ServiceAccount(_messages.Message):
-  """A subscription to receive Google PubSub notifications.
+  r"""A subscription to receive Google PubSub notifications.
 
   Fields:
     email_address: The ID of the notification.
@@ -1059,7 +1064,7 @@ class ServiceAccount(_messages.Message):
 
 
 class StandardQueryParameters(_messages.Message):
-  """Query parameters accepted by all methods.
+  r"""Query parameters accepted by all methods.
 
   Enums:
     AltValueValuesEnum: Data format for the response.
@@ -1072,17 +1077,15 @@ class StandardQueryParameters(_messages.Message):
       token.
     oauth_token: OAuth 2.0 token for the current user.
     prettyPrint: Returns response with indentations and line breaks.
-    quotaUser: Available to use for quota purposes for server-side
-      applications. Can be any arbitrary string assigned to a user, but should
-      not exceed 40 characters. Overrides userIp if both are provided.
+    quotaUser: An opaque string that represents a user for quota purposes.
+      Must not exceed 40 characters.
     trace: A tracing token of the form "token:<tokenid>" to include in api
       requests.
-    userIp: IP address of the site where the request originates. Use this if
-      you want to enforce per-user limits.
+    userIp: Deprecated. Please use quotaUser instead.
   """
 
   class AltValueValuesEnum(_messages.Enum):
-    """Data format for the response.
+    r"""Data format for the response.
 
     Values:
       json: Responses with Content-Type of application/json
@@ -1100,7 +1103,7 @@ class StandardQueryParameters(_messages.Message):
 
 
 class StorageBucketAccessControlsDeleteRequest(_messages.Message):
-  """A StorageBucketAccessControlsDeleteRequest object.
+  r"""A StorageBucketAccessControlsDeleteRequest object.
 
   Fields:
     bucket: Name of a bucket.
@@ -1117,11 +1120,11 @@ class StorageBucketAccessControlsDeleteRequest(_messages.Message):
 
 
 class StorageBucketAccessControlsDeleteResponse(_messages.Message):
-  """An empty StorageBucketAccessControlsDelete response."""
+  r"""An empty StorageBucketAccessControlsDelete response."""
 
 
 class StorageBucketAccessControlsGetRequest(_messages.Message):
-  """A StorageBucketAccessControlsGetRequest object.
+  r"""A StorageBucketAccessControlsGetRequest object.
 
   Fields:
     bucket: Name of a bucket.
@@ -1138,7 +1141,7 @@ class StorageBucketAccessControlsGetRequest(_messages.Message):
 
 
 class StorageBucketAccessControlsInsertRequest(_messages.Message):
-  """A StorageBucketAccessControlsInsertRequest object.
+  r"""A StorageBucketAccessControlsInsertRequest object.
 
   Fields:
     bucket: Name of a bucket.
@@ -1154,7 +1157,7 @@ class StorageBucketAccessControlsInsertRequest(_messages.Message):
 
 
 class StorageBucketAccessControlsListRequest(_messages.Message):
-  """A StorageBucketAccessControlsListRequest object.
+  r"""A StorageBucketAccessControlsListRequest object.
 
   Fields:
     bucket: Name of a bucket.
@@ -1167,7 +1170,7 @@ class StorageBucketAccessControlsListRequest(_messages.Message):
 
 
 class StorageBucketAccessControlsPatchRequest(_messages.Message):
-  """A StorageBucketAccessControlsPatchRequest object.
+  r"""A StorageBucketAccessControlsPatchRequest object.
 
   Fields:
     bucket: Name of a bucket.
@@ -1187,7 +1190,7 @@ class StorageBucketAccessControlsPatchRequest(_messages.Message):
 
 
 class StorageBucketAccessControlsUpdateRequest(_messages.Message):
-  """A StorageBucketAccessControlsUpdateRequest object.
+  r"""A StorageBucketAccessControlsUpdateRequest object.
 
   Fields:
     bucket: Name of a bucket.
@@ -1207,7 +1210,7 @@ class StorageBucketAccessControlsUpdateRequest(_messages.Message):
 
 
 class StorageBucketsDeleteRequest(_messages.Message):
-  """A StorageBucketsDeleteRequest object.
+  r"""A StorageBucketsDeleteRequest object.
 
   Fields:
     bucket: Name of a bucket.
@@ -1226,11 +1229,11 @@ class StorageBucketsDeleteRequest(_messages.Message):
 
 
 class StorageBucketsDeleteResponse(_messages.Message):
-  """An empty StorageBucketsDelete response."""
+  r"""An empty StorageBucketsDelete response."""
 
 
 class StorageBucketsGetIamPolicyRequest(_messages.Message):
-  """A StorageBucketsGetIamPolicyRequest object.
+  r"""A StorageBucketsGetIamPolicyRequest object.
 
   Fields:
     bucket: Name of a bucket.
@@ -1243,7 +1246,7 @@ class StorageBucketsGetIamPolicyRequest(_messages.Message):
 
 
 class StorageBucketsGetRequest(_messages.Message):
-  """A StorageBucketsGetRequest object.
+  r"""A StorageBucketsGetRequest object.
 
   Enums:
     ProjectionValueValuesEnum: Set of properties to return. Defaults to noAcl.
@@ -1261,7 +1264,7 @@ class StorageBucketsGetRequest(_messages.Message):
   """
 
   class ProjectionValueValuesEnum(_messages.Enum):
-    """Set of properties to return. Defaults to noAcl.
+    r"""Set of properties to return. Defaults to noAcl.
 
     Values:
       full: Include all properties.
@@ -1278,7 +1281,7 @@ class StorageBucketsGetRequest(_messages.Message):
 
 
 class StorageBucketsInsertRequest(_messages.Message):
-  """A StorageBucketsInsertRequest object.
+  r"""A StorageBucketsInsertRequest object.
 
   Enums:
     PredefinedAclValueValuesEnum: Apply a predefined set of access controls to
@@ -1298,11 +1301,11 @@ class StorageBucketsInsertRequest(_messages.Message):
     projection: Set of properties to return. Defaults to noAcl, unless the
       bucket resource specifies acl or defaultObjectAcl properties, when it
       defaults to full.
-    userProject: The project to be billed for this request
+    userProject: The project to be billed for this request.
   """
 
   class PredefinedAclValueValuesEnum(_messages.Enum):
-    """Apply a predefined set of access controls to this bucket.
+    r"""Apply a predefined set of access controls to this bucket.
 
     Values:
       authenticatedRead: Project team owners get OWNER access, and
@@ -1322,7 +1325,7 @@ class StorageBucketsInsertRequest(_messages.Message):
     publicReadWrite = 4
 
   class PredefinedDefaultObjectAclValueValuesEnum(_messages.Enum):
-    """Apply a predefined set of default object access controls to this
+    r"""Apply a predefined set of default object access controls to this
     bucket.
 
     Values:
@@ -1346,7 +1349,7 @@ class StorageBucketsInsertRequest(_messages.Message):
     publicRead = 5
 
   class ProjectionValueValuesEnum(_messages.Enum):
-    """Set of properties to return. Defaults to noAcl, unless the bucket
+    r"""Set of properties to return. Defaults to noAcl, unless the bucket
     resource specifies acl or defaultObjectAcl properties, when it defaults to
     full.
 
@@ -1366,7 +1369,7 @@ class StorageBucketsInsertRequest(_messages.Message):
 
 
 class StorageBucketsListRequest(_messages.Message):
-  """A StorageBucketsListRequest object.
+  r"""A StorageBucketsListRequest object.
 
   Enums:
     ProjectionValueValuesEnum: Set of properties to return. Defaults to noAcl.
@@ -1379,12 +1382,11 @@ class StorageBucketsListRequest(_messages.Message):
     prefix: Filter results to buckets whose names begin with this prefix.
     project: A valid API project identifier.
     projection: Set of properties to return. Defaults to noAcl.
-    userProject: The project to be billed for this request, for Requester Pays
-      buckets.
+    userProject: The project to be billed for this request.
   """
 
   class ProjectionValueValuesEnum(_messages.Enum):
-    """Set of properties to return. Defaults to noAcl.
+    r"""Set of properties to return. Defaults to noAcl.
 
     Values:
       full: Include all properties.
@@ -1414,14 +1416,14 @@ class StorageBucketsListChannelsRequest(_messages.Message):
 
 
 class StorageBucketsLockRetentionPolicyRequest(_messages.Message):
-  """A StorageBucketsLockRetentionPolicyRequest object.
+  r"""A StorageBucketsLockRetentionPolicyRequest object.
 
   Fields:
     bucket: Name of a bucket.
     ifMetagenerationMatch: Makes the operation conditional on whether bucket's
       current metageneration matches the given value.
-    userProject: The project to be billed for this request, for Requester Pays
-      buckets.
+    userProject: The project to be billed for this request. Required for
+      Requester Pays buckets.
   """
 
   bucket = _messages.StringField(1, required=True)
@@ -1430,7 +1432,7 @@ class StorageBucketsLockRetentionPolicyRequest(_messages.Message):
 
 
 class StorageBucketsPatchRequest(_messages.Message):
-  """A StorageBucketsPatchRequest object.
+  r"""A StorageBucketsPatchRequest object.
 
   Enums:
     PredefinedAclValueValuesEnum: Apply a predefined set of access controls to
@@ -1456,7 +1458,7 @@ class StorageBucketsPatchRequest(_messages.Message):
   """
 
   class PredefinedAclValueValuesEnum(_messages.Enum):
-    """Apply a predefined set of access controls to this bucket.
+    r"""Apply a predefined set of access controls to this bucket.
 
     Values:
       authenticatedRead: Project team owners get OWNER access, and
@@ -1476,7 +1478,7 @@ class StorageBucketsPatchRequest(_messages.Message):
     publicReadWrite = 4
 
   class PredefinedDefaultObjectAclValueValuesEnum(_messages.Enum):
-    """Apply a predefined set of default object access controls to this
+    r"""Apply a predefined set of default object access controls to this
     bucket.
 
     Values:
@@ -1500,7 +1502,7 @@ class StorageBucketsPatchRequest(_messages.Message):
     publicRead = 5
 
   class ProjectionValueValuesEnum(_messages.Enum):
-    """Set of properties to return. Defaults to full.
+    r"""Set of properties to return. Defaults to full.
 
     Values:
       full: Include all properties.
@@ -1520,7 +1522,7 @@ class StorageBucketsPatchRequest(_messages.Message):
 
 
 class StorageBucketsSetIamPolicyRequest(_messages.Message):
-  """A StorageBucketsSetIamPolicyRequest object.
+  r"""A StorageBucketsSetIamPolicyRequest object.
 
   Fields:
     bucket: Name of a bucket.
@@ -1535,7 +1537,7 @@ class StorageBucketsSetIamPolicyRequest(_messages.Message):
 
 
 class StorageBucketsTestIamPermissionsRequest(_messages.Message):
-  """A StorageBucketsTestIamPermissionsRequest object.
+  r"""A StorageBucketsTestIamPermissionsRequest object.
 
   Fields:
     bucket: Name of a bucket.
@@ -1550,7 +1552,7 @@ class StorageBucketsTestIamPermissionsRequest(_messages.Message):
 
 
 class StorageBucketsUpdateRequest(_messages.Message):
-  """A StorageBucketsUpdateRequest object.
+  r"""A StorageBucketsUpdateRequest object.
 
   Enums:
     PredefinedAclValueValuesEnum: Apply a predefined set of access controls to
@@ -1576,7 +1578,7 @@ class StorageBucketsUpdateRequest(_messages.Message):
   """
 
   class PredefinedAclValueValuesEnum(_messages.Enum):
-    """Apply a predefined set of access controls to this bucket.
+    r"""Apply a predefined set of access controls to this bucket.
 
     Values:
       authenticatedRead: Project team owners get OWNER access, and
@@ -1596,7 +1598,7 @@ class StorageBucketsUpdateRequest(_messages.Message):
     publicReadWrite = 4
 
   class PredefinedDefaultObjectAclValueValuesEnum(_messages.Enum):
-    """Apply a predefined set of default object access controls to this
+    r"""Apply a predefined set of default object access controls to this
     bucket.
 
     Values:
@@ -1620,7 +1622,7 @@ class StorageBucketsUpdateRequest(_messages.Message):
     publicRead = 5
 
   class ProjectionValueValuesEnum(_messages.Enum):
-    """Set of properties to return. Defaults to full.
+    r"""Set of properties to return. Defaults to full.
 
     Values:
       full: Include all properties.
@@ -1640,11 +1642,11 @@ class StorageBucketsUpdateRequest(_messages.Message):
 
 
 class StorageChannelsStopResponse(_messages.Message):
-  """An empty StorageChannelsStop response."""
+  r"""An empty StorageChannelsStop response."""
 
 
 class StorageDefaultObjectAccessControlsDeleteRequest(_messages.Message):
-  """A StorageDefaultObjectAccessControlsDeleteRequest object.
+  r"""A StorageDefaultObjectAccessControlsDeleteRequest object.
 
   Fields:
     bucket: Name of a bucket.
@@ -1661,11 +1663,11 @@ class StorageDefaultObjectAccessControlsDeleteRequest(_messages.Message):
 
 
 class StorageDefaultObjectAccessControlsDeleteResponse(_messages.Message):
-  """An empty StorageDefaultObjectAccessControlsDelete response."""
+  r"""An empty StorageDefaultObjectAccessControlsDelete response."""
 
 
 class StorageDefaultObjectAccessControlsGetRequest(_messages.Message):
-  """A StorageDefaultObjectAccessControlsGetRequest object.
+  r"""A StorageDefaultObjectAccessControlsGetRequest object.
 
   Fields:
     bucket: Name of a bucket.
@@ -1682,7 +1684,7 @@ class StorageDefaultObjectAccessControlsGetRequest(_messages.Message):
 
 
 class StorageDefaultObjectAccessControlsInsertRequest(_messages.Message):
-  """A StorageDefaultObjectAccessControlsInsertRequest object.
+  r"""A StorageDefaultObjectAccessControlsInsertRequest object.
 
   Fields:
     bucket: Name of a bucket.
@@ -1698,7 +1700,7 @@ class StorageDefaultObjectAccessControlsInsertRequest(_messages.Message):
 
 
 class StorageDefaultObjectAccessControlsListRequest(_messages.Message):
-  """A StorageDefaultObjectAccessControlsListRequest object.
+  r"""A StorageDefaultObjectAccessControlsListRequest object.
 
   Fields:
     bucket: Name of a bucket.
@@ -1717,7 +1719,7 @@ class StorageDefaultObjectAccessControlsListRequest(_messages.Message):
 
 
 class StorageDefaultObjectAccessControlsPatchRequest(_messages.Message):
-  """A StorageDefaultObjectAccessControlsPatchRequest object.
+  r"""A StorageDefaultObjectAccessControlsPatchRequest object.
 
   Fields:
     bucket: Name of a bucket.
@@ -1737,7 +1739,7 @@ class StorageDefaultObjectAccessControlsPatchRequest(_messages.Message):
 
 
 class StorageDefaultObjectAccessControlsUpdateRequest(_messages.Message):
-  """A StorageDefaultObjectAccessControlsUpdateRequest object.
+  r"""A StorageDefaultObjectAccessControlsUpdateRequest object.
 
   Fields:
     bucket: Name of a bucket.
@@ -1757,7 +1759,7 @@ class StorageDefaultObjectAccessControlsUpdateRequest(_messages.Message):
 
 
 class StorageNotificationsDeleteRequest(_messages.Message):
-  """A StorageNotificationsDeleteRequest object.
+  r"""A StorageNotificationsDeleteRequest object.
 
   Fields:
     bucket: The parent bucket of the notification.
@@ -1772,11 +1774,11 @@ class StorageNotificationsDeleteRequest(_messages.Message):
 
 
 class StorageNotificationsDeleteResponse(_messages.Message):
-  """An empty StorageNotificationsDelete response."""
+  r"""An empty StorageNotificationsDelete response."""
 
 
 class StorageNotificationsGetRequest(_messages.Message):
-  """A StorageNotificationsGetRequest object.
+  r"""A StorageNotificationsGetRequest object.
 
   Fields:
     bucket: The parent bucket of the notification.
@@ -1791,7 +1793,7 @@ class StorageNotificationsGetRequest(_messages.Message):
 
 
 class StorageNotificationsInsertRequest(_messages.Message):
-  """A StorageNotificationsInsertRequest object.
+  r"""A StorageNotificationsInsertRequest object.
 
   Fields:
     bucket: The parent bucket of the notification.
@@ -1806,7 +1808,7 @@ class StorageNotificationsInsertRequest(_messages.Message):
 
 
 class StorageNotificationsListRequest(_messages.Message):
-  """A StorageNotificationsListRequest object.
+  r"""A StorageNotificationsListRequest object.
 
   Fields:
     bucket: Name of a Google Cloud Storage bucket.
@@ -1819,7 +1821,7 @@ class StorageNotificationsListRequest(_messages.Message):
 
 
 class StorageObjectAccessControlsDeleteRequest(_messages.Message):
-  """A StorageObjectAccessControlsDeleteRequest object.
+  r"""A StorageObjectAccessControlsDeleteRequest object.
 
   Fields:
     bucket: Name of a bucket.
@@ -1842,11 +1844,11 @@ class StorageObjectAccessControlsDeleteRequest(_messages.Message):
 
 
 class StorageObjectAccessControlsDeleteResponse(_messages.Message):
-  """An empty StorageObjectAccessControlsDelete response."""
+  r"""An empty StorageObjectAccessControlsDelete response."""
 
 
 class StorageObjectAccessControlsGetRequest(_messages.Message):
-  """A StorageObjectAccessControlsGetRequest object.
+  r"""A StorageObjectAccessControlsGetRequest object.
 
   Fields:
     bucket: Name of a bucket.
@@ -1869,7 +1871,7 @@ class StorageObjectAccessControlsGetRequest(_messages.Message):
 
 
 class StorageObjectAccessControlsInsertRequest(_messages.Message):
-  """A StorageObjectAccessControlsInsertRequest object.
+  r"""A StorageObjectAccessControlsInsertRequest object.
 
   Fields:
     bucket: Name of a bucket.
@@ -1891,7 +1893,7 @@ class StorageObjectAccessControlsInsertRequest(_messages.Message):
 
 
 class StorageObjectAccessControlsListRequest(_messages.Message):
-  """A StorageObjectAccessControlsListRequest object.
+  r"""A StorageObjectAccessControlsListRequest object.
 
   Fields:
     bucket: Name of a bucket.
@@ -1910,7 +1912,7 @@ class StorageObjectAccessControlsListRequest(_messages.Message):
 
 
 class StorageObjectAccessControlsPatchRequest(_messages.Message):
-  """A StorageObjectAccessControlsPatchRequest object.
+  r"""A StorageObjectAccessControlsPatchRequest object.
 
   Fields:
     bucket: Name of a bucket.
@@ -1936,7 +1938,7 @@ class StorageObjectAccessControlsPatchRequest(_messages.Message):
 
 
 class StorageObjectAccessControlsUpdateRequest(_messages.Message):
-  """A StorageObjectAccessControlsUpdateRequest object.
+  r"""A StorageObjectAccessControlsUpdateRequest object.
 
   Fields:
     bucket: Name of a bucket.
@@ -1962,7 +1964,7 @@ class StorageObjectAccessControlsUpdateRequest(_messages.Message):
 
 
 class StorageObjectsComposeRequest(_messages.Message):
-  """A StorageObjectsComposeRequest object.
+  r"""A StorageObjectsComposeRequest object.
 
   Enums:
     DestinationPredefinedAclValueValuesEnum: Apply a predefined set of access
@@ -1971,7 +1973,8 @@ class StorageObjectsComposeRequest(_messages.Message):
   Fields:
     composeRequest: A ComposeRequest resource to be passed as the request
       body.
-    destinationBucket: Name of the bucket in which to store the new object.
+    destinationBucket: Name of the bucket containing the source objects. The
+      destination object is stored in this bucket.
     destinationObject: Name of the new object. For information about how to
       URL encode object names to be path safe, see Encoding URI Path Parts.
     destinationPredefinedAcl: Apply a predefined set of access controls to the
@@ -1990,7 +1993,7 @@ class StorageObjectsComposeRequest(_messages.Message):
   """
 
   class DestinationPredefinedAclValueValuesEnum(_messages.Enum):
-    """Apply a predefined set of access controls to the destination object.
+    r"""Apply a predefined set of access controls to the destination object.
 
     Values:
       authenticatedRead: Object owner gets OWNER access, and
@@ -2023,7 +2026,7 @@ class StorageObjectsComposeRequest(_messages.Message):
 
 
 class StorageObjectsCopyRequest(_messages.Message):
-  """A StorageObjectsCopyRequest object.
+  r"""A StorageObjectsCopyRequest object.
 
   Enums:
     DestinationPredefinedAclValueValuesEnum: Apply a predefined set of access
@@ -2077,7 +2080,7 @@ class StorageObjectsCopyRequest(_messages.Message):
   """
 
   class DestinationPredefinedAclValueValuesEnum(_messages.Enum):
-    """Apply a predefined set of access controls to the destination object.
+    r"""Apply a predefined set of access controls to the destination object.
 
     Values:
       authenticatedRead: Object owner gets OWNER access, and
@@ -2100,7 +2103,7 @@ class StorageObjectsCopyRequest(_messages.Message):
     publicRead = 5
 
   class ProjectionValueValuesEnum(_messages.Enum):
-    """Set of properties to return. Defaults to noAcl, unless the object
+    r"""Set of properties to return. Defaults to noAcl, unless the object
     resource specifies the acl property, when it defaults to full.
 
     Values:
@@ -2130,7 +2133,7 @@ class StorageObjectsCopyRequest(_messages.Message):
 
 
 class StorageObjectsDeleteRequest(_messages.Message):
-  """A StorageObjectsDeleteRequest object.
+  r"""A StorageObjectsDeleteRequest object.
 
   Fields:
     bucket: Name of the bucket in which the object resides.
@@ -2164,11 +2167,11 @@ class StorageObjectsDeleteRequest(_messages.Message):
 
 
 class StorageObjectsDeleteResponse(_messages.Message):
-  """An empty StorageObjectsDelete response."""
+  r"""An empty StorageObjectsDelete response."""
 
 
 class StorageObjectsGetIamPolicyRequest(_messages.Message):
-  """A StorageObjectsGetIamPolicyRequest object.
+  r"""A StorageObjectsGetIamPolicyRequest object.
 
   Fields:
     bucket: Name of the bucket in which the object resides.
@@ -2187,7 +2190,7 @@ class StorageObjectsGetIamPolicyRequest(_messages.Message):
 
 
 class StorageObjectsGetRequest(_messages.Message):
-  """A StorageObjectsGetRequest object.
+  r"""A StorageObjectsGetRequest object.
 
   Enums:
     ProjectionValueValuesEnum: Set of properties to return. Defaults to noAcl.
@@ -2215,7 +2218,7 @@ class StorageObjectsGetRequest(_messages.Message):
   """
 
   class ProjectionValueValuesEnum(_messages.Enum):
-    """Set of properties to return. Defaults to noAcl.
+    r"""Set of properties to return. Defaults to noAcl.
 
     Values:
       full: Include all properties.
@@ -2236,7 +2239,7 @@ class StorageObjectsGetRequest(_messages.Message):
 
 
 class StorageObjectsInsertRequest(_messages.Message):
-  """A StorageObjectsInsertRequest object.
+  r"""A StorageObjectsInsertRequest object.
 
   Enums:
     PredefinedAclValueValuesEnum: Apply a predefined set of access controls to
@@ -2281,7 +2284,7 @@ class StorageObjectsInsertRequest(_messages.Message):
   """
 
   class PredefinedAclValueValuesEnum(_messages.Enum):
-    """Apply a predefined set of access controls to this object.
+    r"""Apply a predefined set of access controls to this object.
 
     Values:
       authenticatedRead: Object owner gets OWNER access, and
@@ -2304,7 +2307,7 @@ class StorageObjectsInsertRequest(_messages.Message):
     publicRead = 5
 
   class ProjectionValueValuesEnum(_messages.Enum):
-    """Set of properties to return. Defaults to noAcl, unless the object
+    r"""Set of properties to return. Defaults to noAcl, unless the object
     resource specifies the acl property, when it defaults to full.
 
     Values:
@@ -2329,7 +2332,7 @@ class StorageObjectsInsertRequest(_messages.Message):
 
 
 class StorageObjectsListRequest(_messages.Message):
-  """A StorageObjectsListRequest object.
+  r"""A StorageObjectsListRequest object.
 
   Enums:
     ProjectionValueValuesEnum: Set of properties to return. Defaults to noAcl.
@@ -2341,6 +2344,9 @@ class StorageObjectsListRequest(_messages.Message):
       delimiter. Objects whose names, aside from the prefix, contain delimiter
       will have their name, truncated after the delimiter, returned in
       prefixes. Duplicate prefixes are omitted.
+    includeTrailingDelimiter: If true, objects that end in exactly one
+      instance of delimiter will have their metadata included in items in
+      addition to prefixes.
     maxResults: Maximum number of items plus prefixes to return in a single
       page of responses. As duplicate prefixes are omitted, fewer total
       results may be returned than requested. The service will use this
@@ -2356,7 +2362,7 @@ class StorageObjectsListRequest(_messages.Message):
   """
 
   class ProjectionValueValuesEnum(_messages.Enum):
-    """Set of properties to return. Defaults to noAcl.
+    r"""Set of properties to return. Defaults to noAcl.
 
     Values:
       full: Include all properties.
@@ -2367,16 +2373,17 @@ class StorageObjectsListRequest(_messages.Message):
 
   bucket = _messages.StringField(1, required=True)
   delimiter = _messages.StringField(2)
-  maxResults = _messages.IntegerField(3, variant=_messages.Variant.UINT32, default=1000)
-  pageToken = _messages.StringField(4)
-  prefix = _messages.StringField(5)
-  projection = _messages.EnumField('ProjectionValueValuesEnum', 6)
-  userProject = _messages.StringField(7)
-  versions = _messages.BooleanField(8)
+  includeTrailingDelimiter = _messages.BooleanField(3)
+  maxResults = _messages.IntegerField(4, variant=_messages.Variant.UINT32, default=1000)
+  pageToken = _messages.StringField(5)
+  prefix = _messages.StringField(6)
+  projection = _messages.EnumField('ProjectionValueValuesEnum', 7)
+  userProject = _messages.StringField(8)
+  versions = _messages.BooleanField(9)
 
 
 class StorageObjectsPatchRequest(_messages.Message):
-  """A StorageObjectsPatchRequest object.
+  r"""A StorageObjectsPatchRequest object.
 
   Enums:
     PredefinedAclValueValuesEnum: Apply a predefined set of access controls to
@@ -2403,12 +2410,12 @@ class StorageObjectsPatchRequest(_messages.Message):
     objectResource: A Object resource to be passed as the request body.
     predefinedAcl: Apply a predefined set of access controls to this object.
     projection: Set of properties to return. Defaults to full.
-    userProject: The project to be billed for this request. Required for
-      Requester Pays buckets.
+    userProject: The project to be billed for this request, for Requester Pays
+      buckets.
   """
 
   class PredefinedAclValueValuesEnum(_messages.Enum):
-    """Apply a predefined set of access controls to this object.
+    r"""Apply a predefined set of access controls to this object.
 
     Values:
       authenticatedRead: Object owner gets OWNER access, and
@@ -2431,7 +2438,7 @@ class StorageObjectsPatchRequest(_messages.Message):
     publicRead = 5
 
   class ProjectionValueValuesEnum(_messages.Enum):
-    """Set of properties to return. Defaults to full.
+    r"""Set of properties to return. Defaults to full.
 
     Values:
       full: Include all properties.
@@ -2454,7 +2461,7 @@ class StorageObjectsPatchRequest(_messages.Message):
 
 
 class StorageObjectsRewriteRequest(_messages.Message):
-  """A StorageObjectsRewriteRequest object.
+  r"""A StorageObjectsRewriteRequest object.
 
   Enums:
     DestinationPredefinedAclValueValuesEnum: Apply a predefined set of access
@@ -2523,7 +2530,7 @@ class StorageObjectsRewriteRequest(_messages.Message):
   """
 
   class DestinationPredefinedAclValueValuesEnum(_messages.Enum):
-    """Apply a predefined set of access controls to the destination object.
+    r"""Apply a predefined set of access controls to the destination object.
 
     Values:
       authenticatedRead: Object owner gets OWNER access, and
@@ -2546,7 +2553,7 @@ class StorageObjectsRewriteRequest(_messages.Message):
     publicRead = 5
 
   class ProjectionValueValuesEnum(_messages.Enum):
-    """Set of properties to return. Defaults to noAcl, unless the object
+    r"""Set of properties to return. Defaults to noAcl, unless the object
     resource specifies the acl property, when it defaults to full.
 
     Values:
@@ -2579,7 +2586,7 @@ class StorageObjectsRewriteRequest(_messages.Message):
 
 
 class StorageObjectsSetIamPolicyRequest(_messages.Message):
-  """A StorageObjectsSetIamPolicyRequest object.
+  r"""A StorageObjectsSetIamPolicyRequest object.
 
   Fields:
     bucket: Name of the bucket in which the object resides.
@@ -2600,7 +2607,7 @@ class StorageObjectsSetIamPolicyRequest(_messages.Message):
 
 
 class StorageObjectsTestIamPermissionsRequest(_messages.Message):
-  """A StorageObjectsTestIamPermissionsRequest object.
+  r"""A StorageObjectsTestIamPermissionsRequest object.
 
   Fields:
     bucket: Name of the bucket in which the object resides.
@@ -2621,7 +2628,7 @@ class StorageObjectsTestIamPermissionsRequest(_messages.Message):
 
 
 class StorageObjectsUpdateRequest(_messages.Message):
-  """A StorageObjectsUpdateRequest object.
+  r"""A StorageObjectsUpdateRequest object.
 
   Enums:
     PredefinedAclValueValuesEnum: Apply a predefined set of access controls to
@@ -2653,7 +2660,7 @@ class StorageObjectsUpdateRequest(_messages.Message):
   """
 
   class PredefinedAclValueValuesEnum(_messages.Enum):
-    """Apply a predefined set of access controls to this object.
+    r"""Apply a predefined set of access controls to this object.
 
     Values:
       authenticatedRead: Object owner gets OWNER access, and
@@ -2676,7 +2683,7 @@ class StorageObjectsUpdateRequest(_messages.Message):
     publicRead = 5
 
   class ProjectionValueValuesEnum(_messages.Enum):
-    """Set of properties to return. Defaults to full.
+    r"""Set of properties to return. Defaults to full.
 
     Values:
       full: Include all properties.
@@ -2699,7 +2706,7 @@ class StorageObjectsUpdateRequest(_messages.Message):
 
 
 class StorageObjectsWatchAllRequest(_messages.Message):
-  """A StorageObjectsWatchAllRequest object.
+  r"""A StorageObjectsWatchAllRequest object.
 
   Enums:
     ProjectionValueValuesEnum: Set of properties to return. Defaults to noAcl.
@@ -2712,6 +2719,9 @@ class StorageObjectsWatchAllRequest(_messages.Message):
       delimiter. Objects whose names, aside from the prefix, contain delimiter
       will have their name, truncated after the delimiter, returned in
       prefixes. Duplicate prefixes are omitted.
+    includeTrailingDelimiter: If true, objects that end in exactly one
+      instance of delimiter will have their metadata included in items in
+      addition to prefixes.
     maxResults: Maximum number of items plus prefixes to return in a single
       page of responses. As duplicate prefixes are omitted, fewer total
       results may be returned than requested. The service will use this
@@ -2727,7 +2737,7 @@ class StorageObjectsWatchAllRequest(_messages.Message):
   """
 
   class ProjectionValueValuesEnum(_messages.Enum):
-    """Set of properties to return. Defaults to noAcl.
+    r"""Set of properties to return. Defaults to noAcl.
 
     Values:
       full: Include all properties.
@@ -2739,21 +2749,21 @@ class StorageObjectsWatchAllRequest(_messages.Message):
   bucket = _messages.StringField(1, required=True)
   channel = _messages.MessageField('Channel', 2)
   delimiter = _messages.StringField(3)
-  maxResults = _messages.IntegerField(4, variant=_messages.Variant.UINT32, default=1000)
-  pageToken = _messages.StringField(5)
-  prefix = _messages.StringField(6)
-  projection = _messages.EnumField('ProjectionValueValuesEnum', 7)
-  userProject = _messages.StringField(8)
-  versions = _messages.BooleanField(9)
+  includeTrailingDelimiter = _messages.BooleanField(4)
+  maxResults = _messages.IntegerField(5, variant=_messages.Variant.UINT32, default=1000)
+  pageToken = _messages.StringField(6)
+  prefix = _messages.StringField(7)
+  projection = _messages.EnumField('ProjectionValueValuesEnum', 8)
+  userProject = _messages.StringField(9)
+  versions = _messages.BooleanField(10)
 
 
 class StorageProjectsServiceAccountGetRequest(_messages.Message):
-  """A StorageProjectsServiceAccountGetRequest object.
+  r"""A StorageProjectsServiceAccountGetRequest object.
 
   Fields:
     projectId: Project ID
-    userProject: The project to be billed for this request, for Requester Pays
-      buckets.
+    userProject: The project to be billed for this request.
   """
 
   projectId = _messages.StringField(1, required=True)
@@ -2761,24 +2771,24 @@ class StorageProjectsServiceAccountGetRequest(_messages.Message):
 
 
 class TestIamPermissionsResponse(_messages.Message):
-  """A storage.(buckets|objects).testIamPermissions response.
+  r"""A storage.(buckets|objects).testIamPermissions response.
 
   Fields:
     kind: The kind of item this is.
     permissions: The permissions held by the caller. Permissions are always of
       the format storage.resource.capability, where resource is one of buckets
       or objects. The supported permissions are as follows:   -
-      storage.buckets.delete \u2014 Delete bucket.   - storage.buckets.get \u2014 Read
-      bucket metadata.   - storage.buckets.getIamPolicy \u2014 Read bucket IAM
-      policy.   - storage.buckets.create \u2014 Create bucket.   -
-      storage.buckets.list \u2014 List buckets.   - storage.buckets.setIamPolicy \u2014
-      Update bucket IAM policy.   - storage.buckets.update \u2014 Update bucket
-      metadata.   - storage.objects.delete \u2014 Delete object.   -
-      storage.objects.get \u2014 Read object data and metadata.   -
-      storage.objects.getIamPolicy \u2014 Read object IAM policy.   -
-      storage.objects.create \u2014 Create object.   - storage.objects.list \u2014 List
-      objects.   - storage.objects.setIamPolicy \u2014 Update object IAM policy.
-      - storage.objects.update \u2014 Update object metadata.
+      storage.buckets.delete - Delete bucket.   - storage.buckets.get - Read
+      bucket metadata.   - storage.buckets.getIamPolicy - Read bucket IAM
+      policy.   - storage.buckets.create - Create bucket.   -
+      storage.buckets.list - List buckets.   - storage.buckets.setIamPolicy -
+      Update bucket IAM policy.   - storage.buckets.update - Update bucket
+      metadata.   - storage.objects.delete - Delete object.   -
+      storage.objects.get - Read object data and metadata.   -
+      storage.objects.getIamPolicy - Read object IAM policy.   -
+      storage.objects.create - Create object.   - storage.objects.list - List
+      objects.   - storage.objects.setIamPolicy - Update object IAM policy.
+      - storage.objects.update - Update object metadata.
   """
 
   kind = _messages.StringField(1, default=u'storage#testIamPermissionsResponse')


### PR DESCRIPTION
This change updates the JSON API client files in
gslib/third_party/storage_apitools to be consistent with the source
documents (via the JSON API discovery doc) and updates docstrings to
the new style that apitools generates (using raw strings), which makes
this change a bit noisy.

This commit also adds the "includeTrailingDelimiter" field to some
message types, but that is uninteresting because it's unused in the
code.