### PR TITLE
[Moved: See PR #695] Updated Linux CI scripts and configs to working status.

### DIFF
--- a/test/ci/kokoro/config_generator.sh
+++ b/test/ci/kokoro/config_generator.sh
@@ -14,22 +14,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Create a config file for gsutil to use in Kokoro tests.
+# Create a .boto config file for gsutil to use in Kokoro tests.
 # https://cloud.google.com/storage/docs/gsutil/commands/config
 
 GSUTIL_KEY=$1
 API=$2
+OUTPUT_FILE=$3
 
-cat  << EOF
-[Credentials]
-gs_service_key_file = "$GSUTIL_KEY"
+cat > $3 <<- EOM
+	[Credentials]
+	gs_service_key_file = $GSUTIL_KEY
 
-[GSUtil]
-test_notification_url = https://bigstore-test-notify.appspot.com/notify
-default_project_id = bigstore-gsutil-testing
-prefer_api = "$API"
+	[GSUtil]
+	default_project_id = bigstore-gsutil-testing
+	prefer_api = $API
 
-[OAuth2]
-client_id = 909320924072.apps.googleusercontent.com
-client_secret = p3RlpR10xMFh9ZXBS/ZNLYUu
-EOF
+	[OAuth2]
+	client_id = 909320924072.apps.googleusercontent.com
+	client_secret = p3RlpR10xMFh9ZXBS/ZNLYUu
+EOM

--- a/test/ci/kokoro/linux/continuous.cfg
+++ b/test/ci/kokoro/linux/continuous.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "run_integ_tests.sh"
+build_file: "/src/gsutil/test/ci/kokoro/linux/run_integ_tests.sh"
 timeout_mins: 60
 
 # Get access keys from Keystore

--- a/test/ci/kokoro/linux/presubmit.cfg
+++ b/test/ci/kokoro/linux/presubmit.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "run_integ_tests.sh"
+build_file: "/src/gsutil/test/ci/kokoro/linux/run_integ_tests.sh"
 timeout_mins: 60
 
 # Get access keys from Keystore

--- a/test/ci/kokoro/linux/py27_json.cfg
+++ b/test/ci/kokoro/linux/py27_json.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "run_integ_tests.sh"
+build_file: "/src/gsutil/test/ci/kokoro/linux/run_integ_tests.sh"
 timeout_mins: 60
 
 # Get access keys from Keystore

--- a/test/ci/kokoro/linux/py27_xml.cfg
+++ b/test/ci/kokoro/linux/py27_xml.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "run_integ_tests.sh"
+build_file: "/src/gsutil/test/ci/kokoro/linux/run_integ_tests.sh"
 timeout_mins: 60
 
 # Get access keys from Keystore

--- a/test/ci/kokoro/linux/py35_json.cfg
+++ b/test/ci/kokoro/linux/py35_json.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "run_integ_tests.sh"
+build_file: "/src/gsutil/test/ci/kokoro/linux/run_integ_tests.sh"
 timeout_mins: 60
 
 # Get access keys from Keystore

--- a/test/ci/kokoro/linux/py35_xml.cfg
+++ b/test/ci/kokoro/linux/py35_xml.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "run_integ_tests.sh"
+build_file: "/src/gsutil/test/ci/kokoro/linux/run_integ_tests.sh"
 timeout_mins: 60
 
 # Get access keys from Keystore

--- a/test/ci/kokoro/linux/py36_json.cfg
+++ b/test/ci/kokoro/linux/py36_json.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "run_integ_tests.sh"
+build_file: "/src/gsutil/test/ci/kokoro/linux/run_integ_tests.sh"
 timeout_mins: 60
 
 # Get access keys from Keystore

--- a/test/ci/kokoro/linux/py36_xml.cfg
+++ b/test/ci/kokoro/linux/py36_xml.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "run_integ_tests.sh"
+build_file: "/src/gsutil/test/ci/kokoro/linux/run_integ_tests.sh"
 timeout_mins: 60
 
 # Get access keys from Keystore

--- a/test/ci/kokoro/linux/py37_json.cfg
+++ b/test/ci/kokoro/linux/py37_json.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "run_integ_tests.sh"
+build_file: "/src/gsutil/test/ci/kokoro/linux/run_integ_tests.sh"
 timeout_mins: 60
 
 # Get access keys from Keystore

--- a/test/ci/kokoro/linux/py37_xml.cfg
+++ b/test/ci/kokoro/linux/py37_xml.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "run_integ_tests.sh"
+build_file: "/src/gsutil/test/ci/kokoro/linux/run_integ_tests.sh"
 timeout_mins: 60
 
 # Get access keys from Keystore

--- a/test/ci/kokoro/linux/run_integ_tests.sh
+++ b/test/ci/kokoro/linux/run_integ_tests.sh
@@ -2,33 +2,36 @@
 
 # This shell script is used for setting up our Kokoro Ubuntu environment
 # with necessary dependencies for running integration tests, and then
-# running tests when PRs are submitted.
+# running tests when PRs are submitted or code is pushed.
+#
+# This script is intentionally a bit verbose with what it writes to stdout.
+# Since its output is only visible in test run logs, and those logs are only
+# likely to be viewed in the event of an error, I decided it would be beneficial
+# to leave some settings like `set -x` and `cat`s and `echo`s in. This should
+# help future engineers debug what went wrong, and assert info about the test
+# environment at the cost of a small preamble in the logs.
 
-# For now, continuous.sh and presubmit.sh are both symlinks to this file.
-# Kokoro looks for files with those names, but our continuous and presubmit jobs
-# should be identical on Linux.
-
-# -e : Fail on any error
 # -x : Display commands being run
 # -u : Disallow unset variables
 # Doc: https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html#The-Set-Builtin
-set -exu
+set -xu
 
-GITHUB_REPO="https://github.com/GoogleCloudPlatform/gsutil"
-GSUTIL_KEY="/src/keystore/gsutil_kokoro_service_key.json"
-GSUTIL_SRC_PATH="/src/gsutil"
-GSUTIL_ENTRYPOINT="$GSUTIL_SRC_PATH/gsutil.py"
-PYTHON_PATH="/usr/local/bin/python"
-CONFIG_JSON="/src/.boto_json"
-CONFIG_XML="/src/.boto_xml"
+
+# PYMAJOR, PYMINOR, and BOTO_CONFIG environment variables are set per job in:
+# go/kokoro-gsutil-configs
+PYVERSION="$PYMAJOR.$PYMINOR"
+API=${BOTO_CONFIG##*_}
 
 # Processes to use based on default Ubuntu Kokoro specs here:
 # go/gcp-ubuntu-vm-configuration-v32i
 PROCS="4"
 
-# PYMAJOR and PYMINOR environment variables are set for each Kokoro job in:
-# go/kokoro-gsutil-configs
-PYVERSION="$PYMAJOR.$PYMINOR"
+GSUTIL_KEY="/tmpfs/src/keystore/74008_gsutil_kokoro_service_key"
+GSUTIL_SRC="/tmpfs/src/github/src/gsutil"
+GSUTIL_ENTRYPOINT="$GSUTIL_SRC/gsutil.py"
+CFG_GENERATOR="$GSUTIL_SRC/test/ci/kokoro/config_generator.sh"
+BOTO_CONFIG="/tmpfs/src/.boto_$API"
+
 
 function latest_python_release {
   # Return string with latest Python version triplet for a given version tuple.
@@ -40,37 +43,38 @@ function latest_python_release {
     | tail -1
 }
 
-function install_latest_python {
+function install_python {
   pyenv update
   pyenv install -s "$PYVERSIONTRIPLET"
 }
 
 function init_configs {
-  # Create config files for gsutil if they don't exist already
+  # Create .boto config for gsutil
   # https://cloud.google.com/storage/docs/gsutil/commands/config
-  if [[ ! -f  $CONFIG_JSON ]]; then
-    ../config_generator.sh "$GSUTIL_KEY" "json" > "$CONFIG_JSON"
-  fi
-
-  if [[ ! -f  $CONFIG_XML ]]; then
-    ../config_generator.sh "$GSUTIL_KEY" "xml" > "$CONFIG_XML"
-  fi
+  "$CFG_GENERATOR" "$GSUTIL_KEY" "$API" "$BOTO_CONFIG"
+  cat "$BOTO_CONFIG" | grep -v private_key
 }
 
 function init_python {
   # Ensure latest release of desired Python version is installed, and that
-  # dependencies, e.g. crcmod, are installed.
+  # dependencies from pip, e.g. crcmod, are installed.
   PYVERSIONTRIPLET=$(latest_python_release)
-  install_latest_python
+  install_python
   pyenv global "$PYVERSIONTRIPLET"
   python -m pip install -U crcmod
 }
 
-init_python
-init_configs
+function update_submodules {
+  # Most dependencies are included in gsutil via submodules. We need to
+  # tell git to grab our dependencies' source before we can depend on them.
+  cd "$GSUTIL_SRC"
+  git submodule update --init --recursive
+}
 
-cd "$GSUTIL_SRC_PATH"
-git submodule update --init --recursive
+
+init_configs
+init_python
+update_submodules
 
 # Run integration tests
 python "$GSUTIL_ENTRYPOINT" test -p "$PROCS"

--- a/test/ci/kokoro/macos/continuous.cfg
+++ b/test/ci/kokoro/macos/continuous.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "run_integ_tests.sh"
+build_file: "/src/gsutil/test/ci/kokoro/macos/run_integ_tests.sh"
 timeout_mins: 60
 
 

--- a/test/ci/kokoro/macos/presubmit.cfg
+++ b/test/ci/kokoro/macos/presubmit.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "run_integ_tests.sh"
+build_file: "/src/gsutil/test/ci/kokoro/macos/run_integ_tests.sh"
 timeout_mins: 60
 
 

--- a/test/ci/kokoro/macos/py27_json.cfg
+++ b/test/ci/kokoro/macos/py27_json.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "run_integ_tests.sh"
+build_file: "/src/gsutil/test/ci/kokoro/macos/run_integ_tests.sh"
 timeout_mins: 60
 
 

--- a/test/ci/kokoro/macos/py27_xml.cfg
+++ b/test/ci/kokoro/macos/py27_xml.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "run_integ_tests.sh"
+build_file: "/src/gsutil/test/ci/kokoro/macos/run_integ_tests.sh"
 timeout_mins: 60
 
 

--- a/test/ci/kokoro/macos/py35_json.cfg
+++ b/test/ci/kokoro/macos/py35_json.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "run_integ_tests.sh"
+build_file: "/src/gsutil/test/ci/kokoro/macos/run_integ_tests.sh"
 timeout_mins: 60
 
 

--- a/test/ci/kokoro/macos/py35_xml.cfg
+++ b/test/ci/kokoro/macos/py35_xml.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "run_integ_tests.sh"
+build_file: "/src/gsutil/test/ci/kokoro/macos/run_integ_tests.sh"
 timeout_mins: 60
 
 

--- a/test/ci/kokoro/macos/py36_json.cfg
+++ b/test/ci/kokoro/macos/py36_json.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "run_integ_tests.sh"
+build_file: "/src/gsutil/test/ci/kokoro/macos/run_integ_tests.sh"
 timeout_mins: 60
 
 

--- a/test/ci/kokoro/macos/py36_xml.cfg
+++ b/test/ci/kokoro/macos/py36_xml.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "run_integ_tests.sh"
+build_file: "/src/gsutil/test/ci/kokoro/macos/run_integ_tests.sh"
 timeout_mins: 60
 
 

--- a/test/ci/kokoro/macos/py37_json.cfg
+++ b/test/ci/kokoro/macos/py37_json.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "run_integ_tests.sh"
+build_file: "/src/gsutil/test/ci/kokoro/macos/run_integ_tests.sh"
 timeout_mins: 60
 
 

--- a/test/ci/kokoro/macos/py37_xml.cfg
+++ b/test/ci/kokoro/macos/py37_xml.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "run_integ_tests.sh"
+build_file: "/src/gsutil/test/ci/kokoro/macos/run_integ_tests.sh"
 timeout_mins: 60
 
 

--- a/test/ci/kokoro/macos/run_integ_tests.sh
+++ b/test/ci/kokoro/macos/run_integ_tests.sh
@@ -14,13 +14,6 @@
 # Doc: https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html#The-Set-Builtin
 set -exu
 
-# For debugging on the CI branch, let me SSH in
-# go/kokoro-ssh-vm
-#echo "$SSH_AUTHORIZED_KEY" >> ~/.ssh/authoirized_keys
-#external_ip=$(curl -s -H "Metadata-Flavor: Google" http://metadata/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip)
-#echo "INSTANCE_EXTERNAL_IP=${external_ip}"
-#sleep 2400
-
 GITHUB_REPO="https://github.com/GoogleCloudPlatform/gsutil"
 GSUTIL_KEY="/src/keystore/gsutil_kokoro_service_key.json"
 GSUTIL_SRC_PATH="/src/gsutil"

--- a/test/ci/kokoro/macos/run_integ_tests.sh
+++ b/test/ci/kokoro/macos/run_integ_tests.sh
@@ -14,6 +14,13 @@
 # Doc: https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html#The-Set-Builtin
 set -exu
 
+# For debugging on the CI branch, let me SSH in
+# go/kokoro-ssh-vm
+#echo "$SSH_AUTHORIZED_KEY" >> ~/.ssh/authoirized_keys
+#external_ip=$(curl -s -H "Metadata-Flavor: Google" http://metadata/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip)
+#echo "INSTANCE_EXTERNAL_IP=${external_ip}"
+#sleep 2400
+
 GITHUB_REPO="https://github.com/GoogleCloudPlatform/gsutil"
 GSUTIL_KEY="/src/keystore/gsutil_kokoro_service_key.json"
 GSUTIL_SRC_PATH="/src/gsutil"


### PR DESCRIPTION
This PR reflects commits to `ci-testing` branch where I performed
several iterations of testing on our CI scripts and configs.
These broad refactors should allow Linux CI to run tests on
manual invokations.