### PR TITLE
Updated integ tests for Python 3

### DIFF
--- a/gslib/__main__.py
+++ b/gslib/__main__.py
@@ -246,8 +246,7 @@ def main():
   global test_exception_traces
 
   boto_util.MonkeyPatchBoto()
-
-  boto_util.MonkeyPatchBoto()
+  system_util.MonkeyPatchHttp()
 
   # In gsutil 4.0 and beyond, we don't use the boto library for the JSON
   # API. However, we still store gsutil configuration data in the .boto

--- a/gslib/tests/test_Doption.py
+++ b/gslib/tests/test_Doption.py
@@ -102,7 +102,7 @@ class TestDOption(testcase.GsUtilIntegrationTestCase):
       self.assertIn('header: x-goog-generation: ', stderr)
       self.assertIn('header: x-goog-metageneration: 1', stderr)
       self.assertIn('header: x-goog-hash: crc32c=KAwGng==', stderr)
-      self.assertIn('header: x-goog-hash: md5=eB5eJF1ptWaXm4bijSPyxw==', stderr) # TODO(b/129722855): Why does MD5 differ in PY2/PY3?
+      self.assertIn('md5=eB5eJF1ptWaXm4bijSPyxw==', stderr)
       if six.PY2:
         self.assertRegex(
             stderr, '.*HEAD /%s/%s.*Content-Length: 0.*User-Agent: .*gsutil/%s' %

--- a/gslib/tests/test_Doption.py
+++ b/gslib/tests/test_Doption.py
@@ -102,11 +102,11 @@ class TestDOption(testcase.GsUtilIntegrationTestCase):
       self.assertIn('header: x-goog-generation: ', stderr)
       self.assertIn('header: x-goog-metageneration: 1', stderr)
       self.assertIn('header: x-goog-hash: crc32c=KAwGng==', stderr)
+      self.assertIn('header: x-goog-hash: md5=eB5eJF1ptWaXm4bijSPyxw==', stderr) # TODO(b/129722855): Why does MD5 differ in PY2/PY3?
       if six.PY2:
         self.assertRegex(
             stderr, '.*HEAD /%s/%s.*Content-Length: 0.*User-Agent: .*gsutil/%s' %
             (key_uri.bucket_name, key_uri.object_name, gslib.VERSION))
-        self.assertIn('header: x-goog-hash: md5=eB5eJF1ptWaXm4bijSPyxw==', stderr) # TODO(b/129722855): Why does MD5 differ in PY2/PY3?
     elif self.test_api == ApiSelector.JSON:
       self.assertRegex(
           stderr, '.*GET.*b/%s/o/%s.*user-agent:.*gsutil/%s.Python/%s' %

--- a/gslib/tests/test_Doption.py
+++ b/gslib/tests/test_Doption.py
@@ -101,14 +101,12 @@ class TestDOption(testcase.GsUtilIntegrationTestCase):
       self.assertIn('header: Last-Modified', stderr)
       self.assertIn('header: x-goog-generation: ', stderr)
       self.assertIn('header: x-goog-metageneration: 1', stderr)
+      self.assertIn('header: x-goog-hash: crc32c=KAwGng==', stderr)
       if six.PY2:
         self.assertRegex(
             stderr, '.*HEAD /%s/%s.*Content-Length: 0.*User-Agent: .*gsutil/%s' %
             (key_uri.bucket_name, key_uri.object_name, gslib.VERSION))
-        self.assertIn('header: x-goog-hash: crc32c=KAwGng==', stderr)
-        self.assertIn('header: x-goog-hash: md5=eB5eJF1ptWaXm4bijSPyxw==', stderr)
-      else:
-        self.assertIn('header: x-goog-hash', stderr)
+        self.assertIn('header: x-goog-hash: md5=eB5eJF1ptWaXm4bijSPyxw==', stderr) # TODO(b/129722855): Why does MD5 differ in PY2/PY3?
     elif self.test_api == ApiSelector.JSON:
       self.assertRegex(
           stderr, '.*GET.*b/%s/o/%s.*user-agent:.*gsutil/%s.Python/%s' %

--- a/gslib/tests/test_Doption.py
+++ b/gslib/tests/test_Doption.py
@@ -85,20 +85,15 @@ class TestDOption(testcase.GsUtilIntegrationTestCase):
     self.assertIn('You are running gsutil with debug output enabled.', stderr)
     self.assertIn("reply: 'HTTP/1.1 200 OK", stderr)
     self.assertIn('config:', stderr)
+    self.assertIn("reply: 'HTTP/1.1 200 OK", stderr)
+    self.assertIn('header: Expires: ', stderr)
+    self.assertIn('header: Date: ', stderr)
+    self.assertIn('header: Content-Type: application/octet-stream', stderr)
+    self.assertIn('header: Content-Length: 10', stderr)
     if six.PY2:
       self.assertIn("('proxy_pass', u'REDACTED')", stderr)
-      self.assertIn("reply: 'HTTP/1.1 200 OK", stderr)
-      self.assertIn('header: Expires: ', stderr)
-      self.assertIn('header: Date: ', stderr)
-      self.assertIn('header: Content-Type: application/octet-stream', stderr)
-      self.assertIn('header: Content-Length: 10', stderr)
     else:
       self.assertIn("('proxy_pass', 'REDACTED')", stderr)
-      self.assertIn("reply: 'HTTP/1.1 200 OK", stderr)
-      self.assertIn('Expires header: ', stderr)
-      self.assertIn('Date header: ', stderr)
-      self.assertIn('Content-Type header: ', stderr)
-      self.assertIn('Content-Length header: ', stderr)
 
     if self.test_api == ApiSelector.XML:
       if six.PY2:
@@ -114,12 +109,12 @@ class TestDOption(testcase.GsUtilIntegrationTestCase):
         self.assertIn('header: x-goog-hash: crc32c=KAwGng==', stderr)
         self.assertIn('header: x-goog-hash: md5=eB5eJF1ptWaXm4bijSPyxw==', stderr)
       else:
-        self.assertIn('Cache-Control header: ', stderr)
-        self.assertIn('Last-Modified header: ', stderr)
-        self.assertIn('ETag header:', stderr)
-        self.assertIn('x-goog-generation header:', stderr)
-        self.assertIn('x-goog-metageneration header:', stderr)
-        self.assertIn('x-goog-hash header:', stderr)
+        self.assertIn('header: Cache-Control: ', stderr)
+        self.assertIn('header: Last-Modified', stderr)
+        self.assertIn('header: ETag:', stderr)
+        self.assertIn('header: x-goog-generation', stderr)
+        self.assertIn('header: x-goog-metageneration', stderr)
+        self.assertIn('header: x-goog-hash', stderr)
     elif self.test_api == ApiSelector.JSON:
       self.assertRegex(
           stderr, '.*GET.*b/%s/o/%s.*user-agent:.*gsutil/%s.Python/%s' %
@@ -130,7 +125,7 @@ class TestDOption(testcase.GsUtilIntegrationTestCase):
                        'must-revalidate'), stderr)
         self.assertIn("md5Hash: u'eB5eJF1ptWaXm4bijSPyxw=='", stderr)
       else:
-        self.assertIn('Cache-Control header: ', stderr)
+        self.assertIn('header: Cache-Control:', stderr)
         self.assertIn("md5Hash: 'eB5eJF1ptWaXm4bijSPyxw=='", stderr)
 
     if gslib.IS_PACKAGE_INSTALL:

--- a/gslib/tests/test_Doption.py
+++ b/gslib/tests/test_Doption.py
@@ -108,16 +108,15 @@ class TestDOption(testcase.GsUtilIntegrationTestCase):
             stderr, '.*HEAD /%s/%s.*Content-Length: 0.*User-Agent: .*gsutil/%s' %
             (key_uri.bucket_name, key_uri.object_name, gslib.VERSION))
     elif self.test_api == ApiSelector.JSON:
+      self.assertIn(('header: Cache-Control: no-cache, no-store, max-age=0, '
+               'must-revalidate'), stderr)
       self.assertRegex(
           stderr, '.*GET.*b/%s/o/%s.*user-agent:.*gsutil/%s.Python/%s' %
           (key_uri.bucket_name, key_uri.object_name, gslib.VERSION,
            platform.python_version()))
       if six.PY2:
-        self.assertIn(('header: Cache-Control: no-cache, no-store, max-age=0, '
-                       'must-revalidate'), stderr)
         self.assertIn("md5Hash: u'eB5eJF1ptWaXm4bijSPyxw=='", stderr)
       else:
-        self.assertIn('header: Cache-Control:', stderr)
         self.assertIn("md5Hash: 'eB5eJF1ptWaXm4bijSPyxw=='", stderr)
 
     if gslib.IS_PACKAGE_INSTALL:

--- a/gslib/tests/test_Doption.py
+++ b/gslib/tests/test_Doption.py
@@ -96,24 +96,18 @@ class TestDOption(testcase.GsUtilIntegrationTestCase):
       self.assertIn("('proxy_pass', 'REDACTED')", stderr)
 
     if self.test_api == ApiSelector.XML:
+      self.assertIn('header: Cache-Control: ', stderr)
+      self.assertIn('header: ETag: "781e5e245d69b566979b86e28d23f2c7"', stderr)
+      self.assertIn('header: Last-Modified', stderr)
+      self.assertIn('header: x-goog-generation: ', stderr)
+      self.assertIn('header: x-goog-metageneration: 1', stderr)
       if six.PY2:
         self.assertRegex(
             stderr, '.*HEAD /%s/%s.*Content-Length: 0.*User-Agent: .*gsutil/%s' %
             (key_uri.bucket_name, key_uri.object_name, gslib.VERSION))
-        self.assertIn('header: Cache-Control: private, max-age=0',
-                      stderr)
-        self.assertIn('header: Last-Modified: ', stderr)
-        self.assertIn('header: ETag: "781e5e245d69b566979b86e28d23f2c7"', stderr)
-        self.assertIn('header: x-goog-generation: ', stderr)
-        self.assertIn('header: x-goog-metageneration: 1', stderr)
         self.assertIn('header: x-goog-hash: crc32c=KAwGng==', stderr)
         self.assertIn('header: x-goog-hash: md5=eB5eJF1ptWaXm4bijSPyxw==', stderr)
       else:
-        self.assertIn('header: Cache-Control: ', stderr)
-        self.assertIn('header: Last-Modified', stderr)
-        self.assertIn('header: ETag:', stderr)
-        self.assertIn('header: x-goog-generation', stderr)
-        self.assertIn('header: x-goog-metageneration', stderr)
         self.assertIn('header: x-goog-hash', stderr)
     elif self.test_api == ApiSelector.JSON:
       self.assertRegex(


### PR DESCRIPTION
Python 3 integration tests were looking for headers printed in
a slightly wrong order. Corrected the tests.

Bug: b/129722855
Test failure: Doption.TestDOption.test_minus_D_cat