### PR TITLE
Removed `allow_failures` for python 3 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,11 +23,6 @@ matrix:
       dist: xenial
       python: "pypy3.5"
   fast_finish: true
-  allow_failures:
-    - python: "3.5"
-    - python: "3.6"
-    - python: "3.7"
-    - python: "pypy3.5"
 
 before_install:
   - sudo rm -f /etc/boto.cfg
@@ -40,9 +35,3 @@ install:
 script:
   - gsutil version -l
   - gsutil test -u
-matrix:
-    fast_finish: true
-    allow_failures:
-        - python: "3.5"
-        - python: "3.6"
-        - python: "3.7"


### PR DESCRIPTION
py-six-current branch passes all unit tests in python 2 and 3 (hooray!)
so we should require python 3.x to pass all future tests.