### PR TITLE
Fix perfdiag tests that were hitting eof and causing failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,3 @@ install:
 script:
   - gsutil version -l
   - gsutil test -u
-matrix:
-    fast_finish: true
-    allow_failures:
-        - python: "3.5"
-        - python: "3.6"
-        - python: "3.7"

--- a/gslib/boto_translation.py
+++ b/gslib/boto_translation.py
@@ -735,7 +735,8 @@ class BotoTranslation(CloudApi):
                            canned_acl=None, progress_callback=None,
                            headers=None):
     dst_uri.set_contents_from_file(upload_stream, md5=md5, policy=canned_acl,
-                                   cb=progress_callback, headers=headers)
+                                   cb=progress_callback, headers=headers,
+                                   rewind=True)
 
   def _PerformStreamingUpload(self, dst_uri, upload_stream, canned_acl=None,
                               progress_callback=None, headers=None):


### PR DESCRIPTION
Added `rewind=True` to `set_contents_from_file` args.