### PR TITLE
Refactored test_cp to decode strings

### DIFF
--- a/gslib/tests/test_cp.py
+++ b/gslib/tests/test_cp.py
@@ -1543,8 +1543,10 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
     open(logpath, 'w').close()
     self.RunGsUtil(['cp', '-L', logpath, fpath, dsturi])
 
-    with io.open(logpath, 'r', encoding=UTF8) as f:
+    with open(logpath, 'r') as f:
       lines = f.readlines()
+    if six.PY2:
+      lines = [unicode(line, UTF8) for line in lines]
 
     self.assertEqual(len(lines), 2)
 

--- a/gslib/tests/test_cp.py
+++ b/gslib/tests/test_cp.py
@@ -1562,9 +1562,9 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
 
     results = dict(zip(expected_headers, results))
 
-    self.assertEqual(results['Source'][:7], 'file://')  # source
+    self.assertEqual(results['Source'][:7], 'file://')
     self.assertEqual(results['Destination'][:5], '%s://' %
-                     self.default_provider)      # destination
+                     self.default_provider)
 
     date_format = '%Y-%m-%dT%H:%M:%S.%fZ'
     start_date = datetime.datetime.strptime(results['Start'], date_format)

--- a/gslib/tests/test_cp.py
+++ b/gslib/tests/test_cp.py
@@ -1550,31 +1550,38 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
       lines = [unicode(line, UTF8) for line in lines]
     self.assertEqual(len(lines), 2)
 
-    # TODO(b/130189227): Refactor into dictionary results = {header: result}
     expected_headers = ['Source', 'Destination', 'Start', 'End', 'Md5',
                         'UploadId', 'Source Size', 'Bytes Transferred',
                         'Result', 'Description']
     self.assertEqual(expected_headers, lines[0].strip().split(','))
     results = lines[1].strip().split(',')
+
     for header in results:
       if isinstance(header, (six.string_types, six.text_type)):
         header = six.ensure_str(header.encode(UTF8))
-    self.assertEqual(results[0][:7], 'file://')  # source
-    self.assertEqual(results[1][:5], '%s://' %
+
+    results = dict(zip(expected_headers, results))
+
+    self.assertEqual(results['Source'][:7], 'file://')  # source
+    self.assertEqual(results['Destination'][:5], '%s://' %
                      self.default_provider)      # destination
+
     date_format = '%Y-%m-%dT%H:%M:%S.%fZ'
-    start_date = datetime.datetime.strptime(results[2], date_format)
-    end_date = datetime.datetime.strptime(results[3], date_format)
+    start_date = datetime.datetime.strptime(results['Start'], date_format)
+    end_date = datetime.datetime.strptime(results['End'], date_format)
     self.assertEqual(end_date > start_date, True)
+
     if self.RunGsUtil == testcase.GsUtilIntegrationTestCase.RunGsUtil:
       # Check that we didn't do automatic parallel uploads - compose doesn't
       # calculate the MD5 hash. Since RunGsUtil is overriden in
       # TestCpParallelUploads to force parallel uploads, we can check which
       # method was used.
-      self.assertEqual(results[4], 'rL0Y20zC+Fzt72VPzMSk2A==')  # md5
-    self.assertEqual(int(results[6]), 3)  # Source Size
-    self.assertEqual(int(results[7]), 3)  # Bytes Transferred
-    self.assertEqual(results[8], 'OK')  # Result
+      self.assertEqual(results['Md5'], 'rL0Y20zC+Fzt72VPzMSk2A==')
+
+    self.assertEqual(int(results['Source Size']), 3)
+    self.assertEqual(int(results['Bytes Transferred']), 3)
+    self.assertEqual(results['Result'], 'OK')
+
 
   @SequentialAndParallelTransfer
   def test_cp_manifest_download(self):

--- a/gslib/tests/test_cp.py
+++ b/gslib/tests/test_cp.py
@@ -34,7 +34,7 @@ import re
 import string
 import sys
 import threading
-import ast
+import io
 
 import six
 from six.moves import http_client
@@ -1542,12 +1542,10 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
     # Ensure the file is empty.
     open(logpath, 'w').close()
     self.RunGsUtil(['cp', '-L', logpath, fpath, dsturi])
-    with open(logpath, 'r') as f:
+
+    with io.open(logpath, 'r', encoding=UTF8) as f:
       lines = f.readlines()
-    if six.PY3:
-      lines = [six.ensure_str(line.encode(UTF8)) for line in lines]
-    else:  # PY2
-      lines = [unicode(line, UTF8) for line in lines]
+
     self.assertEqual(len(lines), 2)
 
     expected_headers = ['Source', 'Destination', 'Start', 'End', 'Md5',
@@ -1558,7 +1556,7 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
 
     for header in results:
       if isinstance(header, (six.string_types, six.text_type)):
-        header = six.ensure_str(header.encode(UTF8))
+        header = six.ensure_str(header)
 
     results = dict(zip(expected_headers, results))
 

--- a/gslib/utils/copy_helper.py
+++ b/gslib/utils/copy_helper.py
@@ -3684,14 +3684,14 @@ class Manifest(object):
     data = [
         six.ensure_str(row_item['source_uri']),
         six.ensure_str(row_item['destination_uri']),
-        '%sZ' % row_item['start_time'].isoformat(),
-        '%sZ' % row_item['end_time'].isoformat(),
-        row_item['md5'] if 'md5' in row_item else '',
-        row_item['upload_id'] if 'upload_id' in row_item else '',
+        six.ensure_str('%sZ' % row_item['start_time'].isoformat()),
+        six.ensure_str('%sZ' % row_item['end_time'].isoformat()),
+        six.ensure_str(row_item['md5']) if 'md5' in row_item else '',
+        six.ensure_str(row_item['upload_id']) if 'upload_id' in row_item else '',
         six.ensure_str(str(row_item['size'])) if 'size' in row_item else '',
         six.ensure_str(str(row_item['bytes'])) if 'bytes' in row_item else '',
-        row_item['result'],
-        row_item['description']]
+        six.ensure_str(row_item['result']),
+        six.ensure_str(row_item['description'])]
 
     # Aquire a lock to prevent multiple threads writing to the same file at
     # the same time. This would cause a garbled mess in the manifest file.

--- a/gslib/utils/copy_helper.py
+++ b/gslib/utils/copy_helper.py
@@ -27,6 +27,7 @@ import datetime
 import errno
 import gzip
 from hashlib import md5
+import io
 import json
 import logging
 import mimetypes
@@ -3590,7 +3591,7 @@ class Manifest(object):
     """
     try:
       if os.path.exists(self.manifest_path):
-        with open(self.manifest_path, 'r') as f:
+        with io.open(self.manifest_path, 'r', encoding=UTF8) as f:
           first_row = True
           reader = csv.reader(f)
           for row in reader:
@@ -3681,16 +3682,16 @@ class Manifest(object):
     """Writes a manifest entry to the manifest file for the url argument."""
     row_item = self.items[url]
     data = [
-        six.ensure_str(row_item['source_uri'].encode(UTF8)),
-        six.ensure_str(row_item['destination_uri'].encode(UTF8)),
+        row_item['source_uri'],
+        row_item['destination_uri'],
         '%sZ' % row_item['start_time'].isoformat(),
         '%sZ' % row_item['end_time'].isoformat(),
         row_item['md5'] if 'md5' in row_item else '',
         row_item['upload_id'] if 'upload_id' in row_item else '',
-        six.ensure_str(str(row_item['size'])) if 'size' in row_item else '',
-        six.ensure_str(str(row_item['bytes'])) if 'bytes' in row_item else '',
-        six.ensure_str(row_item['result'].encode(UTF8)),
-        six.ensure_str(row_item['description'].encode(UTF8))]
+        str(row_item['size']) if 'size' in row_item else '',
+        str(row_item['bytes']) if 'bytes' in row_item else '',
+        row_item['result'],
+        row_item['description']]
 
     # Aquire a lock to prevent multiple threads writing to the same file at
     # the same time. This would cause a garbled mess in the manifest file.

--- a/gslib/utils/copy_helper.py
+++ b/gslib/utils/copy_helper.py
@@ -3681,17 +3681,16 @@ class Manifest(object):
     """Writes a manifest entry to the manifest file for the url argument."""
     row_item = self.items[url]
     data = [
-        row_item['source_uri'],
-        row_item['destination_uri'],
+        six.ensure_str(row_item['source_uri'].encode(UTF8)),
+        six.ensure_str(row_item['destination_uri'].encode(UTF8)),
         '%sZ' % row_item['start_time'].isoformat(),
         '%sZ' % row_item['end_time'].isoformat(),
         row_item['md5'] if 'md5' in row_item else '',
         row_item['upload_id'] if 'upload_id' in row_item else '',
-        row_item['size'] if 'size' in row_item else '',
-        row_item['bytes'] if 'bytes' in row_item else '',
-        row_item['result'],
-        row_item['description']]
-    data = [six.ensure_str(str(item).encode(UTF8)) for item in data]
+        six.ensure_str(str(row_item['size'])) if 'size' in row_item else '',
+        six.ensure_str(str(row_item['bytes'])) if 'bytes' in row_item else '',
+        six.ensure_str(row_item['result'].encode(UTF8)),
+        six.ensure_str(row_item['description'].encode(UTF8))]
 
     # Aquire a lock to prevent multiple threads writing to the same file at
     # the same time. This would cause a garbled mess in the manifest file.

--- a/gslib/utils/copy_helper.py
+++ b/gslib/utils/copy_helper.py
@@ -3591,7 +3591,7 @@ class Manifest(object):
     """
     try:
       if os.path.exists(self.manifest_path):
-        with io.open(self.manifest_path, 'r', encoding=UTF8) as f:
+        with open(self.manifest_path, 'r') as f:
           first_row = True
           reader = csv.reader(f)
           for row in reader:
@@ -3682,14 +3682,14 @@ class Manifest(object):
     """Writes a manifest entry to the manifest file for the url argument."""
     row_item = self.items[url]
     data = [
-        row_item['source_uri'],
-        row_item['destination_uri'],
+        six.ensure_str(row_item['source_uri']),
+        six.ensure_str(row_item['destination_uri']),
         '%sZ' % row_item['start_time'].isoformat(),
         '%sZ' % row_item['end_time'].isoformat(),
         row_item['md5'] if 'md5' in row_item else '',
         row_item['upload_id'] if 'upload_id' in row_item else '',
-        str(row_item['size']) if 'size' in row_item else '',
-        str(row_item['bytes']) if 'bytes' in row_item else '',
+        six.ensure_str(str(row_item['size'])) if 'size' in row_item else '',
+        six.ensure_str(str(row_item['bytes'])) if 'bytes' in row_item else '',
         row_item['result'],
         row_item['description']]
 

--- a/gslib/utils/copy_helper.py
+++ b/gslib/utils/copy_helper.py
@@ -3694,7 +3694,7 @@ class Manifest(object):
         row_item['result'],
         row_item['description']]
 
-    data = [six.ensure_str(header) for header in data]
+    data = [six.ensure_str(value) for value in data]
 
     # Aquire a lock to prevent multiple threads writing to the same file at
     # the same time. This would cause a garbled mess in the manifest file.


### PR DESCRIPTION
Previous logic was manually removing `b' '` from around strings that
weren't decoded. Refactored so that strings are decoded and don't need
to be stripped.

Bugs: b/130189680 , b/130189227