### PR TITLE
Export BOTO_PATH environment variable

### DIFF
--- a/test/ci/kokoro/linux/run_integ_tests.sh
+++ b/test/ci/kokoro/linux/run_integ_tests.sh
@@ -80,7 +80,7 @@ init_python
 update_submodules
 
 # Check that we're using the correct config
-python "$GSUTIL_ENTRYPOINT" -l
+python "$GSUTIL_ENTRYPOINT" version -l
 # Run integration tests
 python "$GSUTIL_ENTRYPOINT" test -p "$PROCS"
 

--- a/test/ci/kokoro/linux/run_integ_tests.sh
+++ b/test/ci/kokoro/linux/run_integ_tests.sh
@@ -55,7 +55,7 @@ function init_configs {
   # Create .boto config for gsutil
   # https://cloud.google.com/storage/docs/gsutil/commands/config
   "$CFG_GENERATOR" "$GSUTIL_KEY" "$API" "$BOTO_CONFIG"
-  grep -v private_key "$BOTO_CONFIG"
+  cat "$BOTO_CONFIG"
 }
 
 function init_python {
@@ -80,7 +80,7 @@ init_python
 update_submodules
 
 # Check that we're using the correct config
-gsutil version -l
+python "$GSUTIL_ENTRYPOINT" -l
 # Run integration tests
 python "$GSUTIL_ENTRYPOINT" test -p "$PROCS"
 

--- a/test/ci/kokoro/linux/run_integ_tests.sh
+++ b/test/ci/kokoro/linux/run_integ_tests.sh
@@ -32,6 +32,9 @@ GSUTIL_ENTRYPOINT="$GSUTIL_SRC/gsutil.py"
 CFG_GENERATOR="$GSUTIL_SRC/test/ci/kokoro/config_generator.sh"
 BOTO_CONFIG="/tmpfs/src/.boto_$API"
 
+# gsutil looks for this environment variable to find .boto config
+# https://cloud.google.com/storage/docs/boto-gsutil
+export BOTO_PATH="$BOTO_CONFIG"
 
 function latest_python_release {
   # Return string with latest Python version triplet for a given version tuple.
@@ -52,7 +55,7 @@ function init_configs {
   # Create .boto config for gsutil
   # https://cloud.google.com/storage/docs/gsutil/commands/config
   "$CFG_GENERATOR" "$GSUTIL_KEY" "$API" "$BOTO_CONFIG"
-  cat "$BOTO_CONFIG" | grep -v private_key
+  grep -v private_key "$BOTO_CONFIG"
 }
 
 function init_python {
@@ -76,6 +79,8 @@ init_configs
 init_python
 update_submodules
 
+# Check that we're using the correct config
+gsutil version -l
 # Run integration tests
 python "$GSUTIL_ENTRYPOINT" test -p "$PROCS"
 


### PR DESCRIPTION
We now export the BOTO_PATH environment variable
so gsutil will know what config to load. Doc:
https://cloud.google.com/storage/docs/boto-gsutil

A redundant call to `grep` was removed also, and a
call to `gsutil version -l` was added to more easily
see which config is being used at runtime.