### PR TITLE
Remove newline concats to stdin

### DIFF
--- a/gslib/tests/test_cp.py
+++ b/gslib/tests/test_cp.py
@@ -609,7 +609,7 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
                             stdin='bar', return_stderr=True)
     self.assertIn('Copying from <STDIN>', stderr)
     key_uri = bucket_uri.clone_replace_name('foo')
-    self.assertEqual(key_uri.get_contents_as_string(), b'bar\n')
+    self.assertEqual(key_uri.get_contents_as_string(), b'bar')
 
   @unittest.skipIf(IS_WINDOWS, 'os.mkfifo not available on Windows.')
   @SequentialAndParallelTransfer

--- a/gslib/tests/testcase/integration_testcase.py
+++ b/gslib/tests/testcase/integration_testcase.py
@@ -882,11 +882,11 @@ class GsUtilIntegrationTestCase(base.GsUtilTestCase):
     if stdin is not None:
       if six.PY3:
         if isinstance(stdin, bytes):
-          stdin = (stdin + os.linesep.encode('ascii'))
+          stdin = six.ensure_binary(stdin)
         else:
-          stdin = (stdin + os.linesep).encode('utf-8')
+          stdin = stdin.encode('utf-8')
       else:
-        stdin = (stdin + os.linesep).encode('utf-8')
+        stdin = stdin.encode('utf-8')
     # checking to see if test was invoked from a par file (bundled archive)
     # if not, add python executable path to ensure correct version of python
     # is used for testing


### PR DESCRIPTION
The `RunGsUtil` method previously appended os.linesep to `stdin`s
that it encountered. This behavior doesn't reflect how Gsutil
actually operates and was removed.

This is a redo of PR #720 because new commits were merged to the head
of py-six-current and making a new PR is easier than doing a merge. :)

Bug: b/129889651