### PR TITLE
Fixed path to Windows build file (#710)

### DIFF
--- a/test/ci/kokoro/windows/continuous.cfg
+++ b/test/ci/kokoro/windows/continuous.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "gsutil/test/ci/kokoro/windows/run_integ_tests.bat"
+build_file: "src/gsutil/test/ci/kokoro/windows/run_integ_tests.bat"
 timeout_mins: 60
 
 

--- a/test/ci/kokoro/windows/presubmit.cfg
+++ b/test/ci/kokoro/windows/presubmit.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "gsutil/test/ci/kokoro/windows/run_integ_tests.bat"
+build_file: "src/gsutil/test/ci/kokoro/windows/run_integ_tests.bat"
 timeout_mins: 60
 
 

--- a/test/ci/kokoro/windows/py27_json.cfg
+++ b/test/ci/kokoro/windows/py27_json.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "gsutil/test/ci/kokoro/windows/run_integ_tests.bat"
+build_file: "src/gsutil/test/ci/kokoro/windows/run_integ_tests.bat"
 timeout_mins: 60
 
 

--- a/test/ci/kokoro/windows/py27_xml.cfg
+++ b/test/ci/kokoro/windows/py27_xml.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "gsutil/test/ci/kokoro/windows/run_integ_tests.bat"
+build_file: "src/gsutil/test/ci/kokoro/windows/run_integ_tests.bat"
 timeout_mins: 60
 
 

--- a/test/ci/kokoro/windows/py35_json.cfg
+++ b/test/ci/kokoro/windows/py35_json.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "gsutil/test/ci/kokoro/windows/run_integ_tests.bat"
+build_file: "src/gsutil/test/ci/kokoro/windows/run_integ_tests.bat"
 timeout_mins: 60
 
 

--- a/test/ci/kokoro/windows/py35_xml.cfg
+++ b/test/ci/kokoro/windows/py35_xml.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "gsutil/test/ci/kokoro/windows/run_integ_tests.bat"
+build_file: "src/gsutil/test/ci/kokoro/windows/run_integ_tests.bat"
 timeout_mins: 60
 
 

--- a/test/ci/kokoro/windows/py36_json.cfg
+++ b/test/ci/kokoro/windows/py36_json.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "gsutil/test/ci/kokoro/windows/run_integ_tests.bat"
+build_file: "src/gsutil/test/ci/kokoro/windows/run_integ_tests.bat"
 timeout_mins: 60
 
 

--- a/test/ci/kokoro/windows/py36_xml.cfg
+++ b/test/ci/kokoro/windows/py36_xml.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "gsutil/test/ci/kokoro/windows/run_integ_tests.bat"
+build_file: "src/gsutil/test/ci/kokoro/windows/run_integ_tests.bat"
 timeout_mins: 60
 
 

--- a/test/ci/kokoro/windows/py37_json.cfg
+++ b/test/ci/kokoro/windows/py37_json.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "gsutil/test/ci/kokoro/windows/run_integ_tests.bat"
+build_file: "src/gsutil/test/ci/kokoro/windows/run_integ_tests.bat"
 timeout_mins: 60
 
 

--- a/test/ci/kokoro/windows/py37_xml.cfg
+++ b/test/ci/kokoro/windows/py37_xml.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "gsutil/test/ci/kokoro/windows/run_integ_tests.bat"
+build_file: "src/gsutil/test/ci/kokoro/windows/run_integ_tests.bat"
 timeout_mins: 60
 
 


### PR DESCRIPTION
Windows configs needed the full directory path *after* the local
T:\src\github but including the leading /src/ dir. After testing
on the ci-testing branches, Kokoro can find the build script with
this path.

This commit happened before, but I think I mowed it over in a
recent merge. Re-applying it to head with:
```
git checkout -b winbuild2 origin/master
git cherry-pick f30a5f0c4bbdad0692f07b4df553b165549a71c2 -X theirs
```