### PR TITLE
Moved: see PR 722

### DIFF
--- a/gslib/tests/test_cp.py
+++ b/gslib/tests/test_cp.py
@@ -605,11 +605,12 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
   @SequentialAndParallelTransfer
   def test_streaming(self):
     bucket_uri = self.CreateBucket()
+    expected = six.ensure_binary('bar' + os.linesep)
     stderr = self.RunGsUtil(['cp', '-', '%s' % suri(bucket_uri, 'foo')],
                             stdin='bar', return_stderr=True)
     self.assertIn('Copying from <STDIN>', stderr)
     key_uri = bucket_uri.clone_replace_name('foo')
-    self.assertEqual(key_uri.get_contents_as_string(), b'bar\n')
+    self.assertEqual(key_uri.get_contents_as_string(), expected)
 
   @unittest.skipIf(IS_WINDOWS, 'os.mkfifo not available on Windows.')
   @SequentialAndParallelTransfer


### PR DESCRIPTION
Currently in Windows, cp_streaming test fails due to having line
ending \r\n instead of \n. Edited to look for os.linesep instead.

Bug: b/129889651