### PR TITLE
Decode filenames before creation

### DIFF
--- a/gslib/tests/testcase/base.py
+++ b/gslib/tests/testcase/base.py
@@ -205,6 +205,8 @@ class GsUtilTestCase(unittest.TestCase):
       fpath = os.path.join(tmpdir, *file_name)
     if not os.path.isdir(os.path.dirname(fpath)):
       os.makedirs(os.path.dirname(fpath))
+    if isinstance(fpath, six.binary_type):
+        fpath = fpath.decode('utf-8')
 
     with open(fpath, 'wb') as f:
       contents = (contents if contents is not None


### PR DESCRIPTION
Per b/129889537, Windows in Python 2.7 wouldn't correctly create
files with unicode characters. This is because the filename wasn't
being decoded before the temp file was being created. Added a
conditional decode to CreateTempFile in the base test case.