### PR TITLE
Added Windows config generator, build wrapper

### DIFF
--- a/test/ci/kokoro/windows/config_generator.bat
+++ b/test/ci/kokoro/windows/config_generator.bat
@@ -1,0 +1,34 @@
+rem Copyright 2019 Google LLC
+rem
+rem Licensed under the Apache License, Version 2.0 (the "License");
+rem you may not use this file except in compliance with the License.
+rem You may obtain a copy of the License at
+rem
+rem     http://www.apache.org/licenses/LICENSE-2.0
+rem
+rem Unless required by applicable law or agreed to in writing, software
+rem distributed under the License is distributed on an "AS IS" BASIS,
+rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+rem See the License for the specific language governing permissions and
+rem limitations under the License.
+
+rem Create a config file for gsutil to use in Kokoro tests.
+rem https://cloud.google.com/storage/docs/gsutil/commands/config
+
+
+set GSUTIL_KEY=%1
+set API=%2
+set OUTPUT_FILE=%3
+
+(
+echo [Credentials]
+echo gs_service_key_file = %GSUTIL_KEY%
+echo [GSUtil]
+echo test_notification_url = https://bigstore-test-notify.appspot.com/notify
+echo default_project_id = bigstore-gsutil-testing
+echo prefer_api = %API%
+echo [OAuth2]
+echo client_id = 909320924072.apps.googleusercontent.com
+echo client_secret = p3RlpR10xMFh9ZXBS/ZNLYUu
+)>%OUTPUT_FILE%
+

--- a/test/ci/kokoro/windows/continuous.cfg
+++ b/test/ci/kokoro/windows/continuous.cfg
@@ -34,9 +34,3 @@ build_params {
   value: "C:\\src\\gsutil"
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L19
-build_params {
-  key: "PyExe"
-  value "C:\\python$PYMAJOR$PYMINOR\\python.exe"
-}
-

--- a/test/ci/kokoro/windows/presubmit.cfg
+++ b/test/ci/kokoro/windows/presubmit.cfg
@@ -34,9 +34,3 @@ build_params {
   value: "C:\\src\\gsutil"
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L19
-build_params {
-  key: "PyExe"
-  value "C:\\python$PYMAJOR$PYMINOR\\python.exe"
-}
-

--- a/test/ci/kokoro/windows/py27_json.cfg
+++ b/test/ci/kokoro/windows/py27_json.cfg
@@ -34,12 +34,6 @@ build_params {
   value: "C:\\src\\gsutil"
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L19
-build_params {
-  key: "PyExe"
-  value "C:\\python$PYMAJOR$PYMINOR\\python.exe"
-}
-
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/windows/py27_xml.cfg
+++ b/test/ci/kokoro/windows/py27_xml.cfg
@@ -34,12 +34,6 @@ build_params {
   value: "C:\\src\\gsutil"
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L19
-build_params {
-  key: "PyExe"
-  value "C:\\python$PYMAJOR$PYMINOR\\python.exe"
-}
-
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/windows/py35_json.cfg
+++ b/test/ci/kokoro/windows/py35_json.cfg
@@ -34,12 +34,6 @@ build_params {
   value: "C:\\src\\gsutil"
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L19
-build_params {
-  key: "PyExe"
-  value "C:\\python$PYMAJOR$PYMINOR\\python.exe"
-}
-
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/windows/py35_xml.cfg
+++ b/test/ci/kokoro/windows/py35_xml.cfg
@@ -34,12 +34,6 @@ build_params {
   value: "C:\\src\\gsutil"
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L19
-build_params {
-  key: "PyExe"
-  value "C:\\python$PYMAJOR$PYMINOR\\python.exe"
-}
-
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/windows/py36_json.cfg
+++ b/test/ci/kokoro/windows/py36_json.cfg
@@ -34,12 +34,6 @@ build_params {
   value: "C:\\src\\gsutil"
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L19
-build_params {
-  key: "PyExe"
-  value "C:\\python$PYMAJOR$PYMINOR\\python.exe"
-}
-
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/windows/py36_xml.cfg
+++ b/test/ci/kokoro/windows/py36_xml.cfg
@@ -34,12 +34,6 @@ build_params {
   value: "C:\\src\\gsutil"
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L19
-build_params {
-  key: "PyExe"
-  value "C:\\python$PYMAJOR$PYMINOR\\python.exe"
-}
-
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/windows/py37_json.cfg
+++ b/test/ci/kokoro/windows/py37_json.cfg
@@ -34,12 +34,6 @@ build_params {
   value: "C:\\src\\gsutil"
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L19
-build_params {
-  key: "PyExe"
-  value "C:\\python$PYMAJOR$PYMINOR\\python.exe"
-}
-
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/windows/py37_xml.cfg
+++ b/test/ci/kokoro/windows/py37_xml.cfg
@@ -34,12 +34,6 @@ build_params {
   value: "C:\\src\\gsutil"
 }
 
-# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L19
-build_params {
-  key: "PyExe"
-  value "C:\\python$PYMAJOR$PYMINOR\\python.exe"
-}
-
 # Environment variables to specify interpreter version.
 # go/kokoro-env-vars
 env_vars {

--- a/test/ci/kokoro/windows/run_integ_tests.bat
+++ b/test/ci/kokoro/windows/run_integ_tests.bat
@@ -1,0 +1,35 @@
+rem Copyright 2019 Google LLC
+rem
+rem Licensed under the Apache License, Version 2.0 (the "License");
+rem you may not use this file except in compliance with the License.
+rem You may obtain a copy of the License at
+rem
+rem     http://www.apache.org/licenses/LICENSE-2.0
+rem
+rem Unless required by applicable law or agreed to in writing, software
+rem distributed under the License is distributed on an "AS IS" BASIS,
+rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+rem See the License for the specific language governing permissions and
+rem limitations under the License.
+
+rem Kokoro looks for a .bat build file, but all our logic is actually in
+rem a PowerShell script. This simply launches our script with the appropriate
+rem parameters.
+rem
+rem https://stackoverflow.com/questions/19335004/how-to-run-a-powershell-script-from-a-batch-file
+rem http://blog.danskingdom.com/allow-others-to-run-your-powershell-scripts-from-a-batch-file-they-will-love-you-for-it/
+
+rem debug lines, remove me later
+dir
+echo ""
+tree /F
+echo ""
+
+
+set GsutilRepoDir=%1
+set "PyExePath=C:\python%PYMAJOR%%PYMINOR%\python.exe"
+
+cmd config_generator.bat "C:\src\keystore\74008+gsutil_kokoro_service_key" %API% "C:\src\.boto_%API%"
+
+PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%run_integration_tests.ps1%' '%GsutilRepoDir%' '%PyExePath%'";
+

--- a/test/ci/kokoro/windows/run_integ_tests.bat
+++ b/test/ci/kokoro/windows/run_integ_tests.bat
@@ -31,5 +31,5 @@ set "PyExePath=C:\python%PYMAJOR%%PYMINOR%\python.exe"
 
 cmd config_generator.bat "C:\src\keystore\74008+gsutil_kokoro_service_key" %API% "C:\src\.boto_%API%"
 
-PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%run_integration_tests.ps1%' -GsutilRepoDir '%GsutilRepoDir%' -PyExePath '%PyExePath%'";
+PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%run_integration_tests.ps1%' -GsutilRepoDir '%GsutilRepoDir%' -PyExe '%PyExePath%'";
 

--- a/test/ci/kokoro/windows/run_integ_tests.bat
+++ b/test/ci/kokoro/windows/run_integ_tests.bat
@@ -31,5 +31,5 @@ set "PyExePath=C:\python%PYMAJOR%%PYMINOR%\python.exe"
 
 cmd config_generator.bat "C:\src\keystore\74008+gsutil_kokoro_service_key" %API% "C:\src\.boto_%API%"
 
-PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%run_integration_tests.ps1%' '%GsutilRepoDir%' '%PyExePath%'";
+PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%run_integration_tests.ps1%' -GsutilRepoDir '%GsutilRepoDir%' -PyExePath '%PyExePath%'";
 


### PR DESCRIPTION
Added a wrapper .bat script to call our powershell testing script.
Kokoro looks specifically for a .bat script to call. Additionally,
created a config generator for Windows and removed some environment
variables that are instead being calculated at runtime now.