### PR TITLE
Added configs for child jobs

### DIFF
--- a/test/ci/kokoro/linux/py27_json.cfg
+++ b/test/ci/kokoro/linux/py27_json.cfg
@@ -1,0 +1,23 @@
+type: SUB_JOB
+
+group_spec {
+  parent_job_name: "cloud_storage_gsutil/linux/presubmit"
+  parent_job_name: "cloud_storage_gsutil/linux/continuous"
+}
+
+# Environment variables to specify interpreter version.
+# go/kokoro-env-vars
+env_vars {
+  key: "PYMAJOR"
+  value: "2"
+}
+
+env_vars {
+  key: "PYMINOR"
+  value: "7"
+}
+
+env_vars {
+  key: "BOTO_CONFIG"
+  value: "/src/config/.boto_json"
+}

--- a/test/ci/kokoro/linux/py27_xml.cfg
+++ b/test/ci/kokoro/linux/py27_xml.cfg
@@ -1,0 +1,23 @@
+type: SUB_JOB
+
+group_spec {
+  parent_job_name: "cloud_storage_gsutil/linux/presubmit"
+  parent_job_name: "cloud_storage_gsutil/linux/continuous"
+}
+
+# Environment variables to specify interpreter version.
+# go/kokoro-env-vars
+env_vars {
+  key: "PYMAJOR"
+  value: "2"
+}
+
+env_vars {
+  key: "PYMINOR"
+  value: "7"
+}
+
+env_vars {
+  key: "BOTO_CONFIG"
+  value: "/src/config/.boto_xml"
+}

--- a/test/ci/kokoro/linux/py35_json.cfg
+++ b/test/ci/kokoro/linux/py35_json.cfg
@@ -1,0 +1,23 @@
+type: SUB_JOB
+
+group_spec {
+  parent_job_name: "cloud_storage_gsutil/linux/presubmit"
+  parent_job_name: "cloud_storage_gsutil/linux/continuous"
+}
+
+# Environment variables to specify interpreter version.
+# go/kokoro-env-vars
+env_vars {
+  key: "PYMAJOR"
+  value: "3"
+}
+
+env_vars {
+  key: "PYMINOR"
+  value: "5"
+}
+
+env_vars {
+  key: "BOTO_CONFIG"
+  value: "/src/config/.boto_json"
+}

--- a/test/ci/kokoro/linux/py35_xml.cfg
+++ b/test/ci/kokoro/linux/py35_xml.cfg
@@ -1,0 +1,23 @@
+type: SUB_JOB
+
+group_spec {
+  parent_job_name: "cloud_storage_gsutil/linux/presubmit"
+  parent_job_name: "cloud_storage_gsutil/linux/continuous"
+}
+
+# Environment variables to specify interpreter version.
+# go/kokoro-env-vars
+env_vars {
+  key: "PYMAJOR"
+  value: "3"
+}
+
+env_vars {
+  key: "PYMINOR"
+  value: "5"
+}
+
+env_vars {
+  key: "BOTO_CONFIG"
+  value: "/src/config/.boto_xml"
+}

--- a/test/ci/kokoro/linux/py36_json.cfg
+++ b/test/ci/kokoro/linux/py36_json.cfg
@@ -1,0 +1,23 @@
+type: SUB_JOB
+
+group_spec {
+  parent_job_name: "cloud_storage_gsutil/linux/presubmit"
+  parent_job_name: "cloud_storage_gsutil/linux/continuous"
+}
+
+# Environment variables to specify interpreter version.
+# go/kokoro-env-vars
+env_vars {
+  key: "PYMAJOR"
+  value: "3"
+}
+
+env_vars {
+  key: "PYMINOR"
+  value: "6"
+}
+
+env_vars {
+  key: "BOTO_CONFIG"
+  value: "/src/config/.boto_json"
+}

--- a/test/ci/kokoro/linux/py36_xml.cfg
+++ b/test/ci/kokoro/linux/py36_xml.cfg
@@ -1,0 +1,23 @@
+type: SUB_JOB
+
+group_spec {
+  parent_job_name: "cloud_storage_gsutil/linux/presubmit"
+  parent_job_name: "cloud_storage_gsutil/linux/continuous"
+}
+
+# Environment variables to specify interpreter version.
+# go/kokoro-env-vars
+env_vars {
+  key: "PYMAJOR"
+  value: "3"
+}
+
+env_vars {
+  key: "PYMINOR"
+  value: "6"
+}
+
+env_vars {
+  key: "BOTO_CONFIG"
+  value: "/src/config/.boto_xml"
+}

--- a/test/ci/kokoro/linux/py37_json.cfg
+++ b/test/ci/kokoro/linux/py37_json.cfg
@@ -1,0 +1,23 @@
+type: SUB_JOB
+
+group_spec {
+  parent_job_name: "cloud_storage_gsutil/linux/presubmit"
+  parent_job_name: "cloud_storage_gsutil/linux/continuous"
+}
+
+# Environment variables to specify interpreter version.
+# go/kokoro-env-vars
+env_vars {
+  key: "PYMAJOR"
+  value: "3"
+}
+
+env_vars {
+  key: "PYMINOR"
+  value: "7"
+}
+
+env_vars {
+  key: "BOTO_CONFIG"
+  value: "/src/config/.boto_json"
+}

--- a/test/ci/kokoro/linux/py37_xml.cfg
+++ b/test/ci/kokoro/linux/py37_xml.cfg
@@ -1,0 +1,23 @@
+type: SUB_JOB
+
+group_spec {
+  parent_job_name: "cloud_storage_gsutil/linux/presubmit"
+  parent_job_name: "cloud_storage_gsutil/linux/continuous"
+}
+
+# Environment variables to specify interpreter version.
+# go/kokoro-env-vars
+env_vars {
+  key: "PYMAJOR"
+  value: "3"
+}
+
+env_vars {
+  key: "PYMINOR"
+  value: "7"
+}
+
+env_vars {
+  key: "BOTO_CONFIG"
+  value: "/src/config/.boto_xml"
+}

--- a/test/ci/kokoro/macos/py27_json.cfg
+++ b/test/ci/kokoro/macos/py27_json.cfg
@@ -1,0 +1,23 @@
+type: SUB_JOB
+
+group_spec {
+  parent_job_name: "cloud_storage_gsutil/macos/presubmit"
+  parent_job_name: "cloud_storage_gsutil/macos/continuous"
+}
+
+# Environment variables to specify interpreter version.
+# go/kokoro-env-vars
+env_vars {
+  key: "PYMAJOR"
+  value: "2"
+}
+
+env_vars {
+  key: "PYMINOR"
+  value: "7"
+}
+
+env_vars {
+  key: "BOTO_CONFIG"
+  value: "/src/config/.boto_json"
+}

--- a/test/ci/kokoro/macos/py27_xml.cfg
+++ b/test/ci/kokoro/macos/py27_xml.cfg
@@ -1,0 +1,23 @@
+type: SUB_JOB
+
+group_spec {
+  parent_job_name: "cloud_storage_gsutil/macos/presubmit"
+  parent_job_name: "cloud_storage_gsutil/macos/continuous"
+}
+
+# Environment variables to specify interpreter version.
+# go/kokoro-env-vars
+env_vars {
+  key: "PYMAJOR"
+  value: "2"
+}
+
+env_vars {
+  key: "PYMINOR"
+  value: "7"
+}
+
+env_vars {
+  key: "BOTO_CONFIG"
+  value: "/src/config/.boto_xml"
+}

--- a/test/ci/kokoro/macos/py35_json.cfg
+++ b/test/ci/kokoro/macos/py35_json.cfg
@@ -1,0 +1,23 @@
+type: SUB_JOB
+
+group_spec {
+  parent_job_name: "cloud_storage_gsutil/macos/presubmit"
+  parent_job_name: "cloud_storage_gsutil/macos/continuous"
+}
+
+# Environment variables to specify interpreter version.
+# go/kokoro-env-vars
+env_vars {
+  key: "PYMAJOR"
+  value: "3"
+}
+
+env_vars {
+  key: "PYMINOR"
+  value: "5"
+}
+
+env_vars {
+  key: "BOTO_CONFIG"
+  value: "/src/config/.boto_json"
+}

--- a/test/ci/kokoro/macos/py35_xml.cfg
+++ b/test/ci/kokoro/macos/py35_xml.cfg
@@ -1,0 +1,23 @@
+type: SUB_JOB
+
+group_spec {
+  parent_job_name: "cloud_storage_gsutil/macos/presubmit"
+  parent_job_name: "cloud_storage_gsutil/macos/continuous"
+}
+
+# Environment variables to specify interpreter version.
+# go/kokoro-env-vars
+env_vars {
+  key: "PYMAJOR"
+  value: "3"
+}
+
+env_vars {
+  key: "PYMINOR"
+  value: "5"
+}
+
+env_vars {
+  key: "BOTO_CONFIG"
+  value: "/src/config/.boto_xml"
+}

--- a/test/ci/kokoro/macos/py36_json.cfg
+++ b/test/ci/kokoro/macos/py36_json.cfg
@@ -1,0 +1,23 @@
+type: SUB_JOB
+
+group_spec {
+  parent_job_name: "cloud_storage_gsutil/macos/presubmit"
+  parent_job_name: "cloud_storage_gsutil/macos/continuous"
+}
+
+# Environment variables to specify interpreter version.
+# go/kokoro-env-vars
+env_vars {
+  key: "PYMAJOR"
+  value: "3"
+}
+
+env_vars {
+  key: "PYMINOR"
+  value: "6"
+}
+
+env_vars {
+  key: "BOTO_CONFIG"
+  value: "/src/config/.boto_json"
+}

--- a/test/ci/kokoro/macos/py36_xml.cfg
+++ b/test/ci/kokoro/macos/py36_xml.cfg
@@ -1,0 +1,23 @@
+type: SUB_JOB
+
+group_spec {
+  parent_job_name: "cloud_storage_gsutil/macos/presubmit"
+  parent_job_name: "cloud_storage_gsutil/macos/continuous"
+}
+
+# Environment variables to specify interpreter version.
+# go/kokoro-env-vars
+env_vars {
+  key: "PYMAJOR"
+  value: "3"
+}
+
+env_vars {
+  key: "PYMINOR"
+  value: "6"
+}
+
+env_vars {
+  key: "BOTO_CONFIG"
+  value: "/src/config/.boto_xml"
+}

--- a/test/ci/kokoro/macos/py37_json.cfg
+++ b/test/ci/kokoro/macos/py37_json.cfg
@@ -1,0 +1,23 @@
+type: SUB_JOB
+
+group_spec {
+  parent_job_name: "cloud_storage_gsutil/macos/presubmit"
+  parent_job_name: "cloud_storage_gsutil/macos/continuous"
+}
+
+# Environment variables to specify interpreter version.
+# go/kokoro-env-vars
+env_vars {
+  key: "PYMAJOR"
+  value: "3"
+}
+
+env_vars {
+  key: "PYMINOR"
+  value: "7"
+}
+
+env_vars {
+  key: "BOTO_CONFIG"
+  value: "/src/config/.boto_json"
+}

--- a/test/ci/kokoro/macos/py37_xml.cfg
+++ b/test/ci/kokoro/macos/py37_xml.cfg
@@ -1,0 +1,23 @@
+type: SUB_JOB
+
+group_spec {
+  parent_job_name: "cloud_storage_gsutil/macos/presubmit"
+  parent_job_name: "cloud_storage_gsutil/macos/continuous"
+}
+
+# Environment variables to specify interpreter version.
+# go/kokoro-env-vars
+env_vars {
+  key: "PYMAJOR"
+  value: "3"
+}
+
+env_vars {
+  key: "PYMINOR"
+  value: "7"
+}
+
+env_vars {
+  key: "BOTO_CONFIG"
+  value: "/src/config/.boto_xml"
+}

--- a/test/ci/kokoro/windows/py27_json.cfg
+++ b/test/ci/kokoro/windows/py27_json.cfg
@@ -1,0 +1,23 @@
+type: SUB_JOB
+
+group_spec {
+  parent_job_name: "cloud_storage_gsutil/windows/presubmit"
+  parent_job_name: "cloud_storage_gsutil/windows/continuous"
+}
+
+# Environment variables to specify interpreter version.
+# go/kokoro-env-vars
+env_vars {
+  key: "PYMAJOR"
+  value: "2"
+}
+
+env_vars {
+  key: "PYMINOR"
+  value: "7"
+}
+
+env_vars {
+  key: "BOTO_CONFIG"
+  value: "/src/config/.boto_json"
+}

--- a/test/ci/kokoro/windows/py27_xml.cfg
+++ b/test/ci/kokoro/windows/py27_xml.cfg
@@ -1,0 +1,23 @@
+type: SUB_JOB
+
+group_spec {
+  parent_job_name: "cloud_storage_gsutil/windows/presubmit"
+  parent_job_name: "cloud_storage_gsutil/windows/continuous"
+}
+
+# Environment variables to specify interpreter version.
+# go/kokoro-env-vars
+env_vars {
+  key: "PYMAJOR"
+  value: "2"
+}
+
+env_vars {
+  key: "PYMINOR"
+  value: "7"
+}
+
+env_vars {
+  key: "BOTO_CONFIG"
+  value: "/src/config/.boto_xml"
+}

--- a/test/ci/kokoro/windows/py35_json.cfg
+++ b/test/ci/kokoro/windows/py35_json.cfg
@@ -1,0 +1,23 @@
+type: SUB_JOB
+
+group_spec {
+  parent_job_name: "cloud_storage_gsutil/windows/presubmit"
+  parent_job_name: "cloud_storage_gsutil/windows/continuous"
+}
+
+# Environment variables to specify interpreter version.
+# go/kokoro-env-vars
+env_vars {
+  key: "PYMAJOR"
+  value: "3"
+}
+
+env_vars {
+  key: "PYMINOR"
+  value: "5"
+}
+
+env_vars {
+  key: "BOTO_CONFIG"
+  value: "/src/config/.boto_json"
+}

--- a/test/ci/kokoro/windows/py35_xml.cfg
+++ b/test/ci/kokoro/windows/py35_xml.cfg
@@ -1,0 +1,23 @@
+type: SUB_JOB
+
+group_spec {
+  parent_job_name: "cloud_storage_gsutil/windows/presubmit"
+  parent_job_name: "cloud_storage_gsutil/windows/continuous"
+}
+
+# Environment variables to specify interpreter version.
+# go/kokoro-env-vars
+env_vars {
+  key: "PYMAJOR"
+  value: "3"
+}
+
+env_vars {
+  key: "PYMINOR"
+  value: "5"
+}
+
+env_vars {
+  key: "BOTO_CONFIG"
+  value: "/src/config/.boto_xml"
+}

--- a/test/ci/kokoro/windows/py36_json.cfg
+++ b/test/ci/kokoro/windows/py36_json.cfg
@@ -1,0 +1,23 @@
+type: SUB_JOB
+
+group_spec {
+  parent_job_name: "cloud_storage_gsutil/windows/presubmit"
+  parent_job_name: "cloud_storage_gsutil/windows/continuous"
+}
+
+# Environment variables to specify interpreter version.
+# go/kokoro-env-vars
+env_vars {
+  key: "PYMAJOR"
+  value: "3"
+}
+
+env_vars {
+  key: "PYMINOR"
+  value: "6"
+}
+
+env_vars {
+  key: "BOTO_CONFIG"
+  value: "/src/config/.boto_json"
+}

--- a/test/ci/kokoro/windows/py36_xml.cfg
+++ b/test/ci/kokoro/windows/py36_xml.cfg
@@ -1,0 +1,23 @@
+type: SUB_JOB
+
+group_spec {
+  parent_job_name: "cloud_storage_gsutil/windows/presubmit"
+  parent_job_name: "cloud_storage_gsutil/windows/continuous"
+}
+
+# Environment variables to specify interpreter version.
+# go/kokoro-env-vars
+env_vars {
+  key: "PYMAJOR"
+  value: "3"
+}
+
+env_vars {
+  key: "PYMINOR"
+  value: "6"
+}
+
+env_vars {
+  key: "BOTO_CONFIG"
+  value: "/src/config/.boto_xml"
+}

--- a/test/ci/kokoro/windows/py37_json.cfg
+++ b/test/ci/kokoro/windows/py37_json.cfg
@@ -1,0 +1,23 @@
+type: SUB_JOB
+
+group_spec {
+  parent_job_name: "cloud_storage_gsutil/windows/presubmit"
+  parent_job_name: "cloud_storage_gsutil/windows/continuous"
+}
+
+# Environment variables to specify interpreter version.
+# go/kokoro-env-vars
+env_vars {
+  key: "PYMAJOR"
+  value: "3"
+}
+
+env_vars {
+  key: "PYMINOR"
+  value: "7"
+}
+
+env_vars {
+  key: "BOTO_CONFIG"
+  value: "/src/config/.boto_json"
+}

--- a/test/ci/kokoro/windows/py37_xml.cfg
+++ b/test/ci/kokoro/windows/py37_xml.cfg
@@ -1,0 +1,23 @@
+type: SUB_JOB
+
+group_spec {
+  parent_job_name: "cloud_storage_gsutil/windows/presubmit"
+  parent_job_name: "cloud_storage_gsutil/windows/continuous"
+}
+
+# Environment variables to specify interpreter version.
+# go/kokoro-env-vars
+env_vars {
+  key: "PYMAJOR"
+  value: "3"
+}
+
+env_vars {
+  key: "PYMINOR"
+  value: "7"
+}
+
+env_vars {
+  key: "BOTO_CONFIG"
+  value: "/src/config/.boto_xml"
+}


### PR DESCRIPTION
Added these configs so we can inject specific environment variables
into each child job, namely which Python version to use.

See: go/kokoro-env-vars

Note, these differ from the job configs in Google3 in two ways:
1. `find . -type f -name *.cfg -exec sed -i 's|https://INTERNAL_LINK.com|go/kokoro-env-vars|g' {} \;`
2. `find . -type f -name *.cfg -exec sed -i 's|allowed_env_vars|env_vars|g' {} \;`
