### PR TITLE
Use compatibale six.moves.zip function

### DIFF
--- a/gslib/commands/iam.py
+++ b/gslib/commands/iam.py
@@ -644,11 +644,8 @@ class IamCommand(Command):
 
       policy_it = itertools.repeat(protojson.encode_message(policy))
       self.Apply(
-          _SetIamWrapper,
-          zip(
-              policy_it, name_expansion_iterator),
-          _SetIamExceptionHandler,
-          fail_on_error=not self.continue_on_error,
+          _SetIamWrapper, zip(policy_it, name_expansion_iterator),
+          _SetIamExceptionHandler, fail_on_error=not self.continue_on_error,
           seek_ahead_iterator=seek_ahead_iterator)
 
       self.everything_set_okay &= not GetFailureCount() > 0

--- a/gslib/commands/iam.py
+++ b/gslib/commands/iam.py
@@ -645,7 +645,7 @@ class IamCommand(Command):
       policy_it = itertools.repeat(protojson.encode_message(policy))
       self.Apply(
           _SetIamWrapper,
-          itertools.izip(
+          zip(
               policy_it, name_expansion_iterator),
           _SetIamExceptionHandler,
           fail_on_error=not self.continue_on_error,


### PR DESCRIPTION
This function was using itertools.izip which is only available on
Python 2.x. For compatibility, we're now using six.moves.zip.