### PR TITLE
Du comment changes

### DIFF
--- a/gslib/commands/du.py
+++ b/gslib/commands/du.py
@@ -116,19 +116,6 @@ _DETAILED_HELP_TEXT = ("""
 """)
 
 
-def _GetPatternExclusion(file, position, encoding):
-  exclusion_patterns = []
-  file.seek(position)
-  for line in file:
-    if six.PY2:
-      line = line.strip().decode(encoding)
-    else:
-      line = line.strip().encode(encoding)
-    if line:
-      exclusion_patterns.append(line)
-  return exclusion_patterns
-
-
 class DuCommand(Command):
   """Implementation of gsutil du command."""
 
@@ -229,15 +216,12 @@ class DuCommand(Command):
         elif o == '-X':
           if a == '-':
             f = sys.stdin
+            f_close = False
           else:
             f = open(a, 'r') if six.PY2 else open(a, 'r', encoding=UTF8)
-          position = f.tell()
-          try:
-            self.exclude_patterns = _GetPatternExclusion(f, position, UTF8)
-          except:
-            self.exclude_patterns = _GetPatternExclusion(f, position,
-                locale.getpreferredencoding(False))
-          finally:
+            f_close = True
+          self.exclude_patterns = [six.ensure_text(line.strip()) for line in f]
+          if f_close:
             f.close()
 
     if not self.args:

--- a/gslib/commands/du.py
+++ b/gslib/commands/du.py
@@ -115,8 +115,6 @@ _DETAILED_HELP_TEXT = ("""
       gsutil -o GSUtil:default_project_id=project-name du -shc
 """)
 
-LOCAL_ENC = locale.getpreferredencoding(False)
-
 
 def _GetPatternExclusion(file, position, encoding):
   exclusion_patterns = []
@@ -232,12 +230,13 @@ class DuCommand(Command):
           if a == '-':
             f = sys.stdin
           else:
-            f = open(a, 'r', encoding=UTF8)
+            f = open(a, 'r') if six.PY2 else open(a, 'r', encoding=UTF8)
           position = f.tell()
           try:
             self.exclude_patterns = _GetPatternExclusion(f, position, UTF8)
           except:
-            self.exclude_patterns = _GetPatternExclusion(f, position, LOCAL_ENC)
+            self.exclude_patterns = _GetPatternExclusion(f, position,
+                locale.getpreferredencoding(False))
           finally:
             f.close()
 


### PR DESCRIPTION
Changes in response to Matt's comments

* Py2 has no `encoding` option in the `open` command. Added if/else case to handle both versions.

* `_GetPatternExclusion` was a copy-paste for the encode/decode logic and could have been revised and simplified in-line.

* `LOCAL_ENC` no longer needed (tested with mac/linux/win both py2 and 3 with no issues).