### PR TITLE
Broaden `MonkeyPatchHttp()` for additional versions of Python3

### DIFF
--- a/gslib/utils/system_util.py
+++ b/gslib/utils/system_util.py
@@ -250,7 +250,9 @@ def IsRunningInteractively():
 
 
 def MonkeyPatchHttp():
+  # Getting python version array in the following format: [major, minor, micro]
   py_ver = [int(part) for part in platform.python_version().split('.')]
+  # Checking for and applying monkeypatch to python versions 3.4 - 3.6.7
   if (py_ver[0] == 3 and
       4 <= py_ver[1] < 6 or (py_ver[1] == 6 and py_ver[2] < 8)):
     _MonkeyPatchHttpForPython_3x()

--- a/gslib/utils/system_util.py
+++ b/gslib/utils/system_util.py
@@ -250,7 +250,7 @@ def IsRunningInteractively():
 
 def MonkeyPatchHttp():
   ver = sys.version_info
-  # Checking for and applying monkeypatch to python versions 3.4 - 3.6.6
+  # Checking for and applying monkeypatch to python versions 3.0 - 3.6.6
   if (ver.major == 3 and (ver.minor < 6 or (ver.minor == 6 and ver.micro < 7))):
     _MonkeyPatchHttpForPython_3x()
 

--- a/gslib/utils/system_util.py
+++ b/gslib/utils/system_util.py
@@ -249,15 +249,9 @@ def IsRunningInteractively():
 
 
 def MonkeyPatchHttp():
-  # Getting python version array in the following format: [major, minor, micro]
-  py_ver = [
-      sys.version_info.major,
-      sys.version_info.minor,
-      sys.version_info.micro
-  ]
+  ver = sys.version_info
   # Checking for and applying monkeypatch to python versions 3.4 - 3.6.7
-  if (py_ver[0] == 3 and
-      4 <= py_ver[1] < 6 or (py_ver[1] == 6 and py_ver[2] < 8)):
+  if (ver.major == 3 and (ver.minor < 6 or (ver.minor == 6 and ver.micro < 8))):
     _MonkeyPatchHttpForPython_3x()
 
 

--- a/gslib/utils/system_util.py
+++ b/gslib/utils/system_util.py
@@ -251,7 +251,8 @@ def IsRunningInteractively():
 
 def MonkeyPatchHttp():
   py_ver = [int(part) for part in platform.python_version().split('.')]
-  if (py_ver[0] == 3 and 4 <= py_ver[1] <= 6):
+  if (py_ver[0] == 3 and
+      4 <= py_ver[1] < 6 or (py_ver[1] == 6 and py_ver[2] < 8)):
     _MonkeyPatchHttpForPython_3x()
 
 

--- a/gslib/utils/system_util.py
+++ b/gslib/utils/system_util.py
@@ -251,7 +251,11 @@ def IsRunningInteractively():
 
 def MonkeyPatchHttp():
   # Getting python version array in the following format: [major, minor, micro]
-  py_ver = [int(part) for part in platform.python_version().split('.')]
+  py_ver = [
+      sys.version_info.major,
+      sys.version_info.minor,
+      sys.version_info.micro
+  ]
   # Checking for and applying monkeypatch to python versions 3.4 - 3.6.7
   if (py_ver[0] == 3 and
       4 <= py_ver[1] < 6 or (py_ver[1] == 6 and py_ver[2] < 8)):

--- a/gslib/utils/system_util.py
+++ b/gslib/utils/system_util.py
@@ -27,7 +27,6 @@ from __future__ import unicode_literals
 import errno
 import locale
 import os
-import platform
 import struct
 import sys
 

--- a/gslib/utils/system_util.py
+++ b/gslib/utils/system_util.py
@@ -250,8 +250,8 @@ def IsRunningInteractively():
 
 def MonkeyPatchHttp():
   ver = sys.version_info
-  # Checking for and applying monkeypatch to python versions 3.4 - 3.6.7
-  if (ver.major == 3 and (ver.minor < 6 or (ver.minor == 6 and ver.micro < 8))):
+  # Checking for and applying monkeypatch to python versions 3.4 - 3.6.6
+  if (ver.major == 3 and (ver.minor < 6 or (ver.minor == 6 and ver.micro < 7))):
     _MonkeyPatchHttpForPython_3x()
 
 

--- a/gslib/utils/system_util.py
+++ b/gslib/utils/system_util.py
@@ -250,11 +250,12 @@ def IsRunningInteractively():
 
 
 def MonkeyPatchHttp():
-  if platform.python_version().startswith('3.6.5'):
-    _MonkeyPatchHttpForPython_3_6_5()
+  py_ver = [int(part) for part in platform.python_version().split('.')]
+  if (py_ver[0] == 3 and 4 <= py_ver[1] <= 6):
+    _MonkeyPatchHttpForPython_3x()
 
 
-def _MonkeyPatchHttpForPython_3_6_5():
+def _MonkeyPatchHttpForPython_3x():
   # We generally have to do all sorts of gross things when applying runtime
   # patches (dynamic imports, invalid names to resolve symbols in copy/pasted
   # methods, invalid spacing from copy/pasted methods, etc.), so we just disable

--- a/gslib/utils/system_util.py
+++ b/gslib/utils/system_util.py
@@ -275,8 +275,8 @@ def _MonkeyPatchHttpForPython_3x():
   def PatchedBegin(self):
     old_begin(self)
     if self.debuglevel > 0:
-      for hdr in self.headers:
-        print("header:", hdr + ":", self.headers.get(hdr))
+      for hdr, val in self.headers.items():
+        print("header:", hdr + ":", val)
 
   http.client.HTTPResponse.begin = PatchedBegin
 


### PR DESCRIPTION
Some versions of python do not print values along with the keys
of headers returned. Original monkeypatch was only for 3.6.5, but
testing showed additional version of python also needed the fix.