### PR TITLE
Encoding for win

### DIFF
--- a/gslib/commands/version.py
+++ b/gslib/commands/version.py
@@ -33,6 +33,7 @@ from gslib.command import Command
 from gslib.utils import system_util
 from gslib.utils.boto_util import GetFriendlyConfigFilePaths
 from gslib.utils.boto_util import UsingCrcmodExtension
+from gslib.utils.constants import UTF8
 from gslib.utils.parallelism_framework_util import CheckMultiprocessingAvailableAndInit
 
 
@@ -169,10 +170,10 @@ class VersionCommand(Command):
         m.update(content)
         f.close()
       else:
-        f = open(filepath, 'r', encoding='utf-8')
+        f = open(filepath, 'r', encoding=UTF8)
         content = f.read()
         content = re.sub(r'(\r\n|\r|\n)', '\n', content)
-        m.update(content.encode('utf-8'))
+        m.update(content.encode(UTF8))
         f.close()
     return m.hexdigest()
 

--- a/gslib/commands/version.py
+++ b/gslib/commands/version.py
@@ -169,7 +169,7 @@ class VersionCommand(Command):
         m.update(content)
         f.close()
       else:
-        f = open(filepath, 'r')
+        f = open(filepath, 'r', encoding='utf-8')
         content = f.read()
         content = re.sub(r'(\r\n|\r|\n)', '\n', content)
         m.update(content.encode('utf-8'))

--- a/gslib/utils/text_util.py
+++ b/gslib/utils/text_util.py
@@ -302,30 +302,31 @@ def ttyprint(*objects, **kwargs):
     ttywrite(file, data)
   else:  # PY3
     def Py3Print(encoding, sep=sep, end=end):
-      """ Passing in encoding allows for a try-except block to attempt the
-      default encoding and then fall back to utf-8 on failure to encode
+      """ Encode and send data to ttywrite with specified encoding.
 
       Args:
         encoding: Encoding to be used for all encode operations while printing.
         sep: Line separator to be used for printing (defined in outer scope).
         end: End character to be used for printing (defined in outer scope).
-      Return: None
+
+      Returns: None
       """
       if isinstance(sep, str):
         sep = sep.encode(encoding)
       if isinstance(end, str):
         end = end.encode(encoding)
       byte_objects = []
-      for object in objects:
-        if isinstance(object, bytes):
-          byte_objects.append(object)
-        elif isinstance(object, str):
-          byte_objects.append(object.encode(encoding))
+      for item in objects:
+        if isinstance(item, bytes):
+          byte_objects.append(item)
+        elif isinstance(item, str):
+          byte_objects.append(item.encode(encoding))
         else:
-          byte_objects.append(str(object).encode(encoding))
+          byte_objects.append(str(item).encode(encoding))
       data = sep.join(byte_objects)
       data += end
       ttywrite(file, data)
+
     try:
       # Try to print with default encoding.
       Py3Print(locale.getpreferredencoding(False))

--- a/gslib/utils/text_util.py
+++ b/gslib/utils/text_util.py
@@ -301,22 +301,37 @@ def ttyprint(*objects, **kwargs):
     data += end
     ttywrite(file, data)
   else:  # PY3
-    pref_enc = locale.getpreferredencoding(False)
-    if isinstance(sep, str):
-      sep = sep.encode(pref_enc)
-    if isinstance(end, str):
-      end = end.encode(pref_enc)
-    byte_objects = []
-    for object in objects:
-      if isinstance(object, bytes):
-        byte_objects.append(object)
-      elif isinstance(object, str):
-        byte_objects.append(object.encode(pref_enc))
-      else:
-        byte_objects.append(str(object).encode(pref_enc))
-    data = sep.join(byte_objects)
-    data += end
-    ttywrite(file, data)
+    def Py3Print(encoding, sep=sep, end=end):
+      """ Passing in encoding allows for a try-except block to attempt the
+      default encoding and then fall back to utf-8 on failure to encode
+
+      Args:
+        encoding: Encoding to be used for all encode operations while printing.
+        sep: Line separator to be used for printing (defined in outer scope).
+        end: End character to be used for printing (defined in outer scope).
+      Return: None
+      """
+      if isinstance(sep, str):
+        sep = sep.encode(encoding)
+      if isinstance(end, str):
+        end = end.encode(encoding)
+      byte_objects = []
+      for object in objects:
+        if isinstance(object, bytes):
+          byte_objects.append(object)
+        elif isinstance(object, str):
+          byte_objects.append(object.encode(encoding))
+        else:
+          byte_objects.append(str(object).encode(encoding))
+      data = sep.join(byte_objects)
+      data += end
+      ttywrite(file, data)
+    try:
+      # Try to print with default encoding.
+      Py3Print(locale.getpreferredencoding(False))
+    except UnicodeEncodeError:
+      # If default failed, try to print with UTF-8.
+      Py3Print(UTF8)
 
 
 def ttywrite(fp, data):


### PR DESCRIPTION
* Open file with utf-8 encoding when computing code checksum in commands/version.py.

* Try to write using default encoding in ttyprint, fallback to utf-8 if default is unsuccessful.

Both fixes are in response to errors found on Windows.