### PR TITLE
Relative path updated to not use ./

### DIFF
--- a/test/ci/kokoro/linux/continuous.cfg
+++ b/test/ci/kokoro/linux/continuous.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "./run_integ_tests.sh"
+build_file: "run_integ_tests.sh"
 timeout_mins: 60
 
 # Get access keys from Keystore

--- a/test/ci/kokoro/linux/presubmit.cfg
+++ b/test/ci/kokoro/linux/presubmit.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "./run_integ_tests.sh"
+build_file: "run_integ_tests.sh"
 timeout_mins: 60
 
 # Get access keys from Keystore

--- a/test/ci/kokoro/linux/py27_json.cfg
+++ b/test/ci/kokoro/linux/py27_json.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "./run_integ_tests.sh"
+build_file: "run_integ_tests.sh"
 timeout_mins: 60
 
 # Get access keys from Keystore

--- a/test/ci/kokoro/linux/py27_xml.cfg
+++ b/test/ci/kokoro/linux/py27_xml.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "./run_integ_tests.sh"
+build_file: "run_integ_tests.sh"
 timeout_mins: 60
 
 # Get access keys from Keystore

--- a/test/ci/kokoro/linux/py35_json.cfg
+++ b/test/ci/kokoro/linux/py35_json.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "./run_integ_tests.sh"
+build_file: "run_integ_tests.sh"
 timeout_mins: 60
 
 # Get access keys from Keystore

--- a/test/ci/kokoro/linux/py35_xml.cfg
+++ b/test/ci/kokoro/linux/py35_xml.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "./run_integ_tests.sh"
+build_file: "run_integ_tests.sh"
 timeout_mins: 60
 
 # Get access keys from Keystore

--- a/test/ci/kokoro/linux/py36_json.cfg
+++ b/test/ci/kokoro/linux/py36_json.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "./run_integ_tests.sh"
+build_file: "run_integ_tests.sh"
 timeout_mins: 60
 
 # Get access keys from Keystore

--- a/test/ci/kokoro/linux/py36_xml.cfg
+++ b/test/ci/kokoro/linux/py36_xml.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "./run_integ_tests.sh"
+build_file: "run_integ_tests.sh"
 timeout_mins: 60
 
 # Get access keys from Keystore

--- a/test/ci/kokoro/linux/py37_json.cfg
+++ b/test/ci/kokoro/linux/py37_json.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "./run_integ_tests.sh"
+build_file: "run_integ_tests.sh"
 timeout_mins: 60
 
 # Get access keys from Keystore

--- a/test/ci/kokoro/linux/py37_xml.cfg
+++ b/test/ci/kokoro/linux/py37_xml.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "./run_integ_tests.sh"
+build_file: "run_integ_tests.sh"
 timeout_mins: 60
 
 # Get access keys from Keystore

--- a/test/ci/kokoro/macos/continuous.cfg
+++ b/test/ci/kokoro/macos/continuous.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "./run_integ_tests.sh"
+build_file: "run_integ_tests.sh"
 timeout_mins: 60
 
 

--- a/test/ci/kokoro/macos/presubmit.cfg
+++ b/test/ci/kokoro/macos/presubmit.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "./run_integ_tests.sh"
+build_file: "run_integ_tests.sh"
 timeout_mins: 60
 
 

--- a/test/ci/kokoro/macos/py27_json.cfg
+++ b/test/ci/kokoro/macos/py27_json.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "./run_integ_tests.sh"
+build_file: "run_integ_tests.sh"
 timeout_mins: 60
 
 

--- a/test/ci/kokoro/macos/py27_xml.cfg
+++ b/test/ci/kokoro/macos/py27_xml.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "./run_integ_tests.sh"
+build_file: "run_integ_tests.sh"
 timeout_mins: 60
 
 

--- a/test/ci/kokoro/macos/py35_json.cfg
+++ b/test/ci/kokoro/macos/py35_json.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "./run_integ_tests.sh"
+build_file: "run_integ_tests.sh"
 timeout_mins: 60
 
 

--- a/test/ci/kokoro/macos/py35_xml.cfg
+++ b/test/ci/kokoro/macos/py35_xml.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "./run_integ_tests.sh"
+build_file: "run_integ_tests.sh"
 timeout_mins: 60
 
 

--- a/test/ci/kokoro/macos/py36_json.cfg
+++ b/test/ci/kokoro/macos/py36_json.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "./run_integ_tests.sh"
+build_file: "run_integ_tests.sh"
 timeout_mins: 60
 
 

--- a/test/ci/kokoro/macos/py36_xml.cfg
+++ b/test/ci/kokoro/macos/py36_xml.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "./run_integ_tests.sh"
+build_file: "run_integ_tests.sh"
 timeout_mins: 60
 
 

--- a/test/ci/kokoro/macos/py37_json.cfg
+++ b/test/ci/kokoro/macos/py37_json.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "./run_integ_tests.sh"
+build_file: "run_integ_tests.sh"
 timeout_mins: 60
 
 

--- a/test/ci/kokoro/macos/py37_xml.cfg
+++ b/test/ci/kokoro/macos/py37_xml.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "./run_integ_tests.sh"
+build_file: "run_integ_tests.sh"
 timeout_mins: 60
 
 

--- a/test/ci/kokoro/windows/continuous.cfg
+++ b/test/ci/kokoro/windows/continuous.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "./run_integ_tests.ps1"
+build_file: "run_integ_tests.ps1"
 timeout_mins: 60
 
 

--- a/test/ci/kokoro/windows/presubmit.cfg
+++ b/test/ci/kokoro/windows/presubmit.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "./run_integ_tests.ps1"
+build_file: "run_integ_tests.ps1"
 timeout_mins: 60
 
 

--- a/test/ci/kokoro/windows/py27_json.cfg
+++ b/test/ci/kokoro/windows/py27_json.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "./run_integ_tests.ps1"
+build_file: "run_integ_tests.ps1"
 timeout_mins: 60
 
 

--- a/test/ci/kokoro/windows/py27_xml.cfg
+++ b/test/ci/kokoro/windows/py27_xml.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "./run_integ_tests.ps1"
+build_file: "run_integ_tests.ps1"
 timeout_mins: 60
 
 

--- a/test/ci/kokoro/windows/py35_json.cfg
+++ b/test/ci/kokoro/windows/py35_json.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "./run_integ_tests.ps1"
+build_file: "run_integ_tests.ps1"
 timeout_mins: 60
 
 

--- a/test/ci/kokoro/windows/py35_xml.cfg
+++ b/test/ci/kokoro/windows/py35_xml.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "./run_integ_tests.ps1"
+build_file: "run_integ_tests.ps1"
 timeout_mins: 60
 
 

--- a/test/ci/kokoro/windows/py36_json.cfg
+++ b/test/ci/kokoro/windows/py36_json.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "./run_integ_tests.ps1"
+build_file: "run_integ_tests.ps1"
 timeout_mins: 60
 
 

--- a/test/ci/kokoro/windows/py36_xml.cfg
+++ b/test/ci/kokoro/windows/py36_xml.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "./run_integ_tests.ps1"
+build_file: "run_integ_tests.ps1"
 timeout_mins: 60
 
 

--- a/test/ci/kokoro/windows/py37_json.cfg
+++ b/test/ci/kokoro/windows/py37_json.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "./run_integ_tests.ps1"
+build_file: "run_integ_tests.ps1"
 timeout_mins: 60
 
 

--- a/test/ci/kokoro/windows/py37_xml.cfg
+++ b/test/ci/kokoro/windows/py37_xml.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "./run_integ_tests.ps1"
+build_file: "run_integ_tests.ps1"
 timeout_mins: 60
 
 


### PR DESCRIPTION
Kokoro evenually concatenates the relative path with the path its
tracking. Using the ./file notation, we started getting errors like:
`/tmp/workspace/workspace/cloud_storage_gsutil/linux/py27_json/src/github/./run_integ_tests.sh`

Removed instances of `./file` with just `file` using find -exec sed:
`find . -type f -name '*.cfg' -exec sed -i
's|\"./run_integ_tests|\"run_integ_tests|g' {} \;`