### PR TITLE
Contribution doc updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,8 @@ https://cloud.google.com/storage/docs/gsutil_install
 
 The gsutil source code is available at https://github.com/GoogleCloudPlatform/gsutil
 
-Note: Currently we do not directly accept pull requests on GitHub -- see
-https://cloud.google.com/storage/docs/gsutil/addlhelp/ContributingCodetogsutil
-on how to contribute code changes.
+See https://cloud.google.com/storage/docs/gsutil/addlhelp/ContributingCodetogsutil
+for best practices on how to contribute code changes to the gsutil repository.
 
 ## Help and Support
 

--- a/gslib/addlhelp/dev.py
+++ b/gslib/addlhelp/dev.py
@@ -117,10 +117,10 @@ _DETAILED_HELP_TEXT = ("""
   9. Please consider contributing test code for your change, especially if the
      change impacts any of the core gsutil code (like the gsutil cp command).
 
-  10. When it's time to send us code, please submit a PR to the [gsutil GitHub
-      repository](https://github.com/GoogleCloudPlatform/gsutil). For help on
+  10. When it's time to send us code, please submit a PR to the `gsutil GitHub
+      repository <https://github.com/GoogleCloudPlatform/gsutil>`_. For help on
       making GitHub PRs, please refer to this
-      [GitHub help document](https://help.github.com/en/articles/about-pull-requests).
+      `GitHub help document <https://help.github.com/en/articles/about-pull-requests>`_.
 """)
 
 

--- a/gslib/addlhelp/dev.py
+++ b/gslib/addlhelp/dev.py
@@ -117,20 +117,10 @@ _DETAILED_HELP_TEXT = ("""
   9. Please consider contributing test code for your change, especially if the
      change impacts any of the core gsutil code (like the gsutil cp command).
 
-  10. When it's time to send us code, please use the Rietveld code review tool
-      rather than simply sending us a code patch. Do this as follows:
-
-      - Check out the gsutil code from your fork of the gsutil repository and
-        apply your changes.
-      - Download the "upload.py" script from
-        https://github.com/rietveld-codereview/rietveld
-      - Run upload.py from your git directory with the changes.
-      - Click the codereview.appspot.com link it generates, click "Edit Issue",
-        and add mfschwartz@google.com and thobrla@google.com as reviewers, and
-        Cc gs-team@google.com.
-      - Click Publish+Mail Comments.
-      - Once your changes are accepted, submit a pull request on GitHub and we
-        will merge your commits.
+  10. When it's time to send us code, please submit a PR to the [gsutil GitHub
+      repository](https://github.com/GoogleCloudPlatform/gsutil). For help on
+      making GitHub PRs, please refer to this
+      [GitHub help document](https://help.github.com/en/articles/about-pull-requests).
 """)
 
 

--- a/test/ci/CI.md
+++ b/test/ci/CI.md
@@ -9,7 +9,7 @@
 
 Kokoro aims to be our primary CI system. For internal Googlers, its documentation is at [go/gsutil-ci](http://go/gsutil-ci) and the design document for integrating with Kokoro is at [go/gsutil-test-matrix](http://go/gsutil-test-matrix).
 
-These tests launch every time a PR is submitted by a trusted author (Googler in the GoogleCloudPlatform org), or when a trusted author manually invokes tests on an external contributer's PR.
+These tests launch every time a PR is submitted by a trusted author (Googler in the GoogleCloudPlatform org), or when a trusted author manually invokes tests on an external contributer's PR by applying the `kokoro:run` label.
 
 The build configs found in this repository under the `gsutil/test/ci/kokoro` directory and the job configs found internally at [go/gsutil-kokoro-piper](http://go/gsutil-kokoro-piper) define how Kokoro will run our tests, with what scripts, and with which VMs.
 
@@ -20,7 +20,7 @@ We currently support Gsutil on Windows, Mac, and Linux, using Python versoins 2.
 
 Each of these 24 combinations of `(OS / Python version / API)` is run on a separate VM managed by Kokoro, all running in parallel.
 
-These tests launch every time a PR is submitted by a trusted author (Googler in the GoogleCloudPlatform org), or when a trusted author manually invokes tests on an external contributer's PR.
+These tests launch every time a PR is submitted by a trusted author (Googler in the GoogleCloudPlatform org), or when a trusted author manually invokes tests on an external contributer's PR by applying the `kokoro:run` label.
 
 ### Test Scripts
 -----


### PR DESCRIPTION
- Removed note from readme that we don't accept PRs
- Updated contributer guide to direct people to use PRs
- Added note about using `kokoro:run` tag to run CI on external contributions