### PR TITLE
Removed `type` and `group_spec` from build configs

### DIFF
--- a/test/ci/kokoro/linux/py27_json.cfg
+++ b/test/ci/kokoro/linux/py27_json.cfg
@@ -1,10 +1,3 @@
-type: SUB_JOB
-
-group_spec {
-  parent_job_name: "cloud_storage_gsutil/linux/presubmit"
-  parent_job_name: "cloud_storage_gsutil/linux/continuous"
-}
-
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/linux/py27_xml.cfg
+++ b/test/ci/kokoro/linux/py27_xml.cfg
@@ -1,10 +1,3 @@
-type: SUB_JOB
-
-group_spec {
-  parent_job_name: "cloud_storage_gsutil/linux/presubmit"
-  parent_job_name: "cloud_storage_gsutil/linux/continuous"
-}
-
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/linux/py35_json.cfg
+++ b/test/ci/kokoro/linux/py35_json.cfg
@@ -1,10 +1,3 @@
-type: SUB_JOB
-
-group_spec {
-  parent_job_name: "cloud_storage_gsutil/linux/presubmit"
-  parent_job_name: "cloud_storage_gsutil/linux/continuous"
-}
-
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/linux/py35_xml.cfg
+++ b/test/ci/kokoro/linux/py35_xml.cfg
@@ -1,10 +1,3 @@
-type: SUB_JOB
-
-group_spec {
-  parent_job_name: "cloud_storage_gsutil/linux/presubmit"
-  parent_job_name: "cloud_storage_gsutil/linux/continuous"
-}
-
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/linux/py36_json.cfg
+++ b/test/ci/kokoro/linux/py36_json.cfg
@@ -1,10 +1,3 @@
-type: SUB_JOB
-
-group_spec {
-  parent_job_name: "cloud_storage_gsutil/linux/presubmit"
-  parent_job_name: "cloud_storage_gsutil/linux/continuous"
-}
-
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/linux/py36_xml.cfg
+++ b/test/ci/kokoro/linux/py36_xml.cfg
@@ -1,10 +1,3 @@
-type: SUB_JOB
-
-group_spec {
-  parent_job_name: "cloud_storage_gsutil/linux/presubmit"
-  parent_job_name: "cloud_storage_gsutil/linux/continuous"
-}
-
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/linux/py37_json.cfg
+++ b/test/ci/kokoro/linux/py37_json.cfg
@@ -1,10 +1,3 @@
-type: SUB_JOB
-
-group_spec {
-  parent_job_name: "cloud_storage_gsutil/linux/presubmit"
-  parent_job_name: "cloud_storage_gsutil/linux/continuous"
-}
-
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/linux/py37_xml.cfg
+++ b/test/ci/kokoro/linux/py37_xml.cfg
@@ -1,10 +1,3 @@
-type: SUB_JOB
-
-group_spec {
-  parent_job_name: "cloud_storage_gsutil/linux/presubmit"
-  parent_job_name: "cloud_storage_gsutil/linux/continuous"
-}
-
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/macos/py27_json.cfg
+++ b/test/ci/kokoro/macos/py27_json.cfg
@@ -1,10 +1,3 @@
-type: SUB_JOB
-
-group_spec {
-  parent_job_name: "cloud_storage_gsutil/macos/presubmit"
-  parent_job_name: "cloud_storage_gsutil/macos/continuous"
-}
-
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/macos/py27_xml.cfg
+++ b/test/ci/kokoro/macos/py27_xml.cfg
@@ -1,10 +1,3 @@
-type: SUB_JOB
-
-group_spec {
-  parent_job_name: "cloud_storage_gsutil/macos/presubmit"
-  parent_job_name: "cloud_storage_gsutil/macos/continuous"
-}
-
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/macos/py35_json.cfg
+++ b/test/ci/kokoro/macos/py35_json.cfg
@@ -1,10 +1,3 @@
-type: SUB_JOB
-
-group_spec {
-  parent_job_name: "cloud_storage_gsutil/macos/presubmit"
-  parent_job_name: "cloud_storage_gsutil/macos/continuous"
-}
-
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/macos/py35_xml.cfg
+++ b/test/ci/kokoro/macos/py35_xml.cfg
@@ -1,10 +1,3 @@
-type: SUB_JOB
-
-group_spec {
-  parent_job_name: "cloud_storage_gsutil/macos/presubmit"
-  parent_job_name: "cloud_storage_gsutil/macos/continuous"
-}
-
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/macos/py36_json.cfg
+++ b/test/ci/kokoro/macos/py36_json.cfg
@@ -1,10 +1,3 @@
-type: SUB_JOB
-
-group_spec {
-  parent_job_name: "cloud_storage_gsutil/macos/presubmit"
-  parent_job_name: "cloud_storage_gsutil/macos/continuous"
-}
-
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/macos/py36_xml.cfg
+++ b/test/ci/kokoro/macos/py36_xml.cfg
@@ -1,10 +1,3 @@
-type: SUB_JOB
-
-group_spec {
-  parent_job_name: "cloud_storage_gsutil/macos/presubmit"
-  parent_job_name: "cloud_storage_gsutil/macos/continuous"
-}
-
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/macos/py37_json.cfg
+++ b/test/ci/kokoro/macos/py37_json.cfg
@@ -1,10 +1,3 @@
-type: SUB_JOB
-
-group_spec {
-  parent_job_name: "cloud_storage_gsutil/macos/presubmit"
-  parent_job_name: "cloud_storage_gsutil/macos/continuous"
-}
-
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/macos/py37_xml.cfg
+++ b/test/ci/kokoro/macos/py37_xml.cfg
@@ -1,10 +1,3 @@
-type: SUB_JOB
-
-group_spec {
-  parent_job_name: "cloud_storage_gsutil/macos/presubmit"
-  parent_job_name: "cloud_storage_gsutil/macos/continuous"
-}
-
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/windows/py27_json.cfg
+++ b/test/ci/kokoro/windows/py27_json.cfg
@@ -1,10 +1,3 @@
-type: SUB_JOB
-
-group_spec {
-  parent_job_name: "cloud_storage_gsutil/windows/presubmit"
-  parent_job_name: "cloud_storage_gsutil/windows/continuous"
-}
-
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/windows/py27_xml.cfg
+++ b/test/ci/kokoro/windows/py27_xml.cfg
@@ -1,10 +1,3 @@
-type: SUB_JOB
-
-group_spec {
-  parent_job_name: "cloud_storage_gsutil/windows/presubmit"
-  parent_job_name: "cloud_storage_gsutil/windows/continuous"
-}
-
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/windows/py35_json.cfg
+++ b/test/ci/kokoro/windows/py35_json.cfg
@@ -1,10 +1,3 @@
-type: SUB_JOB
-
-group_spec {
-  parent_job_name: "cloud_storage_gsutil/windows/presubmit"
-  parent_job_name: "cloud_storage_gsutil/windows/continuous"
-}
-
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/windows/py35_xml.cfg
+++ b/test/ci/kokoro/windows/py35_xml.cfg
@@ -1,10 +1,3 @@
-type: SUB_JOB
-
-group_spec {
-  parent_job_name: "cloud_storage_gsutil/windows/presubmit"
-  parent_job_name: "cloud_storage_gsutil/windows/continuous"
-}
-
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/windows/py36_json.cfg
+++ b/test/ci/kokoro/windows/py36_json.cfg
@@ -1,10 +1,3 @@
-type: SUB_JOB
-
-group_spec {
-  parent_job_name: "cloud_storage_gsutil/windows/presubmit"
-  parent_job_name: "cloud_storage_gsutil/windows/continuous"
-}
-
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/windows/py36_xml.cfg
+++ b/test/ci/kokoro/windows/py36_xml.cfg
@@ -1,10 +1,3 @@
-type: SUB_JOB
-
-group_spec {
-  parent_job_name: "cloud_storage_gsutil/windows/presubmit"
-  parent_job_name: "cloud_storage_gsutil/windows/continuous"
-}
-
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/windows/py37_json.cfg
+++ b/test/ci/kokoro/windows/py37_json.cfg
@@ -1,10 +1,3 @@
-type: SUB_JOB
-
-group_spec {
-  parent_job_name: "cloud_storage_gsutil/windows/presubmit"
-  parent_job_name: "cloud_storage_gsutil/windows/continuous"
-}
-
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/windows/py37_xml.cfg
+++ b/test/ci/kokoro/windows/py37_xml.cfg
@@ -1,10 +1,3 @@
-type: SUB_JOB
-
-group_spec {
-  parent_job_name: "cloud_storage_gsutil/windows/presubmit"
-  parent_job_name: "cloud_storage_gsutil/windows/continuous"
-}
-
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {


### PR DESCRIPTION
These were leftover when making the build configs based on the job
configs. It turns out that build configs don't have attributes for
type or group spec, only job configs.

Sponge log where we spotted this issue:
go/pr-remove-type-group-spec-sponge-log

Kokoro build proto:
go/kokoro-build