### PR TITLE
Metrics Test Fixes for Windows / py3

### DIFF
--- a/gslib/metrics.py
+++ b/gslib/metrics.py
@@ -731,12 +731,17 @@ class MetricsCollector(object):
       log_file_path = '"%s"' % log_file_path
 
     reporting_code = six.ensure_str(
-        ('from gslib.metrics_reporter import ReportMetrics; '
-        'ReportMetrics("{0}", {1}, log_file_path={2})').format(
+        'from gslib.metrics_reporter import ReportMetrics; '
+        'ReportMetrics("{0}", {1}, log_file_path={2})'.format(
             temp_metrics_file.name,
             log_level,
             log_file_path))
-    execution_args = [sys.executable, '-c', reporting_code]
+    # Python 3 path in windows usually involves spaces (ex: C:\Program Files...)
+    # so it has to be wrapped in double quotes.
+    sys_exc = sys.executable
+    if system_util.IS_WINDOWS and six.PY3:
+      sys_exc = '"%s"' % sys_exc
+    execution_args = [sys_exc, '-c', reporting_code]
     exec_env = os.environ.copy()
     exec_env['PYTHONPATH'] = os.pathsep.join(sys.path)
 

--- a/gslib/metrics.py
+++ b/gslib/metrics.py
@@ -728,11 +728,11 @@ class MetricsCollector(object):
     if log_file_path is not None:
       # If the path is not None, we'll need to surround the path with quotes
       # so that the path is passed as a string to the metrics_reporter module.
-      log_file_path = '"%s"' % log_file_path
+      log_file_path = 'r"%s"' % log_file_path
 
     reporting_code = six.ensure_str(
         'from gslib.metrics_reporter import ReportMetrics; '
-        'ReportMetrics("{0}", {1}, log_file_path={2})'.format(
+        'ReportMetrics(r"{0}", {1}, log_file_path={2})'.format(
             temp_metrics_file.name,
             log_level,
             log_file_path))
@@ -744,6 +744,10 @@ class MetricsCollector(object):
     execution_args = [sys_exc, '-c', reporting_code]
     exec_env = os.environ.copy()
     exec_env['PYTHONPATH'] = os.pathsep.join(sys.path)
+
+    sm_env = dict()
+    for k, v in six.iteritems(exec_env):
+      sm_env[six.ensure_str(k)] = six.ensure_str(v)
 
     try:
       p = subprocess.Popen(execution_args, env=exec_env)

--- a/gslib/metrics.py
+++ b/gslib/metrics.py
@@ -730,11 +730,12 @@ class MetricsCollector(object):
       # so that the path is passed as a string to the metrics_reporter module.
       log_file_path = '"%s"' % log_file_path
 
-    reporting_code = ('from gslib.metrics_reporter import ReportMetrics; '
-                      'ReportMetrics("{0}", {1}, log_file_path={2})').format(
-                          temp_metrics_file.name,
-                          log_level,
-                          log_file_path).encode('utf-8').decode('unicode_escape')
+    reporting_code = six.ensure_str(
+        ('from gslib.metrics_reporter import ReportMetrics; '
+        'ReportMetrics("{0}", {1}, log_file_path={2})').format(
+            temp_metrics_file.name,
+            log_level,
+            log_file_path))
     execution_args = [sys.executable, '-c', reporting_code]
     exec_env = os.environ.copy()
     exec_env['PYTHONPATH'] = os.pathsep.join(sys.path)

--- a/gslib/metrics.py
+++ b/gslib/metrics.py
@@ -736,21 +736,17 @@ class MetricsCollector(object):
             temp_metrics_file.name,
             log_level,
             log_file_path))
-    # Python 3 path in windows usually involves spaces (ex: C:\Program Files...)
-    # so it has to be wrapped in double quotes.
-    sys_exc = sys.executable
-    if system_util.IS_WINDOWS and six.PY3:
-      sys_exc = '"%s"' % sys_exc
-    execution_args = [sys_exc, '-c', reporting_code]
+    execution_args = [sys.executable, '-c', reporting_code]
     exec_env = os.environ.copy()
     exec_env['PYTHONPATH'] = os.pathsep.join(sys.path)
-
     sm_env = dict()
     for k, v in six.iteritems(exec_env):
       sm_env[six.ensure_str(k)] = six.ensure_str(v)
-
     try:
-      p = subprocess.Popen(execution_args, env=exec_env)
+      # In order for Popen to work correctly with Windows/Py3 and spaces in the
+      # path, shell needs to be True, in addition to
+      p = subprocess.Popen(execution_args, env=sm_env, shell=(
+          six.PY3 and system_util.IS_WINDOWS))
       self.logger.debug('Metrics reporting process started...')
 
       if wait_for_report:

--- a/gslib/metrics.py
+++ b/gslib/metrics.py
@@ -720,6 +720,7 @@ class MetricsCollector(object):
       log_level = logging.WARN
 
     temp_metrics_file = tempfile.NamedTemporaryFile(delete=False)
+    temp_metrics_file_name = six.ensure_str(temp_metrics_file.name)
     with temp_metrics_file:
       pickle.dump(self._metrics, temp_metrics_file)
     logging.debug(self._metrics)
@@ -728,23 +729,24 @@ class MetricsCollector(object):
     if log_file_path is not None:
       # If the path is not None, we'll need to surround the path with quotes
       # so that the path is passed as a string to the metrics_reporter module.
-      log_file_path = 'r"%s"' % log_file_path
+      log_file_path = six.ensure_str('r"%s"' % log_file_path)
 
     reporting_code = six.ensure_str(
         'from gslib.metrics_reporter import ReportMetrics; '
         'ReportMetrics(r"{0}", {1}, log_file_path={2})'.format(
-            temp_metrics_file.name,
+            temp_metrics_file_name,
             log_level,
             log_file_path))
     execution_args = [sys.executable, '-c', reporting_code]
     exec_env = os.environ.copy()
     exec_env['PYTHONPATH'] = os.pathsep.join(sys.path)
+    # Ensuring submodule (sm) environment keys and values are all str.
     sm_env = dict()
     for k, v in six.iteritems(exec_env):
       sm_env[six.ensure_str(k)] = six.ensure_str(v)
     try:
-      # In order for Popen to work correctly with Windows/Py3 and spaces in the
-      # path, shell needs to be True, in addition to
+      # In order for Popen to work correctly with Windows/Py3 shell needs
+      # to be True.
       p = subprocess.Popen(execution_args, env=sm_env, shell=(
           six.PY3 and system_util.IS_WINDOWS))
       self.logger.debug('Metrics reporting process started...')

--- a/gslib/tests/testcase/integration_testcase.py
+++ b/gslib/tests/testcase/integration_testcase.py
@@ -883,7 +883,7 @@ class GsUtilIntegrationTestCase(base.GsUtilTestCase):
         else:
           stdin = (stdin + os.linesep).encode('utf-8')
       else:
-          stdin = (stdin + os.linesep).encode('utf-8')
+        stdin = (stdin + os.linesep).encode('utf-8')
     # checking to see if test was invoked from a par file (bundled archive)
     # if not, add python executable path to ensure correct version of python
     # is used for testing


### PR DESCRIPTION
## gsutil metrics test changes for Python3 in Windows

* Changes around submodule Popen to work with Windows / Py3

* Style Guide Indentation Change

* Standardize env_vars

* Add Raw String option

NOTE: All Metrics tests remain passing in macOS & Linux with the above changes