### PR TITLE
Removed BOTO_CONFIG from Windows *.cfg

### DIFF
--- a/test/ci/kokoro/windows/continuous.cfg
+++ b/test/ci/kokoro/windows/continuous.cfg
@@ -34,9 +34,3 @@ build_params {
   value: "C:\\src\\gsutil"
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.run#L19
-build_params {
-  key: "PyExe"
-  value "C:\\python$PYMAJOR$PYMINOR\\python.exe"
-}
-

--- a/test/ci/kokoro/windows/presubmit.cfg
+++ b/test/ci/kokoro/windows/presubmit.cfg
@@ -34,9 +34,3 @@ build_params {
   value: "C:\\src\\gsutil"
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.run#L19
-build_params {
-  key: "PyExe"
-  value "C:\\python$PYMAJOR$PYMINOR\\python.exe"
-}
-

--- a/test/ci/kokoro/windows/py27_json.cfg
+++ b/test/ci/kokoro/windows/py27_json.cfg
@@ -46,7 +46,3 @@ env_vars {
   value: "7"
 }
 
-env_vars {
-  key: "BOTO_CONFIG"
-  value: "/tmpfs/src/.boto_json"
-}

--- a/test/ci/kokoro/windows/py27_xml.cfg
+++ b/test/ci/kokoro/windows/py27_xml.cfg
@@ -46,7 +46,3 @@ env_vars {
   value: "7"
 }
 
-env_vars {
-  key: "BOTO_CONFIG"
-  value: "/tmpfs/src/.boto_xml"
-}

--- a/test/ci/kokoro/windows/py35_json.cfg
+++ b/test/ci/kokoro/windows/py35_json.cfg
@@ -46,7 +46,3 @@ env_vars {
   value: "5"
 }
 
-env_vars {
-  key: "BOTO_CONFIG"
-  value: "/tmpfs/src/.boto_json"
-}

--- a/test/ci/kokoro/windows/py35_xml.cfg
+++ b/test/ci/kokoro/windows/py35_xml.cfg
@@ -46,7 +46,3 @@ env_vars {
   value: "5"
 }
 
-env_vars {
-  key: "BOTO_CONFIG"
-  value: "/tmpfs/src/.boto_xml"
-}

--- a/test/ci/kokoro/windows/py36_json.cfg
+++ b/test/ci/kokoro/windows/py36_json.cfg
@@ -46,7 +46,3 @@ env_vars {
   value: "6"
 }
 
-env_vars {
-  key: "BOTO_CONFIG"
-  value: "/tmpfs/src/.boto_json"
-}

--- a/test/ci/kokoro/windows/py36_xml.cfg
+++ b/test/ci/kokoro/windows/py36_xml.cfg
@@ -46,7 +46,3 @@ env_vars {
   value: "6"
 }
 
-env_vars {
-  key: "BOTO_CONFIG"
-  value: "/tmpfs/src/.boto_xml"
-}

--- a/test/ci/kokoro/windows/py37_json.cfg
+++ b/test/ci/kokoro/windows/py37_json.cfg
@@ -46,7 +46,3 @@ env_vars {
   value: "7"
 }
 
-env_vars {
-  key: "BOTO_CONFIG"
-  value: "/tmpfs/src/.boto_json"
-}

--- a/test/ci/kokoro/windows/py37_xml.cfg
+++ b/test/ci/kokoro/windows/py37_xml.cfg
@@ -46,7 +46,3 @@ env_vars {
   value: "7"
 }
 
-env_vars {
-  key: "BOTO_CONFIG"
-  value: "/tmpfs/src/.boto_xml"
-}


### PR DESCRIPTION
The BOTO_CONFIG environment variable is being calculated at
runtime in the run_integration_tests.bat file, so this environment
being set in the configs is not needed any longer.