### PR TITLE
Add host header support for JSON

### DIFF
--- a/gslib/commands/config.py
+++ b/gslib/commands/config.py
@@ -1070,6 +1070,9 @@ class ConfigCommand(Command):
           '# Setting a non-default gs_host only works if prefer_api=xml.\n'
           '#%s_host = <alternate storage host address>\n'
           '#%s_port = <alternate storage host port>\n'
+          '# In some cases, (e.g. VPC requests) the "host" HTTP header should\n'
+          '# be different than the host used in the request URL.
+          '#%s_host_header = <alternate storage host header>\n'
           % (host_key, host_key))
       if host_key == 'gs':
         config_file.write(

--- a/gslib/commands/config.py
+++ b/gslib/commands/config.py
@@ -1071,7 +1071,7 @@ class ConfigCommand(Command):
           '#%s_host = <alternate storage host address>\n'
           '#%s_port = <alternate storage host port>\n'
           '# In some cases, (e.g. VPC requests) the "host" HTTP header should\n'
-          '# be different than the host used in the request URL.
+          '# be different than the host used in the request URL.\n'
           '#%s_host_header = <alternate storage host header>\n'
           % (host_key, host_key))
       if host_key == 'gs':

--- a/gslib/commands/config.py
+++ b/gslib/commands/config.py
@@ -198,6 +198,7 @@ _DETAILED_HELP_TEXT = ("""
       gs_access_key_id
       gs_host
       gs_json_host
+      gs_json_host_header
       gs_json_port
       gs_oauth2_refresh_token
       gs_port
@@ -1074,6 +1075,7 @@ class ConfigCommand(Command):
         config_file.write(
             '#%s_json_host = <alternate JSON API storage host address>\n'
             '#%s_json_port = <alternate JSON API storage host port>\n\n'
+            '#%s_json_host_header = <alternate JSON API storage host header>\n\n'
             % (host_key, host_key))
       config_file.write('\n')
 

--- a/gslib/commands/config.py
+++ b/gslib/commands/config.py
@@ -197,6 +197,7 @@ _DETAILED_HELP_TEXT = ("""
       aws_secret_access_key
       gs_access_key_id
       gs_host
+      gs_host_header
       gs_json_host
       gs_json_host_header
       gs_json_port
@@ -207,6 +208,7 @@ _DETAILED_HELP_TEXT = ("""
       gs_service_key_file
       gs_service_key_file_password
       s3_host
+      s3_host_header
       s3_port
 
     [Boto]

--- a/gslib/gcs_json_api.py
+++ b/gslib/gcs_json_api.py
@@ -223,7 +223,13 @@ class GcsJsonApi(CloudApi):
 
     self.global_params = apitools_messages.StandardQueryParameters(
         trace='token:%s' % trace_token) if trace_token else None
+
     additional_http_headers = {}
+
+    gs_json_host_header = config.get('Credentials', 'gs_json_host_header', None)
+    if gs_json_host_header and gs_json_host:
+      additional_http_headers['Host'] = gs_json_host_header
+
     self._AddPerfTraceTokenToHeaders(additional_http_headers)
 
     log_request = (debug >= 3)

--- a/gslib/tests/test_perfdiag.py
+++ b/gslib/tests/test_perfdiag.py
@@ -45,7 +45,6 @@ class TestPerfDiag(testcase.GsUtilIntegrationTestCase):
   _custom_endpoint_flags = [
       '-o', 'Credentials:gs_host=' + _gs_ip,
       '-o', 'Credentials:gs_host_header=' + _gs_host,
-      # TODO: gsutil-beta: Add host header support for JSON
       '-o', 'Boto:https_validate_certificates=False']
 
   def _should_run_with_custom_endpoints(self):

--- a/gslib/tests/testcase/integration_testcase.py
+++ b/gslib/tests/testcase/integration_testcase.py
@@ -941,7 +941,7 @@ class GsUtilIntegrationTestCase(base.GsUtilTestCase):
     # Also, maintain any custom host/port/API configuration, since we'll need
     # to contact the same host when operating in a development environment.
     for creds_config_key in (
-        'gs_host', 'gs_json_host', 'gs_post', 'gs_json_port'):
+        'gs_host', 'gs_json_host', 'gs_json_host_header', 'gs_post', 'gs_json_port'):
       boto_config_for_test.append(
           ('Credentials', creds_config_key,
            boto.config.get('Credentials', creds_config_key, None)))


### PR DESCRIPTION
Add host header support for JSON, see issue: #727 

```
python gsutil.py -DD -o "Credentials:gs_json_host_header=www.googleapis.com" -o "Credentials:gs_json_host=restricted.googleapis.com" ls gs://
```