### PR TITLE
Bump vendored boto lib to newest commit.

### DIFF
--- a/gslib/utils/boto_util.py
+++ b/gslib/utils/boto_util.py
@@ -392,66 +392,6 @@ def MonkeyPatchBoto():
 
   boto.plugin.get_plugin = _PatchedGetPluginMethod
 
-  #########################################################################
-
-  # TODO(boto>2.49.0): Remove this.
-  # Fixes SSL issue where SNI was not being used for OpenSSL 1.1.1+
-  # https://github.com/boto/boto/pull/3843/files
-
-  # Import modules and resolve symbols used by our patch method.
-  import socket
-  import ssl
-  InvalidCertificateException = (
-      boto.https_connection.InvalidCertificateException)
-  ValidateCertificateHostname = (
-      boto.https_connection.ValidateCertificateHostname)
-
-  def _PatchedConnectMethod(self):
-    # The lines below were copied directly from the Boto file, so we don't lint
-    # or otherwise alter them.
-    if hasattr(self, "timeout"):
-        sock = socket.create_connection((self.host, self.port), self.timeout)
-    else:
-        sock = socket.create_connection((self.host, self.port))
-    msg = "wrapping ssl socket; "
-    if self.ca_certs:
-        msg += "CA certificate file=%s" % self.ca_certs
-    else:
-        msg += "using system provided SSL certs"
-    boto.log.debug(msg)
-    if hasattr(ssl, 'SSLContext') and getattr(ssl, 'HAS_SNI', False):
-        # Use SSLContext so we can specify server_hostname for SNI
-        # (Required for connections to storage.googleapis.com)
-        context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
-        context.verify_mode = ssl.CERT_REQUIRED
-        if self.ca_certs:
-            context.load_verify_locations(self.ca_certs)
-        if self.cert_file:
-            context.load_cert_chain(self.cert_file, self.key_file)
-        self.sock = context.wrap_socket(sock, server_hostname=self.host)
-        # Add attributes only set in SSLSocket constructor without context:
-        self.sock.keyfile = self.key_file
-        self.sock.certfile = self.cert_file
-        self.sock.cert_reqs = context.verify_mode
-        self.sock.ssl_version = ssl.PROTOCOL_SSLv23
-        self.sock.ca_certs = self.ca_certs
-        self.sock.ciphers = None
-    else:
-        self.sock = ssl.wrap_socket(sock, keyfile=self.key_file,
-                                    certfile=self.cert_file,
-                                    cert_reqs=ssl.CERT_REQUIRED,
-                                    ca_certs=self.ca_certs)
-    cert = self.sock.getpeercert()
-    hostname = self.host.split(':', 0)[0]
-    if not ValidateCertificateHostname(cert, hostname):
-        raise InvalidCertificateException(hostname,
-                                          cert,
-                                          'remote hostname "%s" does not match '
-                                          'certificate' % hostname)
-    # End `_PatchedConnectMethod` declaration.
-  boto.https_connection.CertValidatingHTTPSConnection.connect = (
-      _PatchedConnectMethod)
-
 
 def ProxyInfoFromEnvironmentVar(proxy_env_var):
   """Reads proxy info from the environment and converts to httplib2.ProxyInfo.


### PR DESCRIPTION
Done via `cd gslib/vendored/boto; git pull`.  Commit hash is acd6a95.

Also remove some monkeypatches that we now have in our vendored
version of boto