### PR TITLE
Updated .boto config path in environment variables.

### DIFF
--- a/test/ci/kokoro/linux/py27_json.cfg
+++ b/test/ci/kokoro/linux/py27_json.cfg
@@ -41,5 +41,5 @@ env_vars {
 
 env_vars {
   key: "BOTO_CONFIG"
-  value: "/src/config/.boto_json"
+  value: "/tmpfs/src/.boto_json"
 }

--- a/test/ci/kokoro/linux/py27_xml.cfg
+++ b/test/ci/kokoro/linux/py27_xml.cfg
@@ -41,5 +41,5 @@ env_vars {
 
 env_vars {
   key: "BOTO_CONFIG"
-  value: "/src/config/.boto_xml"
+  value: "/tmpfs/src/.boto_xml"
 }

--- a/test/ci/kokoro/linux/py35_json.cfg
+++ b/test/ci/kokoro/linux/py35_json.cfg
@@ -41,5 +41,5 @@ env_vars {
 
 env_vars {
   key: "BOTO_CONFIG"
-  value: "/src/config/.boto_json"
+  value: "/tmpfs/src/.boto_json"
 }

--- a/test/ci/kokoro/linux/py35_xml.cfg
+++ b/test/ci/kokoro/linux/py35_xml.cfg
@@ -41,5 +41,5 @@ env_vars {
 
 env_vars {
   key: "BOTO_CONFIG"
-  value: "/src/config/.boto_xml"
+  value: "/tmpfs/src/.boto_xml"
 }

--- a/test/ci/kokoro/linux/py36_json.cfg
+++ b/test/ci/kokoro/linux/py36_json.cfg
@@ -41,5 +41,5 @@ env_vars {
 
 env_vars {
   key: "BOTO_CONFIG"
-  value: "/src/config/.boto_json"
+  value: "/tmpfs/src/.boto_json"
 }

--- a/test/ci/kokoro/linux/py36_xml.cfg
+++ b/test/ci/kokoro/linux/py36_xml.cfg
@@ -41,5 +41,5 @@ env_vars {
 
 env_vars {
   key: "BOTO_CONFIG"
-  value: "/src/config/.boto_xml"
+  value: "/tmpfs/src/.boto_xml"
 }

--- a/test/ci/kokoro/linux/py37_json.cfg
+++ b/test/ci/kokoro/linux/py37_json.cfg
@@ -41,5 +41,5 @@ env_vars {
 
 env_vars {
   key: "BOTO_CONFIG"
-  value: "/src/config/.boto_json"
+  value: "/tmpfs/src/.boto_json"
 }

--- a/test/ci/kokoro/linux/py37_xml.cfg
+++ b/test/ci/kokoro/linux/py37_xml.cfg
@@ -41,5 +41,5 @@ env_vars {
 
 env_vars {
   key: "BOTO_CONFIG"
-  value: "/src/config/.boto_xml"
+  value: "/tmpfs/src/.boto_xml"
 }

--- a/test/ci/kokoro/macos/py27_json.cfg
+++ b/test/ci/kokoro/macos/py27_json.cfg
@@ -42,5 +42,5 @@ env_vars {
 
 env_vars {
   key: "BOTO_CONFIG"
-  value: "/src/config/.boto_json"
+  value: "/tmpfs/src/.boto_json"
 }

--- a/test/ci/kokoro/macos/py27_xml.cfg
+++ b/test/ci/kokoro/macos/py27_xml.cfg
@@ -42,5 +42,5 @@ env_vars {
 
 env_vars {
   key: "BOTO_CONFIG"
-  value: "/src/config/.boto_xml"
+  value: "/tmpfs/src/.boto_xml"
 }

--- a/test/ci/kokoro/macos/py35_json.cfg
+++ b/test/ci/kokoro/macos/py35_json.cfg
@@ -42,5 +42,5 @@ env_vars {
 
 env_vars {
   key: "BOTO_CONFIG"
-  value: "/src/config/.boto_json"
+  value: "/tmpfs/src/.boto_json"
 }

--- a/test/ci/kokoro/macos/py35_xml.cfg
+++ b/test/ci/kokoro/macos/py35_xml.cfg
@@ -42,5 +42,5 @@ env_vars {
 
 env_vars {
   key: "BOTO_CONFIG"
-  value: "/src/config/.boto_xml"
+  value: "/tmpfs/src/.boto_xml"
 }

--- a/test/ci/kokoro/macos/py36_json.cfg
+++ b/test/ci/kokoro/macos/py36_json.cfg
@@ -42,5 +42,5 @@ env_vars {
 
 env_vars {
   key: "BOTO_CONFIG"
-  value: "/src/config/.boto_json"
+  value: "/tmpfs/src/.boto_json"
 }

--- a/test/ci/kokoro/macos/py36_xml.cfg
+++ b/test/ci/kokoro/macos/py36_xml.cfg
@@ -42,5 +42,5 @@ env_vars {
 
 env_vars {
   key: "BOTO_CONFIG"
-  value: "/src/config/.boto_xml"
+  value: "/tmpfs/src/.boto_xml"
 }

--- a/test/ci/kokoro/macos/py37_json.cfg
+++ b/test/ci/kokoro/macos/py37_json.cfg
@@ -42,5 +42,5 @@ env_vars {
 
 env_vars {
   key: "BOTO_CONFIG"
-  value: "/src/config/.boto_json"
+  value: "/tmpfs/src/.boto_json"
 }

--- a/test/ci/kokoro/macos/py37_xml.cfg
+++ b/test/ci/kokoro/macos/py37_xml.cfg
@@ -42,5 +42,5 @@ env_vars {
 
 env_vars {
   key: "BOTO_CONFIG"
-  value: "/src/config/.boto_xml"
+  value: "/tmpfs/src/.boto_xml"
 }

--- a/test/ci/kokoro/windows/py27_json.cfg
+++ b/test/ci/kokoro/windows/py27_json.cfg
@@ -54,5 +54,5 @@ env_vars {
 
 env_vars {
   key: "BOTO_CONFIG"
-  value: "/src/config/.boto_json"
+  value: "/tmpfs/src/.boto_json"
 }

--- a/test/ci/kokoro/windows/py27_xml.cfg
+++ b/test/ci/kokoro/windows/py27_xml.cfg
@@ -54,5 +54,5 @@ env_vars {
 
 env_vars {
   key: "BOTO_CONFIG"
-  value: "/src/config/.boto_xml"
+  value: "/tmpfs/src/.boto_xml"
 }

--- a/test/ci/kokoro/windows/py35_json.cfg
+++ b/test/ci/kokoro/windows/py35_json.cfg
@@ -54,5 +54,5 @@ env_vars {
 
 env_vars {
   key: "BOTO_CONFIG"
-  value: "/src/config/.boto_json"
+  value: "/tmpfs/src/.boto_json"
 }

--- a/test/ci/kokoro/windows/py35_xml.cfg
+++ b/test/ci/kokoro/windows/py35_xml.cfg
@@ -54,5 +54,5 @@ env_vars {
 
 env_vars {
   key: "BOTO_CONFIG"
-  value: "/src/config/.boto_xml"
+  value: "/tmpfs/src/.boto_xml"
 }

--- a/test/ci/kokoro/windows/py36_json.cfg
+++ b/test/ci/kokoro/windows/py36_json.cfg
@@ -54,5 +54,5 @@ env_vars {
 
 env_vars {
   key: "BOTO_CONFIG"
-  value: "/src/config/.boto_json"
+  value: "/tmpfs/src/.boto_json"
 }

--- a/test/ci/kokoro/windows/py36_xml.cfg
+++ b/test/ci/kokoro/windows/py36_xml.cfg
@@ -54,5 +54,5 @@ env_vars {
 
 env_vars {
   key: "BOTO_CONFIG"
-  value: "/src/config/.boto_xml"
+  value: "/tmpfs/src/.boto_xml"
 }

--- a/test/ci/kokoro/windows/py37_json.cfg
+++ b/test/ci/kokoro/windows/py37_json.cfg
@@ -54,5 +54,5 @@ env_vars {
 
 env_vars {
   key: "BOTO_CONFIG"
-  value: "/src/config/.boto_json"
+  value: "/tmpfs/src/.boto_json"
 }

--- a/test/ci/kokoro/windows/py37_xml.cfg
+++ b/test/ci/kokoro/windows/py37_xml.cfg
@@ -54,5 +54,5 @@ env_vars {
 
 env_vars {
   key: "BOTO_CONFIG"
-  value: "/src/config/.boto_xml"
+  value: "/tmpfs/src/.boto_xml"
 }


### PR DESCRIPTION
This commit comes in advance of some upcoming test script changes being run on the ci-testing branch.

.boto config files are now found in the path
/tmpfs/src/.boto_[json|xml]

These files were updated with find -exec sed:

`find . -type f -name '*.cfg' -exec sed -i
's|/src/config/.boto_json|/tmpfs/src/.boto_json|g' {} \;`

`find . -type f -name '*.cfg' -exec sed -i
's|/src/config/.boto_xml|/tmpfs/src/.boto_xml|g' {} \;`