### PR TITLE
Prepended continuous config to child configs

### DIFF
--- a/test/ci/kokoro/linux/py27_json.cfg
+++ b/test/ci/kokoro/linux/py27_json.cfg
@@ -1,3 +1,32 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "test/ci/kokoro/linux/run_integ_tests.sh"
+timeout_mins: 60
+
+# Get access keys from Keystore
+# go/kokoro-keystore
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "gsutil_kokoro_service_key"
+    }
+  }
+}
+
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/linux/py27_xml.cfg
+++ b/test/ci/kokoro/linux/py27_xml.cfg
@@ -1,3 +1,32 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "test/ci/kokoro/linux/run_integ_tests.sh"
+timeout_mins: 60
+
+# Get access keys from Keystore
+# go/kokoro-keystore
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "gsutil_kokoro_service_key"
+    }
+  }
+}
+
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/linux/py35_json.cfg
+++ b/test/ci/kokoro/linux/py35_json.cfg
@@ -1,3 +1,32 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "test/ci/kokoro/linux/run_integ_tests.sh"
+timeout_mins: 60
+
+# Get access keys from Keystore
+# go/kokoro-keystore
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "gsutil_kokoro_service_key"
+    }
+  }
+}
+
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/linux/py35_xml.cfg
+++ b/test/ci/kokoro/linux/py35_xml.cfg
@@ -1,3 +1,32 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "test/ci/kokoro/linux/run_integ_tests.sh"
+timeout_mins: 60
+
+# Get access keys from Keystore
+# go/kokoro-keystore
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "gsutil_kokoro_service_key"
+    }
+  }
+}
+
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/linux/py36_json.cfg
+++ b/test/ci/kokoro/linux/py36_json.cfg
@@ -1,3 +1,32 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "test/ci/kokoro/linux/run_integ_tests.sh"
+timeout_mins: 60
+
+# Get access keys from Keystore
+# go/kokoro-keystore
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "gsutil_kokoro_service_key"
+    }
+  }
+}
+
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/linux/py36_xml.cfg
+++ b/test/ci/kokoro/linux/py36_xml.cfg
@@ -1,3 +1,32 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "test/ci/kokoro/linux/run_integ_tests.sh"
+timeout_mins: 60
+
+# Get access keys from Keystore
+# go/kokoro-keystore
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "gsutil_kokoro_service_key"
+    }
+  }
+}
+
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/linux/py37_json.cfg
+++ b/test/ci/kokoro/linux/py37_json.cfg
@@ -1,3 +1,32 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "test/ci/kokoro/linux/run_integ_tests.sh"
+timeout_mins: 60
+
+# Get access keys from Keystore
+# go/kokoro-keystore
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "gsutil_kokoro_service_key"
+    }
+  }
+}
+
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/linux/py37_xml.cfg
+++ b/test/ci/kokoro/linux/py37_xml.cfg
@@ -1,3 +1,32 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "test/ci/kokoro/linux/run_integ_tests.sh"
+timeout_mins: 60
+
+# Get access keys from Keystore
+# go/kokoro-keystore
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "gsutil_kokoro_service_key"
+    }
+  }
+}
+
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/macos/py27_json.cfg
+++ b/test/ci/kokoro/macos/py27_json.cfg
@@ -1,3 +1,33 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "test/ci/kokoro/mac/run_integ_tests.sh"
+timeout_mins: 60
+
+
+# Get access keys from Keystore
+# go/kokoro-keystore
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "gsutil_kokoro_service_key"
+    }
+  }
+}
+
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/macos/py27_xml.cfg
+++ b/test/ci/kokoro/macos/py27_xml.cfg
@@ -1,3 +1,33 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "test/ci/kokoro/mac/run_integ_tests.sh"
+timeout_mins: 60
+
+
+# Get access keys from Keystore
+# go/kokoro-keystore
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "gsutil_kokoro_service_key"
+    }
+  }
+}
+
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/macos/py35_json.cfg
+++ b/test/ci/kokoro/macos/py35_json.cfg
@@ -1,3 +1,33 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "test/ci/kokoro/mac/run_integ_tests.sh"
+timeout_mins: 60
+
+
+# Get access keys from Keystore
+# go/kokoro-keystore
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "gsutil_kokoro_service_key"
+    }
+  }
+}
+
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/macos/py35_xml.cfg
+++ b/test/ci/kokoro/macos/py35_xml.cfg
@@ -1,3 +1,33 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "test/ci/kokoro/mac/run_integ_tests.sh"
+timeout_mins: 60
+
+
+# Get access keys from Keystore
+# go/kokoro-keystore
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "gsutil_kokoro_service_key"
+    }
+  }
+}
+
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/macos/py36_json.cfg
+++ b/test/ci/kokoro/macos/py36_json.cfg
@@ -1,3 +1,33 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "test/ci/kokoro/mac/run_integ_tests.sh"
+timeout_mins: 60
+
+
+# Get access keys from Keystore
+# go/kokoro-keystore
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "gsutil_kokoro_service_key"
+    }
+  }
+}
+
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/macos/py36_xml.cfg
+++ b/test/ci/kokoro/macos/py36_xml.cfg
@@ -1,3 +1,33 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "test/ci/kokoro/mac/run_integ_tests.sh"
+timeout_mins: 60
+
+
+# Get access keys from Keystore
+# go/kokoro-keystore
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "gsutil_kokoro_service_key"
+    }
+  }
+}
+
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/macos/py37_json.cfg
+++ b/test/ci/kokoro/macos/py37_json.cfg
@@ -1,3 +1,33 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "test/ci/kokoro/mac/run_integ_tests.sh"
+timeout_mins: 60
+
+
+# Get access keys from Keystore
+# go/kokoro-keystore
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "gsutil_kokoro_service_key"
+    }
+  }
+}
+
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/macos/py37_xml.cfg
+++ b/test/ci/kokoro/macos/py37_xml.cfg
@@ -1,3 +1,33 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "test/ci/kokoro/mac/run_integ_tests.sh"
+timeout_mins: 60
+
+
+# Get access keys from Keystore
+# go/kokoro-keystore
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "gsutil_kokoro_service_key"
+    }
+  }
+}
+
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/windows/continuous.cfg
+++ b/test/ci/kokoro/windows/continuous.cfg
@@ -31,7 +31,7 @@ before_action {
 # Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L15
 build_params {
   key: "GsutilRepoDir"
-  value: "C:\\keystore\\src\\gsutil"
+  value: "C:\\src\\gsutil"
 }
 
 # Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L19

--- a/test/ci/kokoro/windows/presubmit.cfg
+++ b/test/ci/kokoro/windows/presubmit.cfg
@@ -31,7 +31,7 @@ before_action {
 # Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L15
 build_params {
   key: "GsutilRepoDir"
-  value: "C:\\keystore\\src\\gsutil"
+  value: "C:\\src\\gsutil"
 }
 
 # Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L19

--- a/test/ci/kokoro/windows/py27_json.cfg
+++ b/test/ci/kokoro/windows/py27_json.cfg
@@ -31,7 +31,7 @@ before_action {
 # Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L15
 build_params {
   key: "GsutilRepoDir"
-  value: "C:\\keystore\\src\\gsutil"
+  value: "C:\\src\\gsutil"
 }
 
 # Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L19

--- a/test/ci/kokoro/windows/py27_json.cfg
+++ b/test/ci/kokoro/windows/py27_json.cfg
@@ -1,3 +1,45 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "test/ci/kokoro/windows/run_integ_tests.ps1"
+timeout_mins: 60
+
+
+# Get access keys from Keystore
+# go/kokoro-keystore
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "gsutil_kokoro_service_key"
+    }
+  }
+}
+
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L15
+build_params {
+  key: "GsutilRepoDir"
+  value: "C:\\keystore\\src\\gsutil"
+}
+
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L19
+build_params {
+  key: "PyExe"
+  value "C:\\python$PYMAJOR$PYMINOR\\python.exe"
+}
+
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/windows/py27_xml.cfg
+++ b/test/ci/kokoro/windows/py27_xml.cfg
@@ -31,7 +31,7 @@ before_action {
 # Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L15
 build_params {
   key: "GsutilRepoDir"
-  value: "C:\\keystore\\src\\gsutil"
+  value: "C:\\src\\gsutil"
 }
 
 # Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L19

--- a/test/ci/kokoro/windows/py27_xml.cfg
+++ b/test/ci/kokoro/windows/py27_xml.cfg
@@ -1,3 +1,45 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "test/ci/kokoro/windows/run_integ_tests.ps1"
+timeout_mins: 60
+
+
+# Get access keys from Keystore
+# go/kokoro-keystore
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "gsutil_kokoro_service_key"
+    }
+  }
+}
+
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L15
+build_params {
+  key: "GsutilRepoDir"
+  value: "C:\\keystore\\src\\gsutil"
+}
+
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L19
+build_params {
+  key: "PyExe"
+  value "C:\\python$PYMAJOR$PYMINOR\\python.exe"
+}
+
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/windows/py35_json.cfg
+++ b/test/ci/kokoro/windows/py35_json.cfg
@@ -31,7 +31,7 @@ before_action {
 # Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L15
 build_params {
   key: "GsutilRepoDir"
-  value: "C:\\keystore\\src\\gsutil"
+  value: "C:\\src\\gsutil"
 }
 
 # Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L19

--- a/test/ci/kokoro/windows/py35_json.cfg
+++ b/test/ci/kokoro/windows/py35_json.cfg
@@ -1,3 +1,45 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "test/ci/kokoro/windows/run_integ_tests.ps1"
+timeout_mins: 60
+
+
+# Get access keys from Keystore
+# go/kokoro-keystore
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "gsutil_kokoro_service_key"
+    }
+  }
+}
+
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L15
+build_params {
+  key: "GsutilRepoDir"
+  value: "C:\\keystore\\src\\gsutil"
+}
+
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L19
+build_params {
+  key: "PyExe"
+  value "C:\\python$PYMAJOR$PYMINOR\\python.exe"
+}
+
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/windows/py35_xml.cfg
+++ b/test/ci/kokoro/windows/py35_xml.cfg
@@ -31,7 +31,7 @@ before_action {
 # Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L15
 build_params {
   key: "GsutilRepoDir"
-  value: "C:\\keystore\\src\\gsutil"
+  value: "C:\\src\\gsutil"
 }
 
 # Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L19

--- a/test/ci/kokoro/windows/py35_xml.cfg
+++ b/test/ci/kokoro/windows/py35_xml.cfg
@@ -1,3 +1,45 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "test/ci/kokoro/windows/run_integ_tests.ps1"
+timeout_mins: 60
+
+
+# Get access keys from Keystore
+# go/kokoro-keystore
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "gsutil_kokoro_service_key"
+    }
+  }
+}
+
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L15
+build_params {
+  key: "GsutilRepoDir"
+  value: "C:\\keystore\\src\\gsutil"
+}
+
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L19
+build_params {
+  key: "PyExe"
+  value "C:\\python$PYMAJOR$PYMINOR\\python.exe"
+}
+
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/windows/py36_json.cfg
+++ b/test/ci/kokoro/windows/py36_json.cfg
@@ -31,7 +31,7 @@ before_action {
 # Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L15
 build_params {
   key: "GsutilRepoDir"
-  value: "C:\\keystore\\src\\gsutil"
+  value: "C:\\src\\gsutil"
 }
 
 # Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L19

--- a/test/ci/kokoro/windows/py36_json.cfg
+++ b/test/ci/kokoro/windows/py36_json.cfg
@@ -1,3 +1,45 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "test/ci/kokoro/windows/run_integ_tests.ps1"
+timeout_mins: 60
+
+
+# Get access keys from Keystore
+# go/kokoro-keystore
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "gsutil_kokoro_service_key"
+    }
+  }
+}
+
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L15
+build_params {
+  key: "GsutilRepoDir"
+  value: "C:\\keystore\\src\\gsutil"
+}
+
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L19
+build_params {
+  key: "PyExe"
+  value "C:\\python$PYMAJOR$PYMINOR\\python.exe"
+}
+
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/windows/py36_xml.cfg
+++ b/test/ci/kokoro/windows/py36_xml.cfg
@@ -31,7 +31,7 @@ before_action {
 # Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L15
 build_params {
   key: "GsutilRepoDir"
-  value: "C:\\keystore\\src\\gsutil"
+  value: "C:\\src\\gsutil"
 }
 
 # Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L19

--- a/test/ci/kokoro/windows/py36_xml.cfg
+++ b/test/ci/kokoro/windows/py36_xml.cfg
@@ -1,3 +1,45 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "test/ci/kokoro/windows/run_integ_tests.ps1"
+timeout_mins: 60
+
+
+# Get access keys from Keystore
+# go/kokoro-keystore
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "gsutil_kokoro_service_key"
+    }
+  }
+}
+
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L15
+build_params {
+  key: "GsutilRepoDir"
+  value: "C:\\keystore\\src\\gsutil"
+}
+
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L19
+build_params {
+  key: "PyExe"
+  value "C:\\python$PYMAJOR$PYMINOR\\python.exe"
+}
+
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/windows/py37_json.cfg
+++ b/test/ci/kokoro/windows/py37_json.cfg
@@ -31,7 +31,7 @@ before_action {
 # Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L15
 build_params {
   key: "GsutilRepoDir"
-  value: "C:\\keystore\\src\\gsutil"
+  value: "C:\\src\\gsutil"
 }
 
 # Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L19

--- a/test/ci/kokoro/windows/py37_json.cfg
+++ b/test/ci/kokoro/windows/py37_json.cfg
@@ -1,3 +1,45 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "test/ci/kokoro/windows/run_integ_tests.ps1"
+timeout_mins: 60
+
+
+# Get access keys from Keystore
+# go/kokoro-keystore
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "gsutil_kokoro_service_key"
+    }
+  }
+}
+
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L15
+build_params {
+  key: "GsutilRepoDir"
+  value: "C:\\keystore\\src\\gsutil"
+}
+
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L19
+build_params {
+  key: "PyExe"
+  value "C:\\python$PYMAJOR$PYMINOR\\python.exe"
+}
+
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/windows/py37_xml.cfg
+++ b/test/ci/kokoro/windows/py37_xml.cfg
@@ -31,7 +31,7 @@ before_action {
 # Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L15
 build_params {
   key: "GsutilRepoDir"
-  value: "C:\\keystore\\src\\gsutil"
+  value: "C:\\src\\gsutil"
 }
 
 # Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L19

--- a/test/ci/kokoro/windows/py37_xml.cfg
+++ b/test/ci/kokoro/windows/py37_xml.cfg
@@ -1,3 +1,45 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "test/ci/kokoro/windows/run_integ_tests.ps1"
+timeout_mins: 60
+
+
+# Get access keys from Keystore
+# go/kokoro-keystore
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "gsutil_kokoro_service_key"
+    }
+  }
+}
+
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L15
+build_params {
+  key: "GsutilRepoDir"
+  value: "C:\\keystore\\src\\gsutil"
+}
+
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L19
+build_params {
+  key: "PyExe"
+  value "C:\\python$PYMAJOR$PYMINOR\\python.exe"
+}
+
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {


### PR DESCRIPTION
Child build configs don't inherit from the build config defining
their job, so I'm manually prepending the needed fields.

Sponge logs: go/sponge-needs-build-file-prepend-pr
Sed command used to update these:
`find . -type f -name 'py*.cfg' -exec sed -i -e '1rcontinuous.cfg' -e
'1{h;d}' -e '2{x;G}'  {} \;`

This was tested on the `ci-testing` branch, yeilding output without
the previous error we were seeing.

I'll try to consolidate this pile of configs once things are running. :)