### PR TITLE
Corrected regex matching in test output

### DIFF
--- a/gslib/tests/test_Doption.py
+++ b/gslib/tests/test_Doption.py
@@ -147,7 +147,7 @@ class TestDOption(testcase.GsUtilIntegrationTestCase):
       self.assert_header_in_output(
           'x-goog-hash', 'md5=eB5eJF1ptWaXm4bijSPyxw==', stderr)
       # Check request fields show correct segments.
-      regex_str = r'''send:\s+(b')?HEAD /%s/%s HTTP/[^\\]*\\r\\n(.*)''' % (
+      regex_str = r'''send:\s+([b|u]')?HEAD /%s/%s HTTP/[^\\]*\\r\\n(.*)''' % (
           key_uri.bucket_name, key_uri.object_name)
       regex = re.compile(regex_str)
       match = regex.search(stderr)


### PR DESCRIPTION
Regex matching for test D option was broken in Python 2.x where
in some cases a string may be prepended by a u'' rather than the
expected b''.