### PR TITLE
Print trace in debug mode for rsync sync failures

### DIFF
--- a/gslib/commands/rsync.py
+++ b/gslib/commands/rsync.py
@@ -644,6 +644,9 @@ def _ListUrlRootFunc(cls, args_tuple, thread_state=None):
     cls.logger.error(
         'Caught non-retryable exception while listing %s: %s' %
         (base_url_str, e))
+    # Also print the full stack trace in debugging mode. This makes debugging
+    # a bit easier.
+    cls.logger.debug(traceback.format_exc())
     cls.non_retryable_listing_failures = 1
   out_file.close()
 


### PR DESCRIPTION
In the event of a failure (e.g. due to encoding oddities), the only
thing you currently see is a one-line summary of the error. Seeing
exactly where the error came from would be more helpful for debugging.