### PR TITLE
Bunch of small doc fixes.

### DIFF
--- a/gslib/addlhelp/prod.py
+++ b/gslib/addlhelp/prod.py
@@ -32,16 +32,16 @@ _DETAILED_HELP_TEXT = ("""
   First, it's helpful to understand gsutil's resumable transfer mechanism,
   and how your script needs to be implemented around this mechanism to work
   reliably. gsutil uses resumable transfer support when you attempt to download
-  to a file of any size or to upload a file larger than a configurable
-  threshold (by default, this threshold is %d MiB). If a transfer fails
-  partway through (e.g., because of an intermittent network problem), gsutil
-  uses a truncated randomized binary exponential backoff-and-retry strategy
-  that by default will retry transfers up to 23 times over a 10 minute period
-  of time (see "gsutil help retries" for details). If the transfer fails each
-  of these attempts with no intervening progress, gsutil gives up on the
-  transfer, but keeps a "tracker" file for it in a configurable location (the
-  default location is ~/.gsutil/, in a file named by a combination of the SHA1
-  hash of the name of the bucket and object being transferred and the last 16
+  a file of any size or to upload a file larger than a configurable threshold
+  (by default, this threshold is %d MiB). If a transfer fails partway through
+  (e.g., because of an intermittent network problem), gsutil uses a truncated
+  randomized binary exponential backoff-and-retry strategy that by default will
+  retry transfers up to 23 times over a 10 minute period of time (see
+  "gsutil help retries" for details). If the transfer fails each of these
+  attempts with no intervening progress, gsutil gives up on the transfer, but
+  keeps a "tracker" file for it in a configurable location (the default
+  location is ~/.gsutil/, in a file named by a combination of the SHA1 hash of
+  the name of the bucket and object being transferred and the last 16
   characters of the file name). When transfers fail in this fashion, you can
   rerun gsutil at some later time (e.g., after the networking problem has been
   resolved), and the resumable transfer picks up where it left off.

--- a/gslib/addlhelp/versions.py
+++ b/gslib/addlhelp/versions.py
@@ -43,8 +43,8 @@ _DETAILED_HELP_TEXT = ("""
   (discussed in a later section).
 
   To work with object versioning in gsutil, you can use a flavor of storage URLs
-  that that embed the object generation, which we refer to as version-specific
-  URLs. For example, the version-less object URL:
+  that embed the object generation, which we refer to as version-specific URLs.
+  For example, the version-less object URL:
 
     gs://bucket/object
 

--- a/gslib/commands/acl.py
+++ b/gslib/commands/acl.py
@@ -72,7 +72,7 @@ _SET_DESCRIPTION = """
 
   If you want to make an object or bucket publicly readable or writable, it is
   recommended to use "acl ch", to avoid accidentally removing OWNER permissions.
-  See "gsutil help acl ch" for details.
+  See the "acl ch" section for details.
 
   See "gsutil help acls" for a list of all canned ACLs.
 

--- a/gslib/commands/cp.py
+++ b/gslib/commands/cp.py
@@ -338,7 +338,7 @@ _RESUMABLE_TRANSFERS_TEXT = """
   you ran to start the upload. Until the upload has completed successfully, it
   will not be visible at the destination object and will not replace any
   existing object the upload is intended to overwrite. However, see the section
-  on PARALLEL COMPOSITE UPLOADS, which may leave temporary component objects in
+  on parallel composite uploads, which may leave temporary component objects in
   place during the upload process.
 
   Similarly, gsutil automatically performs resumable downloads (using standard

--- a/gslib/commands/stat.py
+++ b/gslib/commands/stat.py
@@ -53,10 +53,7 @@ _DETAILED_HELP_TEXT = ("""
     gsutil ls -L gs://some-bucket/some-object
 
   but is more efficient because it avoids performing bucket listings and gets
-  the minimum necessary amount of object metadata. Moreover, because it avoids
-  performing bucket listings (which are eventually consistent) the gsutil stat
-  command provides a strongly consistent way to check for the existence (and
-  read the metadata) of an object.
+  the minimum necessary amount of object metadata.
 
   The gsutil stat command will, however, perform bucket listings if you specify
   URLs using wildcards.
@@ -65,8 +62,9 @@ _DETAILED_HELP_TEXT = ("""
 
     gsutil -q stat gs://some-bucket/some-object
 
-  This can be useful for writing scripts, because the exit status will be 0 for
-  an existing object and 1 for a non-existent object.
+  This behavior can be useful when writing scripts: even though nothing is
+  printed from the command, it still has an exit status of 0 for an existing
+  object and 1 for a non-existent object.
 
   Note: Unlike the gsutil ls command, the stat command does not support
   operations on sub-directories. For example, if you run the command:

--- a/gslib/commands/stat.py
+++ b/gslib/commands/stat.py
@@ -53,7 +53,10 @@ _DETAILED_HELP_TEXT = ("""
     gsutil ls -L gs://some-bucket/some-object
 
   but is more efficient because it avoids performing bucket listings and gets
-  the minimum necessary amount of object metadata.
+  the minimum necessary amount of object metadata. Moreover, because it avoids
+  performing bucket listings (which for some storage providers are eventually
+  consistent) the gsutil stat command provides a strongly consistent way to
+  check for the existence (and read the metadata) of an object.
 
   The gsutil stat command will, however, perform bucket listings if you specify
   URLs using wildcards.

--- a/gslib/commands/versioning.py
+++ b/gslib/commands/versioning.py
@@ -52,8 +52,10 @@ _GET_DESCRIPTION = """
 """
 
 _DESCRIPTION = """
-  The Versioning Configuration feature enables you to configure a Google Cloud
-  Storage bucket to keep old versions of objects.
+  The `Versioning Configuration
+  <https://cloud.google.com/storage/docs/object-versioning>`_ feature
+  enables you to configure a Google Cloud Storage bucket to keep old
+  versions of objects.
 
   The gsutil versioning command has two sub-commands:
 """ + _SET_DESCRIPTION + _GET_DESCRIPTION

--- a/gslib/commands/web.py
+++ b/gslib/commands/web.py
@@ -84,7 +84,7 @@ _DESCRIPTION = """
   For example, suppose your company's Domain name is example.com. You could set
   up a website bucket as follows:
 
-  1. Create a bucket called example.com (see the "DOMAIN NAMED BUCKETS"
+  1. Create a bucket called www.example.com (see the "DOMAIN NAMED BUCKETS"
      section of "gsutil help naming" for details about creating such buckets).
 
   2. Create index.html and 404.html files and upload them to the bucket.
@@ -93,8 +93,8 @@ _DESCRIPTION = """
 
        gsutil web set -m index.html -e 404.html gs://www.example.com
 
-  4. Add a DNS CNAME record for example.com pointing to c.storage.googleapis.com
-     (ask your DNS administrator for help with this).
+  4. Add a DNS CNAME record for www.example.com pointing to
+     c.storage.googleapis.com (ask your DNS administrator for help with this).
 
   Now if you open a browser and navigate to http://www.example.com, it will
   display the main page instead of the default bucket listing. Note: It can


### PR DESCRIPTION
Fixes are based on open issues in the output documentation found on cloud.google.com.

Most edits are minor; the most significant change is to stat.py, which [I believe] contains outdated text about the consistency of bucket listing.