### PR TITLE
Updating build script path to a relative path.

### DIFF
--- a/test/ci/kokoro/linux/continuous.cfg
+++ b/test/ci/kokoro/linux/continuous.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "test/ci/kokoro/linux/run_integ_tests.sh"
+build_file: "./run_integ_tests.sh"
 timeout_mins: 60
 
 # Get access keys from Keystore

--- a/test/ci/kokoro/linux/presubmit.cfg
+++ b/test/ci/kokoro/linux/presubmit.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "test/ci/kokoro/linux/run_integ_tests.sh"
+build_file: "./run_integ_tests.sh"
 timeout_mins: 60
 
 # Get access keys from Keystore

--- a/test/ci/kokoro/linux/py27_json.cfg
+++ b/test/ci/kokoro/linux/py27_json.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "test/ci/kokoro/linux/run_integ_tests.sh"
+build_file: "./run_integ_tests.sh"
 timeout_mins: 60
 
 # Get access keys from Keystore

--- a/test/ci/kokoro/linux/py27_xml.cfg
+++ b/test/ci/kokoro/linux/py27_xml.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "test/ci/kokoro/linux/run_integ_tests.sh"
+build_file: "./run_integ_tests.sh"
 timeout_mins: 60
 
 # Get access keys from Keystore

--- a/test/ci/kokoro/linux/py35_json.cfg
+++ b/test/ci/kokoro/linux/py35_json.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "test/ci/kokoro/linux/run_integ_tests.sh"
+build_file: "./run_integ_tests.sh"
 timeout_mins: 60
 
 # Get access keys from Keystore

--- a/test/ci/kokoro/linux/py35_xml.cfg
+++ b/test/ci/kokoro/linux/py35_xml.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "test/ci/kokoro/linux/run_integ_tests.sh"
+build_file: "./run_integ_tests.sh"
 timeout_mins: 60
 
 # Get access keys from Keystore

--- a/test/ci/kokoro/linux/py36_json.cfg
+++ b/test/ci/kokoro/linux/py36_json.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "test/ci/kokoro/linux/run_integ_tests.sh"
+build_file: "./run_integ_tests.sh"
 timeout_mins: 60
 
 # Get access keys from Keystore

--- a/test/ci/kokoro/linux/py36_xml.cfg
+++ b/test/ci/kokoro/linux/py36_xml.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "test/ci/kokoro/linux/run_integ_tests.sh"
+build_file: "./run_integ_tests.sh"
 timeout_mins: 60
 
 # Get access keys from Keystore

--- a/test/ci/kokoro/linux/py37_json.cfg
+++ b/test/ci/kokoro/linux/py37_json.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "test/ci/kokoro/linux/run_integ_tests.sh"
+build_file: "./run_integ_tests.sh"
 timeout_mins: 60
 
 # Get access keys from Keystore

--- a/test/ci/kokoro/linux/py37_xml.cfg
+++ b/test/ci/kokoro/linux/py37_xml.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "test/ci/kokoro/linux/run_integ_tests.sh"
+build_file: "./run_integ_tests.sh"
 timeout_mins: 60
 
 # Get access keys from Keystore

--- a/test/ci/kokoro/macos/continuous.cfg
+++ b/test/ci/kokoro/macos/continuous.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "test/ci/kokoro/mac/run_integ_tests.sh"
+build_file: "./run_integ_tests.sh"
 timeout_mins: 60
 
 

--- a/test/ci/kokoro/macos/presubmit.cfg
+++ b/test/ci/kokoro/macos/presubmit.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "test/ci/kokoro/mac/run_integ_tests.sh"
+build_file: "./run_integ_tests.sh"
 timeout_mins: 60
 
 

--- a/test/ci/kokoro/macos/py27_json.cfg
+++ b/test/ci/kokoro/macos/py27_json.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "test/ci/kokoro/mac/run_integ_tests.sh"
+build_file: "./run_integ_tests.sh"
 timeout_mins: 60
 
 

--- a/test/ci/kokoro/macos/py27_xml.cfg
+++ b/test/ci/kokoro/macos/py27_xml.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "test/ci/kokoro/mac/run_integ_tests.sh"
+build_file: "./run_integ_tests.sh"
 timeout_mins: 60
 
 

--- a/test/ci/kokoro/macos/py35_json.cfg
+++ b/test/ci/kokoro/macos/py35_json.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "test/ci/kokoro/mac/run_integ_tests.sh"
+build_file: "./run_integ_tests.sh"
 timeout_mins: 60
 
 

--- a/test/ci/kokoro/macos/py35_xml.cfg
+++ b/test/ci/kokoro/macos/py35_xml.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "test/ci/kokoro/mac/run_integ_tests.sh"
+build_file: "./run_integ_tests.sh"
 timeout_mins: 60
 
 

--- a/test/ci/kokoro/macos/py36_json.cfg
+++ b/test/ci/kokoro/macos/py36_json.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "test/ci/kokoro/mac/run_integ_tests.sh"
+build_file: "./run_integ_tests.sh"
 timeout_mins: 60
 
 

--- a/test/ci/kokoro/macos/py36_xml.cfg
+++ b/test/ci/kokoro/macos/py36_xml.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "test/ci/kokoro/mac/run_integ_tests.sh"
+build_file: "./run_integ_tests.sh"
 timeout_mins: 60
 
 

--- a/test/ci/kokoro/macos/py37_json.cfg
+++ b/test/ci/kokoro/macos/py37_json.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "test/ci/kokoro/mac/run_integ_tests.sh"
+build_file: "./run_integ_tests.sh"
 timeout_mins: 60
 
 

--- a/test/ci/kokoro/macos/py37_xml.cfg
+++ b/test/ci/kokoro/macos/py37_xml.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "test/ci/kokoro/mac/run_integ_tests.sh"
+build_file: "./run_integ_tests.sh"
 timeout_mins: 60
 
 

--- a/test/ci/kokoro/windows/continuous.cfg
+++ b/test/ci/kokoro/windows/continuous.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "test/ci/kokoro/windows/run_integ_tests.ps1"
+build_file: "./run_integ_tests.ps1"
 timeout_mins: 60
 
 
@@ -28,13 +28,13 @@ before_action {
   }
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L15
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/./run_integ_tests.ps1#L15
 build_params {
   key: "GsutilRepoDir"
   value: "C:\\src\\gsutil"
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L19
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/./run_integ_tests.ps1#L19
 build_params {
   key: "PyExe"
   value "C:\\python$PYMAJOR$PYMINOR\\python.exe"

--- a/test/ci/kokoro/windows/continuous.cfg
+++ b/test/ci/kokoro/windows/continuous.cfg
@@ -28,13 +28,13 @@ before_action {
   }
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/./run_integ_tests.ps1#L15
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L15
 build_params {
   key: "GsutilRepoDir"
   value: "C:\\src\\gsutil"
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/./run_integ_tests.ps1#L19
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L19
 build_params {
   key: "PyExe"
   value "C:\\python$PYMAJOR$PYMINOR\\python.exe"

--- a/test/ci/kokoro/windows/presubmit.cfg
+++ b/test/ci/kokoro/windows/presubmit.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "test/ci/kokoro/windows/run_integ_tests.ps1"
+build_file: "./run_integ_tests.ps1"
 timeout_mins: 60
 
 
@@ -28,13 +28,13 @@ before_action {
   }
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L15
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/./run_integ_tests.ps1#L15
 build_params {
   key: "GsutilRepoDir"
   value: "C:\\src\\gsutil"
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L19
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/./run_integ_tests.ps1#L19
 build_params {
   key: "PyExe"
   value "C:\\python$PYMAJOR$PYMINOR\\python.exe"

--- a/test/ci/kokoro/windows/presubmit.cfg
+++ b/test/ci/kokoro/windows/presubmit.cfg
@@ -28,13 +28,13 @@ before_action {
   }
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/./run_integ_tests.ps1#L15
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L15
 build_params {
   key: "GsutilRepoDir"
   value: "C:\\src\\gsutil"
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/./run_integ_tests.ps1#L19
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L19
 build_params {
   key: "PyExe"
   value "C:\\python$PYMAJOR$PYMINOR\\python.exe"

--- a/test/ci/kokoro/windows/py27_json.cfg
+++ b/test/ci/kokoro/windows/py27_json.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "test/ci/kokoro/windows/run_integ_tests.ps1"
+build_file: "./run_integ_tests.ps1"
 timeout_mins: 60
 
 
@@ -28,13 +28,13 @@ before_action {
   }
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L15
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/./run_integ_tests.ps1#L15
 build_params {
   key: "GsutilRepoDir"
   value: "C:\\src\\gsutil"
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L19
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/./run_integ_tests.ps1#L19
 build_params {
   key: "PyExe"
   value "C:\\python$PYMAJOR$PYMINOR\\python.exe"

--- a/test/ci/kokoro/windows/py27_json.cfg
+++ b/test/ci/kokoro/windows/py27_json.cfg
@@ -28,13 +28,13 @@ before_action {
   }
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/./run_integ_tests.ps1#L15
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L15
 build_params {
   key: "GsutilRepoDir"
   value: "C:\\src\\gsutil"
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/./run_integ_tests.ps1#L19
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L19
 build_params {
   key: "PyExe"
   value "C:\\python$PYMAJOR$PYMINOR\\python.exe"

--- a/test/ci/kokoro/windows/py27_xml.cfg
+++ b/test/ci/kokoro/windows/py27_xml.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "test/ci/kokoro/windows/run_integ_tests.ps1"
+build_file: "./run_integ_tests.ps1"
 timeout_mins: 60
 
 
@@ -28,13 +28,13 @@ before_action {
   }
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L15
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/./run_integ_tests.ps1#L15
 build_params {
   key: "GsutilRepoDir"
   value: "C:\\src\\gsutil"
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L19
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/./run_integ_tests.ps1#L19
 build_params {
   key: "PyExe"
   value "C:\\python$PYMAJOR$PYMINOR\\python.exe"

--- a/test/ci/kokoro/windows/py27_xml.cfg
+++ b/test/ci/kokoro/windows/py27_xml.cfg
@@ -28,13 +28,13 @@ before_action {
   }
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/./run_integ_tests.ps1#L15
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L15
 build_params {
   key: "GsutilRepoDir"
   value: "C:\\src\\gsutil"
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/./run_integ_tests.ps1#L19
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L19
 build_params {
   key: "PyExe"
   value "C:\\python$PYMAJOR$PYMINOR\\python.exe"

--- a/test/ci/kokoro/windows/py35_json.cfg
+++ b/test/ci/kokoro/windows/py35_json.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "test/ci/kokoro/windows/run_integ_tests.ps1"
+build_file: "./run_integ_tests.ps1"
 timeout_mins: 60
 
 
@@ -28,13 +28,13 @@ before_action {
   }
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L15
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/./run_integ_tests.ps1#L15
 build_params {
   key: "GsutilRepoDir"
   value: "C:\\src\\gsutil"
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L19
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/./run_integ_tests.ps1#L19
 build_params {
   key: "PyExe"
   value "C:\\python$PYMAJOR$PYMINOR\\python.exe"

--- a/test/ci/kokoro/windows/py35_json.cfg
+++ b/test/ci/kokoro/windows/py35_json.cfg
@@ -28,13 +28,13 @@ before_action {
   }
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/./run_integ_tests.ps1#L15
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L15
 build_params {
   key: "GsutilRepoDir"
   value: "C:\\src\\gsutil"
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/./run_integ_tests.ps1#L19
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L19
 build_params {
   key: "PyExe"
   value "C:\\python$PYMAJOR$PYMINOR\\python.exe"

--- a/test/ci/kokoro/windows/py35_xml.cfg
+++ b/test/ci/kokoro/windows/py35_xml.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "test/ci/kokoro/windows/run_integ_tests.ps1"
+build_file: "./run_integ_tests.ps1"
 timeout_mins: 60
 
 
@@ -28,13 +28,13 @@ before_action {
   }
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L15
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/./run_integ_tests.ps1#L15
 build_params {
   key: "GsutilRepoDir"
   value: "C:\\src\\gsutil"
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L19
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/./run_integ_tests.ps1#L19
 build_params {
   key: "PyExe"
   value "C:\\python$PYMAJOR$PYMINOR\\python.exe"

--- a/test/ci/kokoro/windows/py35_xml.cfg
+++ b/test/ci/kokoro/windows/py35_xml.cfg
@@ -28,13 +28,13 @@ before_action {
   }
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/./run_integ_tests.ps1#L15
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L15
 build_params {
   key: "GsutilRepoDir"
   value: "C:\\src\\gsutil"
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/./run_integ_tests.ps1#L19
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L19
 build_params {
   key: "PyExe"
   value "C:\\python$PYMAJOR$PYMINOR\\python.exe"

--- a/test/ci/kokoro/windows/py36_json.cfg
+++ b/test/ci/kokoro/windows/py36_json.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "test/ci/kokoro/windows/run_integ_tests.ps1"
+build_file: "./run_integ_tests.ps1"
 timeout_mins: 60
 
 
@@ -28,13 +28,13 @@ before_action {
   }
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L15
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/./run_integ_tests.ps1#L15
 build_params {
   key: "GsutilRepoDir"
   value: "C:\\src\\gsutil"
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L19
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/./run_integ_tests.ps1#L19
 build_params {
   key: "PyExe"
   value "C:\\python$PYMAJOR$PYMINOR\\python.exe"

--- a/test/ci/kokoro/windows/py36_json.cfg
+++ b/test/ci/kokoro/windows/py36_json.cfg
@@ -28,13 +28,13 @@ before_action {
   }
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/./run_integ_tests.ps1#L15
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L15
 build_params {
   key: "GsutilRepoDir"
   value: "C:\\src\\gsutil"
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/./run_integ_tests.ps1#L19
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L19
 build_params {
   key: "PyExe"
   value "C:\\python$PYMAJOR$PYMINOR\\python.exe"

--- a/test/ci/kokoro/windows/py36_xml.cfg
+++ b/test/ci/kokoro/windows/py36_xml.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "test/ci/kokoro/windows/run_integ_tests.ps1"
+build_file: "./run_integ_tests.ps1"
 timeout_mins: 60
 
 
@@ -28,13 +28,13 @@ before_action {
   }
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L15
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/./run_integ_tests.ps1#L15
 build_params {
   key: "GsutilRepoDir"
   value: "C:\\src\\gsutil"
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L19
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/./run_integ_tests.ps1#L19
 build_params {
   key: "PyExe"
   value "C:\\python$PYMAJOR$PYMINOR\\python.exe"

--- a/test/ci/kokoro/windows/py36_xml.cfg
+++ b/test/ci/kokoro/windows/py36_xml.cfg
@@ -28,13 +28,13 @@ before_action {
   }
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/./run_integ_tests.ps1#L15
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L15
 build_params {
   key: "GsutilRepoDir"
   value: "C:\\src\\gsutil"
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/./run_integ_tests.ps1#L19
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L19
 build_params {
   key: "PyExe"
   value "C:\\python$PYMAJOR$PYMINOR\\python.exe"

--- a/test/ci/kokoro/windows/py37_json.cfg
+++ b/test/ci/kokoro/windows/py37_json.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "test/ci/kokoro/windows/run_integ_tests.ps1"
+build_file: "./run_integ_tests.ps1"
 timeout_mins: 60
 
 
@@ -28,13 +28,13 @@ before_action {
   }
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L15
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/./run_integ_tests.ps1#L15
 build_params {
   key: "GsutilRepoDir"
   value: "C:\\src\\gsutil"
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L19
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/./run_integ_tests.ps1#L19
 build_params {
   key: "PyExe"
   value "C:\\python$PYMAJOR$PYMINOR\\python.exe"

--- a/test/ci/kokoro/windows/py37_json.cfg
+++ b/test/ci/kokoro/windows/py37_json.cfg
@@ -28,13 +28,13 @@ before_action {
   }
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/./run_integ_tests.ps1#L15
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L15
 build_params {
   key: "GsutilRepoDir"
   value: "C:\\src\\gsutil"
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/./run_integ_tests.ps1#L19
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L19
 build_params {
   key: "PyExe"
   value "C:\\python$PYMAJOR$PYMINOR\\python.exe"

--- a/test/ci/kokoro/windows/py37_xml.cfg
+++ b/test/ci/kokoro/windows/py37_xml.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "test/ci/kokoro/windows/run_integ_tests.ps1"
+build_file: "./run_integ_tests.ps1"
 timeout_mins: 60
 
 
@@ -28,13 +28,13 @@ before_action {
   }
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L15
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/./run_integ_tests.ps1#L15
 build_params {
   key: "GsutilRepoDir"
   value: "C:\\src\\gsutil"
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L19
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/./run_integ_tests.ps1#L19
 build_params {
   key: "PyExe"
   value "C:\\python$PYMAJOR$PYMINOR\\python.exe"

--- a/test/ci/kokoro/windows/py37_xml.cfg
+++ b/test/ci/kokoro/windows/py37_xml.cfg
@@ -28,13 +28,13 @@ before_action {
   }
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/./run_integ_tests.ps1#L15
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L15
 build_params {
   key: "GsutilRepoDir"
   value: "C:\\src\\gsutil"
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/./run_integ_tests.ps1#L19
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L19
 build_params {
   key: "PyExe"
   value "C:\\python$PYMAJOR$PYMINOR\\python.exe"


### PR DESCRIPTION
After getting errors such as `AbortException: Build script does not exist: /tmp/workspace/workspace/cloud_storage_gsutil/linux/py27_json/src/github/test/ci/kokoro/linux/run_integ_tests.sh` in the Kokoro build logs, I updated the build script to use a relative path.

This was done with find / sed commands such as `find . -type f -name '*.cfg' -exec sed -i 's|test/ci/kokoro/linux/run_integ_tests.sh|./run_integ_tests.sh|g' {} \;`