### PR TITLE
Refactored `ttyprint` and `ttywrite`

### DIFF
--- a/gslib/__main__.py
+++ b/gslib/__main__.py
@@ -168,7 +168,7 @@ def _OutputAndExit(message, exception=None):
   else:
     err = '%s\n' % message
   try:
-    text_util.ttyprint(err, end='', file=sys.stderr)
+    text_util.print_to_fd(err, end='', file=sys.stderr)
   except UnicodeDecodeError:
     # Can happen when outputting invalid Unicode filenames.
     sys.stderr.write(err)

--- a/gslib/command_runner.py
+++ b/gslib/command_runner.py
@@ -58,7 +58,7 @@ from gslib.utils.parallelism_framework_util import CheckMultiprocessingAvailable
 from gslib.utils.text_util import CompareVersions
 from gslib.utils.text_util import InsistAsciiHeader
 from gslib.utils.text_util import InsistAsciiHeaderValue
-from gslib.utils.text_util import ttyprint
+from gslib.utils.text_util import print_to_fd
 from gslib.utils.unit_util import SECONDS_PER_DAY
 from gslib.utils.update_util import LookUpGsutilVersion
 from gslib.tests.util import HAS_NON_DEFAULT_GS_HOST
@@ -480,7 +480,7 @@ class CommandRunner(object):
         f.write(str(cur_ts))
       (g, m) = CompareVersions(cur_ver, gslib.VERSION)
       if m:
-        ttyprint('\n'.join(textwrap.wrap(
+        print_to_fd('\n'.join(textwrap.wrap(
             'A newer version of gsutil (%s) is available than the version you '
             'are running (%s). NOTE: This is a major new version, so it is '
             'strongly recommended that you review the release note details at '
@@ -488,18 +488,18 @@ class CommandRunner(object):
             'in scripts.' % (cur_ver, gslib.VERSION, RELEASE_NOTES_URL))))
         if gslib.IS_PACKAGE_INSTALL:
           return False
-        ttyprint('\n')
+        print_to_fd('\n')
         answer = input('Would you like to update [y/N]? ')
         return answer and answer.lower()[0] == 'y'
       elif g:
-        ttyprint('\n'.join(textwrap.wrap(
+        print_to_fd('\n'.join(textwrap.wrap(
             'A newer version of gsutil (%s) is available than the version you '
             'are running (%s). A detailed log of gsutil release changes is '
             'available at %s if you would like to read them before updating.'
             % (cur_ver, gslib.VERSION, RELEASE_NOTES_URL))))
         if gslib.IS_PACKAGE_INSTALL:
           return False
-        ttyprint('\n')
+        print_to_fd('\n')
         answer = input('Would you like to update [Y/n]? ')
         return not answer or answer.lower()[0] != 'n'
     return False

--- a/gslib/commands/du.py
+++ b/gslib/commands/du.py
@@ -34,7 +34,7 @@ from gslib.utils import ls_helper
 from gslib.utils.constants import NO_MAX
 from gslib.utils.constants import S3_DELETE_MARKER_GUID
 from gslib.utils.constants import UTF8
-from gslib.utils.text_util import ttyprint
+from gslib.utils.text_util import print_to_fd
 from gslib.utils.unit_util import MakeHumanReadable
 from gslib.utils import text_util
 
@@ -152,7 +152,7 @@ class DuCommand(Command):
     if six.PY2:
       name = name.decode(UTF8)
 
-    text_util.ttyprint('{size:<11}  {name}'.format(
+    text_util.print_to_fd('{size:<11}  {name}'.format(
         size=size_string,
         name=six.ensure_text(name)), end=self.line_ending)
 
@@ -187,7 +187,7 @@ class DuCommand(Command):
           size=size_string,
           url=six.ensure_text(url_str),
           ending=six.ensure_text(self.line_ending))
-      ttyprint(url_detail, file=sys.stdout, end='')
+      print_to_fd(url_detail, file=sys.stdout, end='')
 
     return (num_objs, num_bytes)
 

--- a/gslib/commands/hash.py
+++ b/gslib/commands/hash.py
@@ -215,9 +215,9 @@ class HashCommand(Command):
             hash_dict['md5'] = obj_metadata.md5Hash
           if crc32c_present:
             hash_dict['crc32c'] = obj_metadata.crc32c
-        text_util.ttyprint('Hashes [%s] for %s:' % (output_format, file_name))
+        text_util.print_to_fd('Hashes [%s] for %s:' % (output_format, file_name))
         for name, digest in six.iteritems(hash_dict):
-          text_util.ttyprint('\tHash (%s):\t\t%s' % (name,
+          text_util.print_to_fd('\tHash (%s):\t\t%s' % (name,
                                         (format_func(digest) if url.IsFileUrl()
                                          else cloud_format_func(digest))))
 

--- a/gslib/commands/help.py
+++ b/gslib/commands/help.py
@@ -192,7 +192,7 @@ class HelpCommand(Command):
     if IS_WINDOWS or not IsRunningInteractively():
       help_str = re.sub('<B>', '', help_str)
       help_str = re.sub('</B>', '', help_str)
-      text_util.ttyprint(help_str)
+      text_util.print_to_fd(help_str)
       return
     help_str = re.sub('<B>', '\033[1m', help_str)
     help_str = re.sub('</B>', '\033[0;0m', help_str)
@@ -208,7 +208,7 @@ class HelpCommand(Command):
         raise CommandException('Unable to open pager (%s): %s' %
                                (' '.join(pager), e))
     else:
-      text_util.ttyprint(help_str)
+      text_util.print_to_fd(help_str)
 
   def _LoadHelpMaps(self):
     """Returns tuple of help type and help name.

--- a/gslib/commands/logging.py
+++ b/gslib/commands/logging.py
@@ -163,15 +163,15 @@ class LoggingCommand(Command):
         self.args[0], bucket_fields=['logging'])
 
     if bucket_url.scheme == 's3':
-      text_util.ttyprint(self.gsutil_api.XmlPassThroughGetLogging(
+      text_util.print_to_fd(self.gsutil_api.XmlPassThroughGetLogging(
           bucket_url, provider=bucket_url.scheme), end='')
     else:
       if (bucket_metadata.logging and bucket_metadata.logging.logBucket and
           bucket_metadata.logging.logObjectPrefix):
-        text_util.ttyprint(str(encoding.MessageToJson(
+        text_util.print_to_fd(str(encoding.MessageToJson(
             bucket_metadata.logging)))
       else:
-        text_util.ttyprint('%s has no logging configuration.' % bucket_url)
+        text_util.print_to_fd('%s has no logging configuration.' % bucket_url)
     return 0
 
   def _Enable(self):

--- a/gslib/commands/ls.py
+++ b/gslib/commands/ls.py
@@ -322,7 +322,7 @@ class LsCommand(Command):
     """
     if (listing_style == ListingStyle.SHORT or
         listing_style == ListingStyle.LONG):
-      text_util.ttyprint(bucket_blr)
+      text_util.print_to_fd(bucket_blr)
       return
     # listing_style == ListingStyle.LONG_LONG:
     # We're guaranteed by the caller that the root object is populated.
@@ -405,7 +405,7 @@ class LsCommand(Command):
                                          '{bucket_policy_only_enabled}\n')
 
 
-    text_util.ttyprint((('{bucket} :\n'
+    text_util.print_to_fd((('{bucket} :\n'
            '\tStorage class:\t\t\t{storage_class}\n'
            '\tLocation constraint:\t\t{location_constraint}\n'
            '\tVersioning enabled:\t\t{versioning}\n'
@@ -425,7 +425,7 @@ class LsCommand(Command):
            '\tACL:\t\t\t\t{acl}\n'
            '\tDefault ACL:\t\t\t{default_acl}').format(**fields)))
     if bucket_blr.storage_url.scheme == 's3':
-      text_util.ttyprint('Note: this is an S3 bucket so configuration values may be '
+      text_util.print_to_fd('Note: this is an S3 bucket so configuration values may be '
             'blank. To retrieve bucket configuration values, use '
             'individual configuration commands such as gsutil acl get '
             '<bucket>.')
@@ -463,7 +463,7 @@ class LsCommand(Command):
         'metageneration': encoded_metagen,
         'etag': encoded_etag
     }
-    text_util.ttyprint(printstr % format_args)
+    text_util.print_to_fd(printstr % format_args)
     return (num_objs, num_bytes)
 
   def RunCommand(self):
@@ -509,7 +509,7 @@ class LsCommand(Command):
 
     def MaybePrintBucketHeader(blr):
       if len(self.args) > 1:
-        text_util.ttyprint('%s:' % blr.url_string.decode('utf-8'))
+        text_util.print_to_fd('%s:' % blr.url_string.decode('utf-8'))
     print_bucket_header = MaybePrintBucketHeader
 
     for url_str in self.args:
@@ -566,7 +566,7 @@ class LsCommand(Command):
         # URL names a bucket, object, or object subdir ->
         # list matching object(s) / subdirs.
         def _PrintPrefixLong(blr):
-          text_util.ttyprint('%-33s%s' % ('', blr.url_string.decode('utf-8')))
+          text_util.print_to_fd('%-33s%s' % ('', blr.url_string.decode('utf-8')))
 
         if listing_style == ListingStyle.SHORT:
           # ls helper by default readies us for a short listing.
@@ -617,7 +617,7 @@ class LsCommand(Command):
         total_objs += exp_objs
 
     if total_objs and listing_style != ListingStyle.SHORT:
-      text_util.ttyprint(('TOTAL: %d objects, %d bytes (%s)' %
+      text_util.print_to_fd(('TOTAL: %d objects, %d bytes (%s)' %
              (total_objs, total_bytes, MakeHumanReadable(float(total_bytes)))))
     if got_nomatch_errors:
       raise CommandException('One or more URLs matched no objects.')

--- a/gslib/commands/perfdiag.py
+++ b/gslib/commands/perfdiag.py
@@ -1647,148 +1647,148 @@ class PerfDiagCommand(Command):
     mean = float(sum(trials)) / n
     stdev = math.sqrt(sum((x - mean)**2 for x in trials) / n)
 
-    text_util.ttyprint(str(n).rjust(6), '', end=' ')
-    text_util.ttyprint(('%.1f' % (mean * 1000)).rjust(9), '', end=' ')
-    text_util.ttyprint(('%.1f' % (stdev * 1000)).rjust(12), '', end=' ')
-    text_util.ttyprint(('%.1f' % (Percentile(trials, 0.5) * 1000)).rjust(11), '', end=' ')
-    text_util.ttyprint(('%.1f' % (Percentile(trials, 0.9) * 1000)).rjust(11), '')
+    text_util.print_to_fd(str(n).rjust(6), '', end=' ')
+    text_util.print_to_fd(('%.1f' % (mean * 1000)).rjust(9), '', end=' ')
+    text_util.print_to_fd(('%.1f' % (stdev * 1000)).rjust(12), '', end=' ')
+    text_util.print_to_fd(('%.1f' % (Percentile(trials, 0.5) * 1000)).rjust(11), '', end=' ')
+    text_util.print_to_fd(('%.1f' % (Percentile(trials, 0.9) * 1000)).rjust(11), '')
 
   def _DisplayResults(self):
     """Displays results collected from diagnostic run."""
-    text_util.ttyprint()
-    text_util.ttyprint('=' * 78)
-    text_util.ttyprint('DIAGNOSTIC RESULTS'.center(78))
-    text_util.ttyprint('=' * 78)
+    text_util.print_to_fd()
+    text_util.print_to_fd('=' * 78)
+    text_util.print_to_fd('DIAGNOSTIC RESULTS'.center(78))
+    text_util.print_to_fd('=' * 78)
 
     if 'latency' in self.results:
-      text_util.ttyprint()
-      text_util.ttyprint('-' * 78)
-      text_util.ttyprint('Latency'.center(78))
-      text_util.ttyprint('-' * 78)
-      text_util.ttyprint('Operation       Size  Trials  Mean (ms)  Std Dev (ms)  '
+      text_util.print_to_fd()
+      text_util.print_to_fd('-' * 78)
+      text_util.print_to_fd('Latency'.center(78))
+      text_util.print_to_fd('-' * 78)
+      text_util.print_to_fd('Operation       Size  Trials  Mean (ms)  Std Dev (ms)  '
              'Median (ms)  90th % (ms)')
-      text_util.ttyprint('=========  =========  ======  =========  ============  '
+      text_util.print_to_fd('=========  =========  ======  =========  ============  '
              '===========  ===========')
       for key in sorted(self.results['latency']):
         trials = sorted(self.results['latency'][key])
         op, numbytes = key.split('_')
         numbytes = int(numbytes)
         if op == 'METADATA':
-          text_util.ttyprint('Metadata'.rjust(9), '', end=' ')
-          text_util.ttyprint(MakeHumanReadable(numbytes).rjust(9), '', end=' ')
+          text_util.print_to_fd('Metadata'.rjust(9), '', end=' ')
+          text_util.print_to_fd(MakeHumanReadable(numbytes).rjust(9), '', end=' ')
           self._DisplayStats(trials)
         if op == 'DOWNLOAD':
-          text_util.ttyprint('Download'.rjust(9), '', end=' ')
-          text_util.ttyprint(MakeHumanReadable(numbytes).rjust(9), '', end=' ')
+          text_util.print_to_fd('Download'.rjust(9), '', end=' ')
+          text_util.print_to_fd(MakeHumanReadable(numbytes).rjust(9), '', end=' ')
           self._DisplayStats(trials)
         if op == 'UPLOAD':
-          text_util.ttyprint('Upload'.rjust(9), '', end=' ')
-          text_util.ttyprint(MakeHumanReadable(numbytes).rjust(9), '', end=' ')
+          text_util.print_to_fd('Upload'.rjust(9), '', end=' ')
+          text_util.print_to_fd(MakeHumanReadable(numbytes).rjust(9), '', end=' ')
           self._DisplayStats(trials)
         if op == 'DELETE':
-          text_util.ttyprint('Delete'.rjust(9), '', end=' ')
-          text_util.ttyprint(MakeHumanReadable(numbytes).rjust(9), '', end=' ')
+          text_util.print_to_fd('Delete'.rjust(9), '', end=' ')
+          text_util.print_to_fd(MakeHumanReadable(numbytes).rjust(9), '', end=' ')
           self._DisplayStats(trials)
 
     if 'write_throughput' in self.results:
-      text_util.ttyprint()
-      text_util.ttyprint('-' * 78)
-      text_util.ttyprint('Write Throughput'.center(78))
-      text_util.ttyprint('-' * 78)
+      text_util.print_to_fd()
+      text_util.print_to_fd('-' * 78)
+      text_util.print_to_fd('Write Throughput'.center(78))
+      text_util.print_to_fd('-' * 78)
       write_thru = self.results['write_throughput']
-      text_util.ttyprint('Copied %s %s file(s) for a total transfer size of %s.' % (
+      text_util.print_to_fd('Copied %s %s file(s) for a total transfer size of %s.' % (
           self.num_objects,
           MakeHumanReadable(write_thru['file_size']),
           MakeHumanReadable(write_thru['total_bytes_copied'])))
-      text_util.ttyprint('Write throughput: %s/s.' % (
+      text_util.print_to_fd('Write throughput: %s/s.' % (
           MakeBitsHumanReadable(write_thru['bytes_per_second'] * 8)))
       if 'parallelism' in write_thru:  # Compatibility with old versions.
-        text_util.ttyprint('Parallelism strategy: %s' % write_thru['parallelism'])
+        text_util.print_to_fd('Parallelism strategy: %s' % write_thru['parallelism'])
 
     if 'write_throughput_file' in self.results:
-      text_util.ttyprint()
-      text_util.ttyprint('-' * 78)
-      text_util.ttyprint('Write Throughput With File I/O'.center(78))
-      text_util.ttyprint('-' * 78)
+      text_util.print_to_fd()
+      text_util.print_to_fd('-' * 78)
+      text_util.print_to_fd('Write Throughput With File I/O'.center(78))
+      text_util.print_to_fd('-' * 78)
       write_thru_file = self.results['write_throughput_file']
-      text_util.ttyprint('Copied %s %s file(s) for a total transfer size of %s.' % (
+      text_util.print_to_fd('Copied %s %s file(s) for a total transfer size of %s.' % (
           self.num_objects,
           MakeHumanReadable(write_thru_file['file_size']),
           MakeHumanReadable(write_thru_file['total_bytes_copied'])))
-      text_util.ttyprint('Write throughput: %s/s.' % (
+      text_util.print_to_fd('Write throughput: %s/s.' % (
           MakeBitsHumanReadable(write_thru_file['bytes_per_second'] * 8)))
       if 'parallelism' in write_thru_file:  # Compatibility with old versions.
-        text_util.ttyprint('Parallelism strategy: %s' % write_thru_file['parallelism'])
+        text_util.print_to_fd('Parallelism strategy: %s' % write_thru_file['parallelism'])
 
     if 'read_throughput' in self.results:
-      text_util.ttyprint()
-      text_util.ttyprint('-' * 78)
-      text_util.ttyprint('Read Throughput'.center(78))
-      text_util.ttyprint('-' * 78)
+      text_util.print_to_fd()
+      text_util.print_to_fd('-' * 78)
+      text_util.print_to_fd('Read Throughput'.center(78))
+      text_util.print_to_fd('-' * 78)
       read_thru = self.results['read_throughput']
-      text_util.ttyprint('Copied %s %s file(s) for a total transfer size of %s.' % (
+      text_util.print_to_fd('Copied %s %s file(s) for a total transfer size of %s.' % (
           self.num_objects,
           MakeHumanReadable(read_thru['file_size']),
           MakeHumanReadable(read_thru['total_bytes_copied'])))
-      text_util.ttyprint('Read throughput: %s/s.' % (
+      text_util.print_to_fd('Read throughput: %s/s.' % (
           MakeBitsHumanReadable(read_thru['bytes_per_second'] * 8)))
       if 'parallelism' in read_thru:  # Compatibility with old versions.
-        text_util.ttyprint('Parallelism strategy: %s' % read_thru['parallelism'])
+        text_util.print_to_fd('Parallelism strategy: %s' % read_thru['parallelism'])
 
     if 'read_throughput_file' in self.results:
-      text_util.ttyprint()
-      text_util.ttyprint('-' * 78)
-      text_util.ttyprint('Read Throughput With File I/O'.center(78))
-      text_util.ttyprint('-' * 78)
+      text_util.print_to_fd()
+      text_util.print_to_fd('-' * 78)
+      text_util.print_to_fd('Read Throughput With File I/O'.center(78))
+      text_util.print_to_fd('-' * 78)
       read_thru_file = self.results['read_throughput_file']
-      text_util.ttyprint('Copied %s %s file(s) for a total transfer size of %s.' % (
+      text_util.print_to_fd('Copied %s %s file(s) for a total transfer size of %s.' % (
           self.num_objects,
           MakeHumanReadable(read_thru_file['file_size']),
           MakeHumanReadable(read_thru_file['total_bytes_copied'])))
-      text_util.ttyprint('Read throughput: %s/s.' % (
+      text_util.print_to_fd('Read throughput: %s/s.' % (
           MakeBitsHumanReadable(read_thru_file['bytes_per_second'] * 8)))
       if 'parallelism' in read_thru_file:  # Compatibility with old versions.
-        text_util.ttyprint('Parallelism strategy: %s' % read_thru_file['parallelism'])
+        text_util.print_to_fd('Parallelism strategy: %s' % read_thru_file['parallelism'])
 
     if 'listing' in self.results:
-      text_util.ttyprint()
-      text_util.ttyprint('-' * 78)
-      text_util.ttyprint('Listing'.center(78))
-      text_util.ttyprint('-' * 78)
+      text_util.print_to_fd()
+      text_util.print_to_fd('-' * 78)
+      text_util.print_to_fd('Listing'.center(78))
+      text_util.print_to_fd('-' * 78)
 
       listing = self.results['listing']
       insert = listing['insert']
       delete = listing['delete']
-      text_util.ttyprint('After inserting %s objects:' % listing['num_files'])
-      text_util.ttyprint(('  Total time for objects to appear: %.2g seconds' %
+      text_util.print_to_fd('After inserting %s objects:' % listing['num_files'])
+      text_util.print_to_fd(('  Total time for objects to appear: %.2g seconds' %
              insert['time_took']))
-      text_util.ttyprint('  Number of listing calls made: %s' % insert['num_listing_calls'])
-      text_util.ttyprint(('  Individual listing call latencies: [%s]' %
+      text_util.print_to_fd('  Number of listing calls made: %s' % insert['num_listing_calls'])
+      text_util.print_to_fd(('  Individual listing call latencies: [%s]' %
              ', '.join('%.2gs' % lat for lat in insert['list_latencies'])))
-      text_util.ttyprint(('  Files reflected after each call: [%s]' %
+      text_util.print_to_fd(('  Files reflected after each call: [%s]' %
              ', '.join(map(str, insert['files_seen_after_listing']))))
 
-      text_util.ttyprint('After deleting %s objects:' % listing['num_files'])
-      text_util.ttyprint(('  Total time for objects to appear: %.2g seconds' %
+      text_util.print_to_fd('After deleting %s objects:' % listing['num_files'])
+      text_util.print_to_fd(('  Total time for objects to appear: %.2g seconds' %
              delete['time_took']))
-      text_util.ttyprint('  Number of listing calls made: %s' % delete['num_listing_calls'])
-      text_util.ttyprint(('  Individual listing call latencies: [%s]' %
+      text_util.print_to_fd('  Number of listing calls made: %s' % delete['num_listing_calls'])
+      text_util.print_to_fd(('  Individual listing call latencies: [%s]' %
              ', '.join('%.2gs' % lat for lat in delete['list_latencies'])))
-      text_util.ttyprint(('  Files reflected after each call: [%s]' %
+      text_util.print_to_fd(('  Files reflected after each call: [%s]' %
              ', '.join(map(str, delete['files_seen_after_listing']))))
 
     if 'sysinfo' in self.results:
-      text_util.ttyprint()
-      text_util.ttyprint('-' * 78)
-      text_util.ttyprint('System Information'.center(78))
-      text_util.ttyprint('-' * 78)
+      text_util.print_to_fd()
+      text_util.print_to_fd('-' * 78)
+      text_util.print_to_fd('System Information'.center(78))
+      text_util.print_to_fd('-' * 78)
       info = self.results['sysinfo']
-      text_util.ttyprint('IP Address: \n  %s' % info['ip_address'])
-      text_util.ttyprint('Temporary Directory: \n  %s' % info['tempdir'])
-      text_util.ttyprint('Bucket URI: \n  %s' % self.results['bucket_uri'])
-      text_util.ttyprint('gsutil Version: \n  %s' % self.results.get('gsutil_version',
+      text_util.print_to_fd('IP Address: \n  %s' % info['ip_address'])
+      text_util.print_to_fd('Temporary Directory: \n  %s' % info['tempdir'])
+      text_util.print_to_fd('Bucket URI: \n  %s' % self.results['bucket_uri'])
+      text_util.print_to_fd('gsutil Version: \n  %s' % self.results.get('gsutil_version',
                                                         'Unknown'))
-      text_util.ttyprint('boto Version: \n  %s' % self.results.get('boto_version', 'Unknown'))
+      text_util.print_to_fd('boto Version: \n  %s' % self.results.get('boto_version', 'Unknown'))
 
       if 'gmt_timestamp' in info:
         ts_string = info['gmt_timestamp']
@@ -1803,29 +1803,29 @@ class PerfDiagCommand(Command):
           # Converts the GMT time tuple to local Linux timestamp.
           localtime = calendar.timegm(timetuple)
           localdt = datetime.datetime.fromtimestamp(localtime)
-          text_util.ttyprint('Measurement time: \n %s' % localdt.strftime(
+          text_util.print_to_fd('Measurement time: \n %s' % localdt.strftime(
               '%Y-%m-%d %I:%M:%S %p %Z'))
 
       if 'on_gce' in info:
-        text_util.ttyprint('Running on GCE: \n  %s' % info['on_gce'])
+        text_util.print_to_fd('Running on GCE: \n  %s' % info['on_gce'])
         if info['on_gce']:
-          text_util.ttyprint('GCE Instance:\n\t%s' %
+          text_util.print_to_fd('GCE Instance:\n\t%s' %
                  info['gce_instance_info'].replace('\n', '\n\t'))
-      text_util.ttyprint('Bucket location: \n  %s' % info['bucket_location'])
-      text_util.ttyprint('Bucket storage class: \n  %s' % info['bucket_storageClass'])
-      text_util.ttyprint('Google Server: \n  %s' % info['googserv_route'])
-      text_util.ttyprint('Google Server IP Addresses: \n  %s' %
+      text_util.print_to_fd('Bucket location: \n  %s' % info['bucket_location'])
+      text_util.print_to_fd('Bucket storage class: \n  %s' % info['bucket_storageClass'])
+      text_util.print_to_fd('Google Server: \n  %s' % info['googserv_route'])
+      text_util.print_to_fd('Google Server IP Addresses: \n  %s' %
              ('\n  '.join(info['googserv_ips'])))
-      text_util.ttyprint('Google Server Hostnames: \n  %s' %
+      text_util.print_to_fd('Google Server Hostnames: \n  %s' %
              ('\n  '.join(info['googserv_hostnames'])))
-      text_util.ttyprint('Google DNS thinks your IP is: \n  %s' % info['dns_o-o_ip'])
-      text_util.ttyprint('CPU Count: \n  %s' % info['cpu_count'])
-      text_util.ttyprint('CPU Load Average: \n  %s' % info['load_avg'])
+      text_util.print_to_fd('Google DNS thinks your IP is: \n  %s' % info['dns_o-o_ip'])
+      text_util.print_to_fd('CPU Count: \n  %s' % info['cpu_count'])
+      text_util.print_to_fd('CPU Load Average: \n  %s' % info['load_avg'])
       try:
-        text_util.ttyprint(('Total Memory: \n  %s' %
+        text_util.print_to_fd(('Total Memory: \n  %s' %
                MakeHumanReadable(info['meminfo']['mem_total'])))
         # Free memory is really MemFree + Buffers + Cached.
-        text_util.ttyprint('Free Memory: \n  %s' % MakeHumanReadable(
+        text_util.print_to_fd('Free Memory: \n  %s' % MakeHumanReadable(
             info['meminfo']['mem_free'] +
             info['meminfo']['mem_buffers'] +
             info['meminfo']['mem_cached']))
@@ -1839,90 +1839,90 @@ class PerfDiagCommand(Command):
           try:
             delta = (netstat_after['tcp_%s' % tcp_type] -
                      netstat_before['tcp_%s' % tcp_type])
-            text_util.ttyprint('TCP segments %s during test:\n  %d' % (tcp_type, delta))
+            text_util.print_to_fd('TCP segments %s during test:\n  %d' % (tcp_type, delta))
           except TypeError:
             pass
       else:
-        text_util.ttyprint('TCP segment counts not available because "netstat" was not '
+        text_util.print_to_fd('TCP segment counts not available because "netstat" was not '
                'found during test runs')
 
       if 'disk_counters_end' in info and 'disk_counters_start' in info:
-        text_util.ttyprint('Disk Counter Deltas:\n', end=' ')
+        text_util.print_to_fd('Disk Counter Deltas:\n', end=' ')
         disk_after = info['disk_counters_end']
         disk_before = info['disk_counters_start']
-        text_util.ttyprint('', 'disk'.rjust(6), end=' ')
+        text_util.print_to_fd('', 'disk'.rjust(6), end=' ')
         for colname in ['reads', 'writes', 'rbytes', 'wbytes', 'rtime',
                         'wtime']:
-          text_util.ttyprint(colname.rjust(8), end=' ')
-        text_util.ttyprint()
+          text_util.print_to_fd(colname.rjust(8), end=' ')
+        text_util.print_to_fd()
         for diskname in sorted(disk_after):
           before = disk_before[diskname]
           after = disk_after[diskname]
           (reads1, writes1, rbytes1, wbytes1, rtime1, wtime1) = before
           (reads2, writes2, rbytes2, wbytes2, rtime2, wtime2) = after
-          text_util.ttyprint('', diskname.rjust(6), end=' ')
+          text_util.print_to_fd('', diskname.rjust(6), end=' ')
           deltas = [reads2-reads1, writes2-writes1, rbytes2-rbytes1,
                     wbytes2-wbytes1, rtime2-rtime1, wtime2-wtime1]
           for delta in deltas:
-            text_util.ttyprint(str(delta).rjust(8), end=' ')
-          text_util.ttyprint()
+            text_util.print_to_fd(str(delta).rjust(8), end=' ')
+          text_util.print_to_fd()
 
       if 'tcp_proc_values' in info:
-        text_util.ttyprint('TCP /proc values:\n', end=' ')
+        text_util.print_to_fd('TCP /proc values:\n', end=' ')
         for item in six.iteritems(info['tcp_proc_values']):
-          text_util.ttyprint('   %s = %s' % item)
+          text_util.print_to_fd('   %s = %s' % item)
 
       if 'boto_https_enabled' in info:
-        text_util.ttyprint('Boto HTTPS Enabled: \n  %s' % info['boto_https_enabled'])
+        text_util.print_to_fd('Boto HTTPS Enabled: \n  %s' % info['boto_https_enabled'])
 
       if 'using_proxy' in info:
-        text_util.ttyprint('Requests routed through proxy: \n  %s' % info['using_proxy'])
+        text_util.print_to_fd('Requests routed through proxy: \n  %s' % info['using_proxy'])
 
       if 'google_host_dns_latency' in info:
-        text_util.ttyprint(('Latency of the DNS lookup for Google Storage server (ms): '
+        text_util.print_to_fd(('Latency of the DNS lookup for Google Storage server (ms): '
                '\n  %.1f' % (info['google_host_dns_latency'] * 1000.0)))
 
       if 'google_host_connect_latencies' in info:
-        text_util.ttyprint('Latencies connecting to Google Storage server IPs (ms):')
+        text_util.print_to_fd('Latencies connecting to Google Storage server IPs (ms):')
         for ip, latency in six.iteritems(info['google_host_connect_latencies']):
-          text_util.ttyprint('  %s = %.1f' % (ip, latency * 1000.0))
+          text_util.print_to_fd('  %s = %.1f' % (ip, latency * 1000.0))
 
       if 'proxy_dns_latency' in info:
-        text_util.ttyprint(('Latency of the DNS lookup for the configured proxy (ms): '
+        text_util.print_to_fd(('Latency of the DNS lookup for the configured proxy (ms): '
                '\n  %.1f' % (info['proxy_dns_latency'] * 1000.0)))
 
       if 'proxy_host_connect_latency' in info:
-        text_util.ttyprint(('Latency connecting to the configured proxy (ms): \n  %.1f' %
+        text_util.print_to_fd(('Latency connecting to the configured proxy (ms): \n  %.1f' %
                (info['proxy_host_connect_latency'] * 1000.0)))
 
     if 'request_errors' in self.results and 'total_requests' in self.results:
-      text_util.ttyprint()
-      text_util.ttyprint('-' * 78)
-      text_util.ttyprint('In-Process HTTP Statistics'.center(78))
-      text_util.ttyprint('-' * 78)
+      text_util.print_to_fd()
+      text_util.print_to_fd('-' * 78)
+      text_util.print_to_fd('In-Process HTTP Statistics'.center(78))
+      text_util.print_to_fd('-' * 78)
       total = int(self.results['total_requests'])
       numerrors = int(self.results['request_errors'])
       numbreaks = int(self.results['connection_breaks'])
       availability = (((total - numerrors) / float(total)) * 100
                       if total > 0 else 100)
-      text_util.ttyprint('Total HTTP requests made: %d' % total)
-      text_util.ttyprint('HTTP 5xx errors: %d' % numerrors)
-      text_util.ttyprint('HTTP connections broken: %d' % numbreaks)
-      text_util.ttyprint('Availability: %.7g%%' % availability)
+      text_util.print_to_fd('Total HTTP requests made: %d' % total)
+      text_util.print_to_fd('HTTP 5xx errors: %d' % numerrors)
+      text_util.print_to_fd('HTTP connections broken: %d' % numbreaks)
+      text_util.print_to_fd('Availability: %.7g%%' % availability)
       if 'error_responses_by_code' in self.results:
         sorted_codes = sorted(
             six.iteritems(self.results['error_responses_by_code']))
         if sorted_codes:
-          text_util.ttyprint('Error responses by code:')
-          text_util.ttyprint('\n'.join('  %s: %s' % c for c in sorted_codes))
+          text_util.print_to_fd('Error responses by code:')
+          text_util.print_to_fd('\n'.join('  %s: %s' % c for c in sorted_codes))
 
     if self.output_file:
       with open(self.output_file, 'w') as f:
         json.dump(self.results, f, indent=2)
-      text_util.ttyprint()
-      text_util.ttyprint("Output file written to '%s'." % self.output_file)
+      text_util.print_to_fd()
+      text_util.print_to_fd("Output file written to '%s'." % self.output_file)
 
-    text_util.ttyprint()
+    text_util.print_to_fd()
 
   def _ParsePositiveInteger(self, val, msg):
     """Tries to convert val argument to a positive integer.

--- a/gslib/gcs_json_media.py
+++ b/gslib/gcs_json_media.py
@@ -671,7 +671,7 @@ class HttpWithDownloadStream(httplib2.Http):
             if self.stream is None:
               raise apitools_exceptions.InvalidUserInputError(
                   'Cannot exercise HttpWithDownloadStream with no stream')
-            text_util.ttywrite(self.stream, new_data)
+            text_util.write_to_fd(self.stream, new_data)
             bytes_read += len(new_data)
           else:
             break

--- a/gslib/utils/cat_helper.py
+++ b/gslib/utils/cat_helper.py
@@ -70,7 +70,7 @@ class CatHelper(object):
       buf = src_fd.read(io.DEFAULT_BUFFER_SIZE)
       if not buf:
         break
-      text_util.ttywrite(dst_fd, buf)
+      text_util.write_to_fd(dst_fd, buf)
 
   def CatUrlStrings(self, url_strings, show_header=False, start_byte=0,
                     end_byte=None, cat_out_fd=None):

--- a/gslib/utils/copy_helper.py
+++ b/gslib/utils/copy_helper.py
@@ -2366,7 +2366,7 @@ class SlicedDownloadFileWrapper(object):
     assert (self._start_byte <= current_file_pos and
             current_file_pos + len(data) <= self._end_byte + 1)
 
-    text_util.ttywrite(self._orig_fp, data)
+    text_util.write_to_fd(self._orig_fp, data)
     current_file_pos = self._orig_fp.tell()
 
     threshold = TRACKERFILE_UPDATE_THRESHOLD

--- a/gslib/utils/ls_helper.py
+++ b/gslib/utils/ls_helper.py
@@ -103,7 +103,7 @@ def PrintDir(bucket_listing_ref):
   Args:
     bucket_listing_ref: BucketListingRef of type BUCKET or PREFIX.
   """
-  text_util.ttyprint(bucket_listing_ref.url_string)
+  text_util.print_to_fd(bucket_listing_ref.url_string)
 
 
 # pylint: disable=unused-argument
@@ -125,12 +125,12 @@ def PrintDirHeader(bucket_listing_ref):
   Args:
     bucket_listing_ref: BucketListingRef of type PREFIX.
   """
-  text_util.ttyprint('{}:'.format(bucket_listing_ref.url_string))
+  text_util.print_to_fd('{}:'.format(bucket_listing_ref.url_string))
 
 
 def PrintNewLine():
   """Default function for printing new lines between directories."""
-  text_util.ttyprint()
+  text_util.print_to_fd()
 
 
 # pylint: disable=too-many-statements
@@ -162,44 +162,44 @@ def PrintFullInfoAboutObject(bucket_listing_ref, incl_acl=True):
     num_bytes = obj.size
     num_objs = 1
 
-  text_util.ttyprint('{}:'.format(url_str))
+  text_util.print_to_fd('{}:'.format(url_str))
   if obj.timeCreated:
-    text_util.ttyprint(MakeMetadataLine(
+    text_util.print_to_fd(MakeMetadataLine(
         'Creation time', obj.timeCreated.strftime('%a, %d %b %Y %H:%M:%S GMT')))
   if obj.updated:
-    text_util.ttyprint(MakeMetadataLine(
+    text_util.print_to_fd(MakeMetadataLine(
         'Update time', obj.updated.strftime('%a, %d %b %Y %H:%M:%S GMT')))
   if (obj.timeStorageClassUpdated and
       obj.timeStorageClassUpdated != obj.timeCreated):
-    text_util.ttyprint(MakeMetadataLine(
+    text_util.print_to_fd(MakeMetadataLine(
         'Storage class update time',
         obj.timeStorageClassUpdated.strftime('%a, %d %b %Y %H:%M:%S GMT')))
   if obj.storageClass:
-    text_util.ttyprint(MakeMetadataLine('Storage class', obj.storageClass))
+    text_util.print_to_fd(MakeMetadataLine('Storage class', obj.storageClass))
   if obj.temporaryHold:
-    text_util.ttyprint(MakeMetadataLine('Temporary Hold', 'Enabled'))
+    text_util.print_to_fd(MakeMetadataLine('Temporary Hold', 'Enabled'))
   if obj.eventBasedHold:
-    text_util.ttyprint(MakeMetadataLine('Event-Based Hold', 'Enabled'))
+    text_util.print_to_fd(MakeMetadataLine('Event-Based Hold', 'Enabled'))
   if obj.retentionExpirationTime:
-    text_util.ttyprint(MakeMetadataLine(
+    text_util.print_to_fd(MakeMetadataLine(
         'Retention Expiration',
         obj.retentionExpirationTime.strftime('%a, %d %b %Y %H:%M:%S GMT')))
   if obj.kmsKeyName:
-    text_util.ttyprint(MakeMetadataLine('KMS key', obj.kmsKeyName))
+    text_util.print_to_fd(MakeMetadataLine('KMS key', obj.kmsKeyName))
   if obj.cacheControl:
-    text_util.ttyprint(MakeMetadataLine('Cache-Control', obj.cacheControl))
+    text_util.print_to_fd(MakeMetadataLine('Cache-Control', obj.cacheControl))
   if obj.contentDisposition:
-    text_util.ttyprint(MakeMetadataLine('Content-Disposition', obj.contentDisposition))
+    text_util.print_to_fd(MakeMetadataLine('Content-Disposition', obj.contentDisposition))
   if obj.contentEncoding:
-    text_util.ttyprint(MakeMetadataLine('Content-Encoding', obj.contentEncoding))
+    text_util.print_to_fd(MakeMetadataLine('Content-Encoding', obj.contentEncoding))
   if obj.contentLanguage:
-    text_util.ttyprint(MakeMetadataLine('Content-Language', obj.contentLanguage))
-  text_util.ttyprint(MakeMetadataLine('Content-Length', obj.size))
-  text_util.ttyprint(MakeMetadataLine('Content-Type', obj.contentType))
+    text_util.print_to_fd(MakeMetadataLine('Content-Language', obj.contentLanguage))
+  text_util.print_to_fd(MakeMetadataLine('Content-Length', obj.size))
+  text_util.print_to_fd(MakeMetadataLine('Content-Type', obj.contentType))
   if obj.componentCount:
-    text_util.ttyprint(MakeMetadataLine('Component-Count', obj.componentCount))
+    text_util.print_to_fd(MakeMetadataLine('Component-Count', obj.componentCount))
   if obj.timeDeleted:
-    text_util.ttyprint(MakeMetadataLine(
+    text_util.print_to_fd(MakeMetadataLine(
         'Archived time',
         obj.timeDeleted.strftime('%a, %d %b %Y %H:%M:%S GMT')))
   marker_props = {}
@@ -211,42 +211,42 @@ def PrintFullInfoAboutObject(bucket_listing_ref, incl_acl=True):
       else:
         marker_props[add_prop.key] = add_prop.value
     if non_marker_props:
-      text_util.ttyprint(MakeMetadataLine('Metadata', ''))
+      text_util.print_to_fd(MakeMetadataLine('Metadata', ''))
       for ap in non_marker_props:
         ap_key = '{}'.format(ap.key)
         ap_value = '{}'.format(ap.value)
         meta_data_line = MakeMetadataLine(ap_key, ap_value, indent=2)
-        text_util.ttyprint(meta_data_line)
+        text_util.print_to_fd(meta_data_line)
   if obj.customerEncryption:
     if not obj.crc32c:
-      text_util.ttyprint(MakeMetadataLine('Hash (crc32c)', 'encrypted'))
+      text_util.print_to_fd(MakeMetadataLine('Hash (crc32c)', 'encrypted'))
     if not obj.md5Hash:
-      text_util.ttyprint(MakeMetadataLine('Hash (md5)', 'encrypted'))
-    text_util.ttyprint(MakeMetadataLine(
+      text_util.print_to_fd(MakeMetadataLine('Hash (md5)', 'encrypted'))
+    text_util.print_to_fd(MakeMetadataLine(
         'Encryption algorithm', obj.customerEncryption.encryptionAlgorithm))
-    text_util.ttyprint(MakeMetadataLine(
+    text_util.print_to_fd(MakeMetadataLine(
         'Encryption key SHA256', obj.customerEncryption.keySha256))
   if obj.crc32c:
-    text_util.ttyprint(MakeMetadataLine('Hash (crc32c)', obj.crc32c))
+    text_util.print_to_fd(MakeMetadataLine('Hash (crc32c)', obj.crc32c))
   if obj.md5Hash:
-    text_util.ttyprint(MakeMetadataLine('Hash (md5)', obj.md5Hash))
-  text_util.ttyprint(MakeMetadataLine('ETag', obj.etag.strip('"\'')))
+    text_util.print_to_fd(MakeMetadataLine('Hash (md5)', obj.md5Hash))
+  text_util.print_to_fd(MakeMetadataLine('ETag', obj.etag.strip('"\'')))
   if obj.generation:
     generation_str = GenerationFromUrlAndString(storage_url, obj.generation)
-    text_util.ttyprint(MakeMetadataLine('Generation', generation_str))
+    text_util.print_to_fd(MakeMetadataLine('Generation', generation_str))
   if obj.metageneration:
-    text_util.ttyprint(MakeMetadataLine('Metageneration', obj.metageneration))
+    text_util.print_to_fd(MakeMetadataLine('Metageneration', obj.metageneration))
   if incl_acl:
     # JSON API won't return acls as part of the response unless we have
     # full control scope
     if obj.acl:
-      text_util.ttyprint(MakeMetadataLine('ACL', AclTranslation.JsonFromMessage(obj.acl)))
+      text_util.print_to_fd(MakeMetadataLine('ACL', AclTranslation.JsonFromMessage(obj.acl)))
     elif S3_ACL_MARKER_GUID in marker_props:
-      text_util.ttyprint(MakeMetadataLine('ACL', marker_props[S3_ACL_MARKER_GUID]))
+      text_util.print_to_fd(MakeMetadataLine('ACL', marker_props[S3_ACL_MARKER_GUID]))
     else:
       # Empty ACLs are possible with Bucket Policy Only and no longer imply
       # ACCESS DENIED anymore.
-      text_util.ttyprint(MakeMetadataLine('ACL', '[]'))
+      text_util.print_to_fd(MakeMetadataLine('ACL', '[]'))
 
   return (num_objs, num_bytes)
 
@@ -261,7 +261,7 @@ def PrintObject(bucket_listing_ref):
     (num_objects, num_bytes).
   """
   try:
-    text_util.ttyprint(bucket_listing_ref.url_string)
+    text_util.print_to_fd(bucket_listing_ref.url_string)
   except IOError as e:
     # Windows throws an IOError 0 here for object names containing Unicode
     # chars. Ignore it.

--- a/gslib/utils/text_util.py
+++ b/gslib/utils/text_util.py
@@ -301,8 +301,8 @@ def print_to_fd(*objects, **kwargs):
     return expected_keywords.values()
 
   
-  def _get_normalized_strings(*objects):
-    """Ensure a list of string-like objects all have proper encoding"""
+  def _get_byte_strings(*objects):
+    """Gets a `bytes` string for each item in a list of printable objects."""
     byte_objects = []
     for item in objects:
       if not isinstance(item, (six.binary_type, six.text_type)):
@@ -321,7 +321,7 @@ def print_to_fd(*objects, **kwargs):
   sep, end, file = _get_args(**kwargs)
   sep = six.ensure_binary(sep)
   end = six.ensure_binary(end)
-  data = _get_normalized_strings(*objects)
+  data = _get_byte_strings(*objects)
   data = sep.join(data)
   data += end
   write_to_fd(file, data)

--- a/gslib/utils/text_util.py
+++ b/gslib/utils/text_util.py
@@ -295,8 +295,8 @@ def print_to_fd(*objects, **kwargs):
           error_msg.format(
             key,
             ' '.join(expected_keywords.keys())))
-        else:
-          expected_keywords[key] = value
+      else:
+        expected_keywords[key] = value
 
     return expected_keywords.values()
 

--- a/gslib/utils/text_util.py
+++ b/gslib/utils/text_util.py
@@ -300,8 +300,9 @@ def print_to_fd(*objects, **kwargs):
 
     return expected_keywords.values()
 
-  def _get_normalized_string(*objects, sep):
-    """Transform a list of string-like objects into a single string."""
+  
+  def _get_normalized_string(*objects):
+    """Ensure a list of string-like objects all have proper encoding"""
     byte_objects = []
     for item in objects:
       if not isinstance(item, (six.binary_type, six.text_type)):
@@ -315,12 +316,13 @@ def print_to_fd(*objects, **kwargs):
         # The item should be unicode. If it's not, ensure_binary()
         # will throw a TypeError.
         byte_objects.append(six.ensure_binary(item))
-    return sep.join(byte_objects)
+    return byte_objects
     
   sep, end, file = _get_args(**kwargs)
   sep = six.ensure_binary(sep)
   end = six.ensure_binary(end)
-  data = _get_normalized_strings(*objects, sep)
+  data = _get_normalized_strings(*objects)
+  data = sep.join(data)
   data += end
   write_to_fd(file, data)
 

--- a/gslib/utils/text_util.py
+++ b/gslib/utils/text_util.py
@@ -295,14 +295,6 @@ def print_to_fd(*objects, **kwargs):
                     error_msg.format(
                         key,
                         ' '.join(expected_keywords.keys())))
-            elif type(value) != type(expected_keywords[value]):
-                error_msg = (
-                    '{key} is an unexpected type. {key} must be '
-                    '{typeOfValue}')
-                raise TypeError(
-                    error_msg.format(
-                        key=key,
-                        typeOfValue=str(type(value))))
             else:
                 expected_keywords[key] = value
 
@@ -312,7 +304,7 @@ def print_to_fd(*objects, **kwargs):
 
     sep = six.ensure_binary(sep)
     end = six.ensure_binary(end)
-    byte_objects = [six.ensure_binary(str(item)) for item in objects]
+    byte_objects = [six.ensure_binary(item) for item in objects]
     data = sep.join(byte_objects)
     data += end
     write_to_fd(file, data)

--- a/gslib/utils/text_util.py
+++ b/gslib/utils/text_util.py
@@ -300,12 +300,27 @@ def print_to_fd(*objects, **kwargs):
 
     return expected_keywords.values()
 
-  sep, end, file = _get_args(**kwargs)
+  def _get_normalized_string(*objects, sep):
+    """Transform a list of string-like objects into a single string."""
+    byte_objects = []
+    for item in objects:
+      if not isinstance(item, (six.binary_type, six.text_type)):
+        # If the item wasn't bytes or unicode, its __str__ method
+        # should return one of those types.
+        item = str(item)
 
+      if isinstance(item, six.binary_type):
+        byte_objects.append(item)
+      else:
+        # The item should be unicode. If it's not, ensure_binary()
+        # will throw a TypeError.
+        byte_objects.append(six.ensure_binary(item))
+    return sep.join(byte_objects)
+    
+  sep, end, file = _get_args(**kwargs)
   sep = six.ensure_binary(sep)
   end = six.ensure_binary(end)
-  byte_objects = [six.ensure_binary(item) for item in objects]
-  data = sep.join(byte_objects)
+  data = _get_normalized_strings(*objects, sep)
   data += end
   write_to_fd(file, data)
 

--- a/gslib/utils/text_util.py
+++ b/gslib/utils/text_util.py
@@ -311,21 +311,21 @@ def print_to_fd(*objects, **kwargs):
 
 
 def write_to_fd(fd, data):
-  """Write given data to given file descriptor, doing any conversions needed.isinstance"""
+  """Write given data to given file descriptor, doing any conversions needed"""
   if six.PY2:
     fd.write(data)
-  else:
-    if isinstance(data, bytes):
-      if (hasattr(fd, 'mode') and 'b' in fd.mode) or isinstance(fd, io.BytesIO):
-        fd.write(data)
-      elif hasattr(fd, 'buffer'):
-        fd.buffer.write(data)
-      else:
-        fd.write(six.ensure_text(data))
-    elif 'b' in fd.mode:
-      fd.write(six.ensure_binary(data))
-    else:
+  # PY3 logic:
+  if isinstance(data, bytes):
+    if (hasattr(fd, 'mode') and 'b' in fd.mode) or isinstance(fd, io.BytesIO):
       fd.write(data)
+    elif hasattr(fd, 'buffer'):
+      fd.buffer.write(data)
+    else:
+      fd.write(six.ensure_text(data))
+  elif 'b' in fd.mode:
+    fd.write(six.ensure_binary(data))
+  else:
+    fd.write(data)
 
 
 def RemoveCRLFFromString(input_str):

--- a/gslib/utils/text_util.py
+++ b/gslib/utils/text_util.py
@@ -274,7 +274,7 @@ def print_to_fd(*objects, **kwargs):
     """
     def _get_args(**kwargs):
         """Validates keyword arguments that would be used in Print
-        
+
         Valid keyword arguments, mirroring print(), are 'sep',
         'end', and 'file'. These must be of types string, string,
         and file / file interface respectively.
@@ -311,10 +311,7 @@ def print_to_fd(*objects, **kwargs):
 
 
 def write_to_fd(fd, data):
-    """Write given data to given file descriptor, doing any conversions needed.
-
-    Given string data that may be bytes or unicode, or 
-    """
+    """Write given data to given file descriptor, doing any conversions needed.isinstance"""
     if six.PY2:
         fd.write(data)
     else:
@@ -325,8 +322,10 @@ def write_to_fd(fd, data):
                 fd.buffer.write(data)
             else:
                 fd.write(six.ensure_text(data))
-        else:
+        elif 'b' in fd.mode:
             fd.write(six.ensure_binary(data))
+        else:
+            fd.write(data)
 
 
 def RemoveCRLFFromString(input_str):

--- a/gslib/utils/text_util.py
+++ b/gslib/utils/text_util.py
@@ -314,6 +314,7 @@ def write_to_fd(fd, data):
   """Write given data to given file descriptor, doing any conversions needed"""
   if six.PY2:
     fd.write(data)
+    return
   # PY3 logic:
   if isinstance(data, bytes):
     if (hasattr(fd, 'mode') and 'b' in fd.mode) or isinstance(fd, io.BytesIO):

--- a/gslib/utils/text_util.py
+++ b/gslib/utils/text_util.py
@@ -301,7 +301,7 @@ def print_to_fd(*objects, **kwargs):
     return expected_keywords.values()
 
   
-  def _get_normalized_string(*objects):
+  def _get_normalized_strings(*objects):
     """Ensure a list of string-like objects all have proper encoding"""
     byte_objects = []
     for item in objects:


### PR DESCRIPTION
Note: haven't tested this refactor yet, putting this up for initial review, will work more on this after we have boto smoothed out.

Refactored ttyprint and ttywrite functions to be a little more
succinct and to utilize the available six.ensure_* functions.
Renamed ttyprint to print_to_fd and ttywrite to write_to_fd,
and updated references to tty*.