### PR TITLE
Python exe path computed at runtime

### DIFF
--- a/test/ci/kokoro/windows/py27_json.cfg
+++ b/test/ci/kokoro/windows/py27_json.cfg
@@ -34,12 +34,6 @@ build_params {
   value: "C:\\src\\gsutil"
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.run#L19
-build_params {
-  key: "PyExe"
-  value "C:\\python$PYMAJOR$PYMINOR\\python.exe"
-}
-
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/windows/py27_xml.cfg
+++ b/test/ci/kokoro/windows/py27_xml.cfg
@@ -34,12 +34,6 @@ build_params {
   value: "C:\\src\\gsutil"
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.run#L19
-build_params {
-  key: "PyExe"
-  value "C:\\python$PYMAJOR$PYMINOR\\python.exe"
-}
-
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/windows/py35_json.cfg
+++ b/test/ci/kokoro/windows/py35_json.cfg
@@ -34,12 +34,6 @@ build_params {
   value: "C:\\src\\gsutil"
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.run#L19
-build_params {
-  key: "PyExe"
-  value "C:\\python$PYMAJOR$PYMINOR\\python.exe"
-}
-
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/windows/py35_xml.cfg
+++ b/test/ci/kokoro/windows/py35_xml.cfg
@@ -34,12 +34,6 @@ build_params {
   value: "C:\\src\\gsutil"
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.run#L19
-build_params {
-  key: "PyExe"
-  value "C:\\python$PYMAJOR$PYMINOR\\python.exe"
-}
-
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/windows/py36_json.cfg
+++ b/test/ci/kokoro/windows/py36_json.cfg
@@ -34,12 +34,6 @@ build_params {
   value: "C:\\src\\gsutil"
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.run#L19
-build_params {
-  key: "PyExe"
-  value "C:\\python$PYMAJOR$PYMINOR\\python.exe"
-}
-
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/windows/py36_xml.cfg
+++ b/test/ci/kokoro/windows/py36_xml.cfg
@@ -34,12 +34,6 @@ build_params {
   value: "C:\\src\\gsutil"
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.run#L19
-build_params {
-  key: "PyExe"
-  value "C:\\python$PYMAJOR$PYMINOR\\python.exe"
-}
-
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/windows/py37_json.cfg
+++ b/test/ci/kokoro/windows/py37_json.cfg
@@ -34,12 +34,6 @@ build_params {
   value: "C:\\src\\gsutil"
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.run#L19
-build_params {
-  key: "PyExe"
-  value "C:\\python$PYMAJOR$PYMINOR\\python.exe"
-}
-
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/windows/py37_xml.cfg
+++ b/test/ci/kokoro/windows/py37_xml.cfg
@@ -34,12 +34,6 @@ build_params {
   value: "C:\\src\\gsutil"
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.run#L19
-build_params {
-  key: "PyExe"
-  value "C:\\python$PYMAJOR$PYMINOR\\python.exe"
-}
-
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/windows/run_integ_tests.bat
+++ b/test/ci/kokoro/windows/run_integ_tests.bat
@@ -12,7 +12,7 @@ tree /F
 echo ""
 
 set GsutilRepoDir=%1
-set PyExe=%2
+set "PyExePath=C:\\python%PYMAJOR%%PYMINOR%\\python.exe"
 
-PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%run_integration_tests.ps1%' '%GsutilRepoDir%' '%PyExe%'";
+PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%run_integration_tests.ps1%' '%GsutilRepoDir%' '%PyExePath%'";
 


### PR DESCRIPTION
The config format we're using doesn't allow bash-style string
concatenation. As a result, we're instead building the path to
the Python executable on Windows using the PYMAJOR and PYMINOR
environment variables in the batch script calling our powershell
test runner.