### PR TITLE
Revised get_random_ascii_characters function

### DIFF
--- a/gslib/utils/text_util.py
+++ b/gslib/utils/text_util.py
@@ -363,7 +363,7 @@ def RemoveCRLFFromString(input_str):
 
 
 def get_random_ascii_chars(size, seed=0):
-  """Generates string representation of a list of ASCII characters.
+  """Generates binary string representation of a list of ASCII characters.
 
   Args:
     size: Integer quantity of characters to generate.
@@ -375,7 +375,6 @@ def get_random_ascii_chars(size, seed=0):
     equal to size argument.
   """
   random.seed(seed)
-  charset = string.ascii_letters
   contents = str([random.choice(string.ascii_letters) for _ in range(size)])
   contents = six.ensure_binary(contents)
   random.seed()  # Reset the seed for any other tests.

--- a/gslib/utils/text_util.py
+++ b/gslib/utils/text_util.py
@@ -29,6 +29,7 @@ import random
 import six
 import string
 from six.moves import urllib
+from six.moves import range
 
 from gslib.exception import CommandException
 from gslib.lazy_wrapper import LazyWrapper
@@ -361,24 +362,21 @@ def RemoveCRLFFromString(input_str):
   return re.sub(r'[\r\n]', '', input_str)
 
 
-def get_random_ascii_chars(size, seed=None):
-  """Generates random ASCII characters up to a given size.
+def get_random_ascii_chars(size, seed=0):
+  """Generates string representation of a list of ASCII characters.
 
   Args:
     size: Integer quantity of characters to generate.
     seed: A seed may be specified for deterministic behavior.
-          None is used as the default value.
+          Int 0 is used as the default value.
 
   Returns:
-    ASCII encoded bytestring of length equal to size argument.
-    Please note Python 2 strings are bytes by default, while
-    Python 3 string are Unicode by default.
+    Binary encoded string representation of a list of characters of length
+    equal to size argument.
   """
   random.seed(seed)
-  charset = string.printable
-
-  contents = ''.join([random.choice(charset) for _ in range(size)]
-                      ).encode('ascii')
-
+  charset = string.ascii_letters
+  contents = str([random.choice(string.ascii_letters) for _ in range(size)])
+  contents = six.ensure_binary(contents)
   random.seed()  # Reset the seed for any other tests.
   return contents


### PR DESCRIPTION
For b/129794995 to fix failing `test_cp_resumable_upload_gzip_encoded_break`

get_random_ascii_characters actually needed to return a string
representation of a list of characters, rather than an actual
list of characters for our testing purposes. The logic has been
revised to represent this need, bearing closer to is original
authorship with some revisions for Python 3 compatibility.

For context, the original function in master branch looked like this:
```
    random.seed(0)
    contents = str([random.choice(string.ascii_letters)
                    for _ in xrange(self.halt_size)])
    random.seed()  # Reset the seed for any other tests.
```
via https://github.com/GoogleCloudPlatform/gsutil/blob/master/gslib/tests/test_cp.py#L1706