### PR TITLE
Replaced 'utf-8' literals with constants.UTF8

### DIFF
--- a/gslib/boto_resumable_upload.py
+++ b/gslib/boto_resumable_upload.py
@@ -64,6 +64,7 @@ from gslib.exception import InvalidUrlError
 from gslib.utils.boto_util import GetMaxRetryDelay
 from gslib.utils.boto_util import GetNumRetries
 from gslib.utils.constants import XML_PROGRESS_CALLBACKS
+from gslib.utils.constants import UTF8
 
 
 if six.PY3:
@@ -354,7 +355,7 @@ class BotoResumableUpload(object):
           total_bytes_uploaded += len(buf)
         else:
           # Probably a unicode/str object, try encoding.
-          buf_bytes = buf.encode('utf-8')
+          buf_bytes = buf.encode(UTF8)
           http_conn.send(buf_bytes)
           total_bytes_uploaded += len(buf_bytes)
 

--- a/gslib/commands/ls.py
+++ b/gslib/commands/ls.py
@@ -509,7 +509,7 @@ class LsCommand(Command):
 
     def MaybePrintBucketHeader(blr):
       if len(self.args) > 1:
-        text_util.print_to_fd('%s:' % blr.url_string.decode('utf-8'))
+        text_util.print_to_fd('%s:' % blr.url_string.decode(UTF8))
     print_bucket_header = MaybePrintBucketHeader
 
     for url_str in self.args:
@@ -566,7 +566,7 @@ class LsCommand(Command):
         # URL names a bucket, object, or object subdir ->
         # list matching object(s) / subdirs.
         def _PrintPrefixLong(blr):
-          text_util.print_to_fd('%-33s%s' % ('', blr.url_string.decode('utf-8')))
+          text_util.print_to_fd('%-33s%s' % ('', blr.url_string.decode(UTF8)))
 
         if listing_style == ListingStyle.SHORT:
           # ls helper by default readies us for a short listing.

--- a/gslib/commands/perfdiag.py
+++ b/gslib/commands/perfdiag.py
@@ -60,6 +60,7 @@ from gslib.third_party.storage_apitools import storage_v1_messages as apitools_m
 from gslib.utils import text_util
 from gslib.utils.boto_util import GetMaxRetryDelay
 from gslib.utils.boto_util import ResumableThreshold
+from gslib.utils.constants import UTF8
 from gslib.utils.cloud_api_helper import GetCloudApiInstance
 from gslib.utils.cloud_api_helper import GetDownloadSerializationData
 from gslib.utils.hashing_helper import CalculateB64EncodedMd5FromContents
@@ -524,7 +525,7 @@ class PerfDiagCommand(Command):
     (stdoutdata, _) = p.communicate()
     if six.PY3:
       if isinstance(stdoutdata, bytes):
-        stdoutdata = stdoutdata.decode('utf-8')
+        stdoutdata = stdoutdata.decode(UTF8)
     if raise_on_error and p.returncode:
       raise CommandException("Received non-zero return code (%d) from "
                              "subprocess '%s'." % (p.returncode, ' '.join(cmd)))

--- a/gslib/commands/test.py
+++ b/gslib/commands/test.py
@@ -44,6 +44,7 @@ from gslib.tests.util import GetTestNames
 from gslib.tests.util import InvokedFromParFile
 from gslib.tests.util import unittest
 from gslib.utils.constants import NO_MAX
+from gslib.utils.constants import UTF8
 from gslib.utils.system_util import IS_WINDOWS
 
 # pylint: disable=g-import-not-at-top
@@ -442,7 +443,7 @@ class TestCommand(Command):
           new_stderr = result.stderr.split(b'\n')
           print('Results for failed test %s:' % result.name)
           for line in new_stderr:
-            print(line.decode('utf-8').strip())
+            print(line.decode(UTF8).strip())
 
     return (num_parallel_failures,
             (process_run_finish_time - parallel_start_time))

--- a/gslib/gcs_json_api.py
+++ b/gslib/gcs_json_api.py
@@ -83,6 +83,7 @@ from gslib.utils.boto_util import JsonResumableChunkSizeDefined
 from gslib.utils.cloud_api_helper import ListToGetFields
 from gslib.utils.cloud_api_helper import ValidateDstObjectMetadata
 from gslib.utils.constants import NUM_OBJECTS_PER_LIST_PAGE
+from gslib.utils.constants import UTF8
 from gslib.utils.encryption_helper import Base64Sha256FromBase64EncryptionKey
 from gslib.utils.encryption_helper import CryptoKeyType
 from gslib.utils.encryption_helper import CryptoKeyWrapperFromKey
@@ -869,7 +870,7 @@ class GcsJsonApi(CloudApi):
                                            bucket_name, object_name))
       if six.PY3:
         if not isinstance(decryption_key, bytes):
-          decryption_key = decryption_key.encode('utf-8')
+          decryption_key = decryption_key.encode(UTF8)
       return self._GetObjectMetadataHelper(
           bucket_name, object_name, generation=generation, fields=fields,
           decryption_tuple=CryptoKeyWrapperFromKey(decryption_key))

--- a/gslib/gcs_json_media.py
+++ b/gslib/gcs_json_media.py
@@ -38,6 +38,7 @@ from gslib.progress_callback import ProgressCallbackWithTimeout
 from gslib.utils.constants import DEBUGLEVEL_DUMP_REQUESTS
 from gslib.utils.constants import SSL_TIMEOUT_SEC
 from gslib.utils.constants import TRANSFER_BUFFER_SIZE
+from gslib.utils.constants import UTF8
 from gslib.utils import text_util
 import httplib2
 from httplib2 import parse_uri
@@ -145,7 +146,7 @@ class UploadCallbackConnectionClassFactory(object):
             if isinstance(item, bytes):
               items.append(item)
             else:
-              items.append(item.encode('utf-8'))
+              items.append(item.encode(UTF8))
         msg = b'\r\n'.join(items)
         num_metadata_bytes = len(msg)
         if outer_debug == DEBUGLEVEL_DUMP_REQUESTS and outer_logger:
@@ -258,7 +259,7 @@ class UploadCallbackConnectionClassFactory(object):
             if isinstance(partial_buffer, bytes):
               httplib2.HTTPSConnectionWithTimeout.send(self, partial_buffer)
             else:
-              httplib2.HTTPSConnectionWithTimeout.send(self, partial_buffer.encode('utf-8'))
+              httplib2.HTTPSConnectionWithTimeout.send(self, partial_buffer.encode(UTF8))
           sent_data_bytes = len(partial_buffer)
           if num_metadata_bytes:
             if num_metadata_bytes <= sent_data_bytes:

--- a/gslib/parallel_tracker_file.py
+++ b/gslib/parallel_tracker_file.py
@@ -29,6 +29,7 @@ import six
 import gslib
 from gslib.exception import CommandException
 from gslib.tracker_file import RaiseUnwritableTrackerFileException
+from gslib.utils.constants import UTF8
 
 
 ObjectFromTracker = namedtuple('ObjectFromTracker',
@@ -166,9 +167,9 @@ def ValidateParallelCompositeTrackerData(
   """
   if six.PY3:
     if isinstance(existing_enc_sha256, str):
-      existing_enc_sha256 = existing_enc_sha256.encode('utf-8')
+      existing_enc_sha256 = existing_enc_sha256.encode(UTF8)
     if isinstance(current_enc_key_sha256, str):
-      current_enc_key_sha256 = current_enc_key_sha256.encode('utf-8')
+      current_enc_key_sha256 = current_enc_key_sha256.encode(UTF8)
   if existing_prefix and existing_enc_sha256 != current_enc_key_sha256:
     try:
       logger.warn('Upload tracker file (%s) does not match current encryption '

--- a/gslib/pubsub_api.py
+++ b/gslib/pubsub_api.py
@@ -39,6 +39,7 @@ from gslib.utils.boto_util import GetCertsFile
 from gslib.utils.boto_util import GetMaxRetryDelay
 from gslib.utils.boto_util import GetNewHttp
 from gslib.utils.boto_util import GetNumRetries
+from gslib.utils.constants import UTF8
 
 
 TRANSLATABLE_APITOOLS_EXCEPTIONS = (apitools_exceptions.HttpError)
@@ -165,7 +166,7 @@ class PubsubApi(object):
     if isinstance(http_error, apitools_exceptions.HttpError):
       if getattr(http_error, 'content', None):
         try:
-          json_obj = json.loads(http_error.content.decode('utf-8'))
+          json_obj = json.loads(http_error.content.decode(UTF8))
           if 'error' in json_obj and 'message' in json_obj['error']:
             return json_obj['error']['message']
         except Exception:  # pylint: disable=broad-except

--- a/gslib/resumable_streaming_upload.py
+++ b/gslib/resumable_streaming_upload.py
@@ -25,6 +25,7 @@ import six
 
 from gslib.exception import CommandException
 from gslib.utils.boto_util import GetJsonResumableChunkSize
+from gslib.utils.constants import UTF8
 
 
 class ResumableStreamingJsonUploadWrapper(object):
@@ -157,7 +158,7 @@ class ResumableStreamingJsonUploadWrapper(object):
       if six.PY3:
         if buffered_data:
           buffered_data = [
-            bd.encode('utf-8') if isinstance(bd, str) else bd
+            bd.encode(UTF8) if isinstance(bd, str) else bd
             for bd in buffered_data]
       data = b''.join(buffered_data) if buffered_data else b''
 

--- a/gslib/tests/test_acl.py
+++ b/gslib/tests/test_acl.py
@@ -32,6 +32,7 @@ from gslib.tests.util import ObjectToURI as suri
 from gslib.tests.util import SetBotoConfigForTest
 from gslib.tests.util import unittest
 from gslib.utils import acl_helper
+from gslib.utils.constants import UTF8
 from gslib.utils.retry_util import Retry
 from gslib.utils.translation_helper import AclTranslation
 
@@ -104,7 +105,7 @@ class TestAcl(TestAclBase):
     obj_uri = suri(self.CreateObject(contents=b'foo'))
     acl_string = self.RunGsUtil(self._get_acl_prefix + [obj_uri],
                                 return_stdout=True)
-    inpath = self.CreateTempFile(contents=acl_string.encode('utf-8'))
+    inpath = self.CreateTempFile(contents=acl_string.encode(UTF8))
     self.RunGsUtil(self._set_acl_prefix + ['public-read', obj_uri])
     acl_string2 = self.RunGsUtil(self._get_acl_prefix + [obj_uri],
                                  return_stdout=True)
@@ -122,7 +123,7 @@ class TestAcl(TestAclBase):
                                 return_stdout=True)
     acl_string = re.sub(r'"role"', r'"role" \n', acl_string)
     acl_string = re.sub(r'"entity"', r'\n "entity"', acl_string)
-    inpath = self.CreateTempFile(contents=acl_string.encode('utf-8'))
+    inpath = self.CreateTempFile(contents=acl_string.encode(UTF8))
 
     self.RunGsUtil(self._set_acl_prefix + [inpath, obj_uri])
 
@@ -134,7 +135,7 @@ class TestAcl(TestAclBase):
     bucket_uri = suri(self.CreateBucket())
     acl_string = self.RunGsUtil(self._get_acl_prefix + [bucket_uri],
                                 return_stdout=True)
-    inpath = self.CreateTempFile(contents=acl_string.encode('utf-8'))
+    inpath = self.CreateTempFile(contents=acl_string.encode(UTF8))
     self.RunGsUtil(self._set_acl_prefix + ['public-read', bucket_uri])
     acl_string2 = self.RunGsUtil(self._get_acl_prefix + [bucket_uri],
                                  return_stdout=True)
@@ -179,7 +180,7 @@ class TestAcl(TestAclBase):
     _Check1()
 
     # Now change it back to the default via XML.
-    inpath = self.CreateTempFile(contents=acl_string.encode('utf-8'))
+    inpath = self.CreateTempFile(contents=acl_string.encode(UTF8))
     self.RunGsUtil(self._set_defacl_prefix + [inpath, suri(bucket_uri)])
 
     # Default object ACL may take some time to propagate.
@@ -509,7 +510,7 @@ class TestAcl(TestAclBase):
     # Get the object's current ACL for application via set.
     current_acl = self.RunGsUtil(['acl', 'get', suri(object_uri)],
                                  return_stdout=True)
-    current_acl_file = self.CreateTempFile(contents=current_acl.encode('utf-8'))
+    current_acl_file = self.CreateTempFile(contents=current_acl.encode(UTF8))
 
     with SetBotoConfigForTest([('GSUtil', 'task_estimation_threshold', '1'),
                                ('GSUtil', 'task_estimation_force', 'True')]):
@@ -684,14 +685,14 @@ class TestS3CompatibleAcl(TestAclBase):
 
     stdout = self.RunGsUtil(self._get_acl_prefix + [suri(obj_uri)],
                             return_stdout=True)
-    set_contents = self.CreateTempFile(contents=stdout.encode('utf-8'))
+    set_contents = self.CreateTempFile(contents=stdout.encode(UTF8))
     self.RunGsUtil(self._set_acl_prefix + [set_contents, suri(obj_uri)])
 
   def testAclBucketGetSet(self):
     bucket_uri = self.CreateBucket()
     stdout = self.RunGsUtil(self._get_acl_prefix + [suri(bucket_uri)],
                             return_stdout=True)
-    set_contents = self.CreateTempFile(contents=stdout.encode('utf-8'))
+    set_contents = self.CreateTempFile(contents=stdout.encode(UTF8))
     self.RunGsUtil(self._set_acl_prefix + [set_contents, suri(bucket_uri)])
 
 

--- a/gslib/tests/test_bucketconfig.py
+++ b/gslib/tests/test_bucketconfig.py
@@ -23,6 +23,7 @@ import json
 import gslib.tests.testcase as testcase
 from gslib.tests.testcase.integration_testcase import SkipForS3
 from gslib.tests.util import ObjectToURI as suri
+from gslib.utils.constants import UTF8
 
 
 class TestBucketConfig(testcase.GsUtilIntegrationTestCase):
@@ -61,8 +62,8 @@ class TestBucketConfig(testcase.GsUtilIntegrationTestCase):
     """Tests that bucket config patching affects only the desired config."""
     bucket_uri = self.CreateBucket()
     lifecycle_path = self.CreateTempFile(
-        contents=self.lifecycle_doc.encode('utf-8'))
-    cors_path = self.CreateTempFile(contents=self.cors_doc.encode('utf-8'))
+        contents=self.lifecycle_doc.encode(UTF8))
+    cors_path = self.CreateTempFile(contents=self.cors_doc.encode(UTF8))
 
     self.RunGsUtil(self._set_cors_command + [cors_path, suri(bucket_uri)])
     cors_out = self.RunGsUtil(self._get_cors_command + [suri(bucket_uri)],

--- a/gslib/tests/test_cors.py
+++ b/gslib/tests/test_cors.py
@@ -26,6 +26,7 @@ from xml.dom.minidom import parseString
 import gslib.tests.testcase as testcase
 from gslib.tests.testcase.integration_testcase import SkipForS3
 from gslib.tests.util import ObjectToURI as suri
+from gslib.utils.constants import UTF8
 from gslib.utils.retry_util import Retry
 from gslib.utils.translation_helper import CorsTranslation
 
@@ -105,7 +106,7 @@ class TestCors(testcase.GsUtilIntegrationTestCase):
 
   def test_set_empty_cors1(self):
     bucket_uri = self.CreateBucket()
-    fpath = self.CreateTempFile(contents=self.empty_doc1.encode('utf-8'))
+    fpath = self.CreateTempFile(contents=self.empty_doc1.encode(UTF8))
     self.RunGsUtil(self._set_cmd_prefix + [fpath, suri(bucket_uri)])
     stdout = self.RunGsUtil(self._get_cmd_prefix + [suri(bucket_uri)],
                             return_stdout=True)
@@ -113,7 +114,7 @@ class TestCors(testcase.GsUtilIntegrationTestCase):
 
   def test_set_empty_cors2(self):
     bucket_uri = self.CreateBucket()
-    fpath = self.CreateTempFile(contents=self.empty_doc2.encode('utf-8'))
+    fpath = self.CreateTempFile(contents=self.empty_doc2.encode(UTF8))
     self.RunGsUtil(self._set_cmd_prefix + [fpath, suri(bucket_uri)])
     stdout = self.RunGsUtil(self._get_cmd_prefix + [suri(bucket_uri)],
                             return_stdout=True)
@@ -121,7 +122,7 @@ class TestCors(testcase.GsUtilIntegrationTestCase):
 
   def test_non_null_cors(self):
     bucket_uri = self.CreateBucket()
-    fpath = self.CreateTempFile(contents=self.cors_doc.encode('utf-8'))
+    fpath = self.CreateTempFile(contents=self.cors_doc.encode(UTF8))
     self.RunGsUtil(self._set_cmd_prefix + [fpath, suri(bucket_uri)])
     stdout = self.RunGsUtil(self._get_cmd_prefix + [suri(bucket_uri)],
                             return_stdout=True)
@@ -129,14 +130,14 @@ class TestCors(testcase.GsUtilIntegrationTestCase):
 
   def test_bad_cors_xml(self):
     bucket_uri = self.CreateBucket()
-    fpath = self.CreateTempFile(contents=self.xml_cors_doc.encode('utf-8'))
+    fpath = self.CreateTempFile(contents=self.xml_cors_doc.encode(UTF8))
     stderr = self.RunGsUtil(self._set_cmd_prefix + [fpath, suri(bucket_uri)],
                             expected_status=1, return_stderr=True)
     self.assertIn('XML CORS data provided', stderr)
 
   def test_bad_cors(self):
     bucket_uri = self.CreateBucket()
-    fpath = self.CreateTempFile(contents=self.cors_bad.encode('utf-8'))
+    fpath = self.CreateTempFile(contents=self.cors_bad.encode(UTF8))
     stderr = self.RunGsUtil(self._set_cmd_prefix + [fpath, suri(bucket_uri)],
                             expected_status=1, return_stderr=True)
     self.assertNotIn('XML CORS data provided', stderr)
@@ -144,7 +145,7 @@ class TestCors(testcase.GsUtilIntegrationTestCase):
   def test_cors_doc_not_wrapped_in_json_list(self):
     bucket_uri = self.CreateBucket()
     fpath = self.CreateTempFile(
-      contents=self.cors_doc_not_nested_in_list.encode('utf-8'))
+      contents=self.cors_doc_not_nested_in_list.encode(UTF8))
     stderr = self.RunGsUtil(self._set_cmd_prefix + [fpath, suri(bucket_uri)],
                             expected_status=1, return_stderr=True)
     self.assertIn('should be formatted as a list', stderr)
@@ -212,7 +213,7 @@ class TestCors(testcase.GsUtilIntegrationTestCase):
         'gs://%sgsutil-test-test-set-wildcard-non-null-cors-' % random_prefix))
     wildcard = '%s*' % common_prefix
 
-    fpath = self.CreateTempFile(contents=self.cors_doc.encode('utf-8'))
+    fpath = self.CreateTempFile(contents=self.cors_doc.encode(UTF8))
 
     # Use @Retry as hedge against bucket listing eventual consistency.
     expected = set(['Setting CORS on %s/...' % suri(bucket1_uri),

--- a/gslib/tests/test_cp.py
+++ b/gslib/tests/test_cp.py
@@ -261,7 +261,7 @@ def TestCpMvPOSIXBucketToLocalNoErrors(cls, bucket_uri, tmpdir, is_cp=True):
     gid = attrs_dict.get(GID_ATTR)
     mode = attrs_dict.get(MODE_ATTR)
     cls.CreateObject(bucket_uri=bucket_uri, object_name=obj_name,
-                     contents=obj_name.encode('utf-8'),
+                     contents=obj_name.encode(UTF8),
                      uid=uid, gid=gid, mode=mode)
   for obj_name in six.iterkeys(test_params):
     # Move objects one at a time to avoid listing consistency.
@@ -1386,7 +1386,7 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
     contents = b'content'
     fpath = self.CreateTempFile(contents=contents)
     stdout = self.RunGsUtil(['cp', fpath, '-'], return_stdout=True)
-    self.assertIn(contents, stdout.encode('utf-8'))
+    self.assertIn(contents, stdout.encode(UTF8))
 
   @SequentialAndParallelTransfer
   def test_cp_zero_byte_file(self):
@@ -1524,8 +1524,8 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
                    'Unicode handling on Windows requires mods to site-packages')
   @SequentialAndParallelTransfer
   def test_cp_manifest_upload_unicode(self):
-    return self._ManifestUpload('foo-unicöde'.encode('utf-8'), 'bar-unicöde'.encode('utf-8'),
-                                'manifest-unicöde'.encode('utf-8'))
+    return self._ManifestUpload('foo-unicöde'.encode(UTF8), 'bar-unicöde'.encode(UTF8),
+                                'manifest-unicöde'.encode(UTF8))
 
   @SequentialAndParallelTransfer
   def test_cp_manifest_upload(self):
@@ -1603,7 +1603,7 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
           line_parts = []
           for some_str in some_strs:
             if some_str.startswith("b'"):
-              line_parts.append(ast.literal_eval(some_str).decode('utf-8'))
+              line_parts.append(ast.literal_eval(some_str).decode(UTF8))
             else:
               line_parts.append(some_str)
           decode_lines.append(','.join(line_parts))

--- a/gslib/tests/test_du.py
+++ b/gslib/tests/test_du.py
@@ -23,6 +23,7 @@ import gslib.tests.testcase as testcase
 from gslib.tests.testcase.integration_testcase import SkipForS3
 from gslib.tests.util import GenerationFromURI as urigen
 from gslib.tests.util import ObjectToURI as suri
+from gslib.utils.constants import UTF8
 from gslib.utils.retry_util import Retry
 
 
@@ -229,7 +230,7 @@ class TestDu(testcase.GsUtilIntegrationTestCase):
     """Tests file exclusion with the -X flag."""
     bucket_uri, obj_uris = self._create_nested_subdir()
     fpath = self.CreateTempFile(
-      contents='*sub2/five*\n*sub1材/four'.encode('utf-8'))
+      contents='*sub2/five*\n*sub1材/four'.encode(UTF8))
 
     # Use @Retry as hedge against bucket listing eventual consistency.
     @Retry(AssertionError, tries=3, timeout_secs=1)

--- a/gslib/tests/test_iam.py
+++ b/gslib/tests/test_iam.py
@@ -31,6 +31,7 @@ from gslib.tests.util import GenerationFromURI as urigen
 from gslib.tests.util import SetBotoConfigForTest
 from gslib.tests.util import unittest
 from gslib.third_party.storage_apitools import storage_v1_messages as apitools_messages
+from gslib.utils.constants import UTF8
 from gslib.utils.iam_helper import BindingsToDict
 from gslib.utils.iam_helper import BindingStringToTuple as bstt
 from gslib.utils.iam_helper import BindingsTuple
@@ -736,7 +737,7 @@ class TestIamSet(TestIamIntegration):
     self.bucket_iam_string = self.RunGsUtil(
         ['iam', 'get', self.bucket.uri], return_stdout=True)
     self.old_bucket_iam_path = self.CreateTempFile(
-        contents=self.bucket_iam_string.encode('utf-8'))
+        contents=self.bucket_iam_string.encode(UTF8))
 
     # Using the existing bucket's policy, make an altered policy that allows
     # allUsers to be "legacyBucketReader"s. Some tests will later apply this
@@ -746,7 +747,7 @@ class TestIamSet(TestIamIntegration):
         IAM_BUCKET_READ_ROLE,
         self.public_bucket_read_binding)
     self.new_bucket_iam_path = self.CreateTempFile(
-        contents=json.dumps(self.new_bucket_iam_policy).encode('utf-8'))
+        contents=json.dumps(self.new_bucket_iam_policy).encode(UTF8))
 
     # Using the existing bucket's policy, make an altered policy that contains
     # a binding with a condition in it. Some tests will later apply this policy.
@@ -762,7 +763,7 @@ class TestIamSet(TestIamIntegration):
     self.object_iam_string = self.RunGsUtil(
         ['iam', 'get', tmp_object.uri], return_stdout=True)
     self.old_object_iam_path = self.CreateTempFile(
-        contents=self.object_iam_string.encode('utf-8'))
+        contents=self.object_iam_string.encode(UTF8))
 
     # Using the existing object's policy, make an altered policy that allows
     # allUsers to be "legacyObjectReader"s. Some tests will later apply this
@@ -771,7 +772,7 @@ class TestIamSet(TestIamIntegration):
         json.loads(self.object_iam_string), IAM_OBJECT_READ_ROLE,
         self.public_object_read_binding)
     self.new_object_iam_path = self.CreateTempFile(
-        contents=json.dumps(self.new_object_iam_policy).encode('utf-8'))
+        contents=json.dumps(self.new_object_iam_policy).encode(UTF8))
 
   def test_seek_ahead_iam(self):
     """Ensures that the seek-ahead iterator is being used with iam commands."""

--- a/gslib/tests/test_label.py
+++ b/gslib/tests/test_label.py
@@ -35,6 +35,7 @@ from gslib.tests.testcase.integration_testcase import SkipForGS
 from gslib.tests.testcase.integration_testcase import SkipForS3
 from gslib.tests.util import ObjectToURI as suri
 from gslib.utils.retry_util import Retry
+from gslib.utils.constants import UTF8
 
 KEY1 = 'key_one'
 KEY2 = 'key_two'
@@ -58,7 +59,7 @@ class TestLabelS3(testcase.GsUtilIntegrationTestCase):
   def setUp(self):
     super(TestLabelS3, self).setUp()
     self.xml_fpath = self.CreateTempFile(
-      contents=self._label_xml.encode('utf-8'))
+      contents=self._label_xml.encode(UTF8))
 
   def _LabelDictFromXmlString(self, xml_str):
     label_dict = {}
@@ -141,7 +142,7 @@ class TestLabelGS(testcase.GsUtilIntegrationTestCase):
   def setUp(self):
     super(TestLabelGS, self).setUp()
     self.json_fpath = self.CreateTempFile(
-      contents=json.dumps(self._label_dict).encode('utf-8'))
+      contents=json.dumps(self._label_dict).encode(UTF8))
 
   def testSetAndGetOnOneBucket(self):
     bucket_uri = self.CreateBucket()

--- a/gslib/tests/test_naming.py
+++ b/gslib/tests/test_naming.py
@@ -719,7 +719,7 @@ class GsutilNamingTests(testcase.GsUtilUnitTestCase):
     dst_bucket_uri = self.CreateBucket(test_objects=['f0'])
     output = self.RunCommand('ls', ['-R', suri(dst_bucket_uri, '*')],
                              return_stdout=True)
-    expected = set([suri(dst_bucket_uri, 'f0').encode('utf-8')])
+    expected = set([suri(dst_bucket_uri, 'f0').encode(UTF8)])
     expected.add(b'')  # Blank line between subdir listings.
     actual = set([line.strip() for line in output.split(b'\n')])
     self.assertEqual(expected, actual)
@@ -731,8 +731,8 @@ class GsutilNamingTests(testcase.GsUtilUnitTestCase):
     output = self.RunCommand('ls', [suri(src_bucket_uri, 'src_subdir')],
                              return_stdout=True)
     expected = set([
-        suri(src_bucket_uri, 'src_subdir', 'foo').encode('utf-8'),
-        (suri(src_bucket_uri, 'src_subdir', 'nested') + src_bucket_uri.delim).encode('utf-8')])
+        suri(src_bucket_uri, 'src_subdir', 'foo').encode(UTF8),
+        (suri(src_bucket_uri, 'src_subdir', 'nested') + src_bucket_uri.delim).encode(UTF8)])
     expected.add(b'')  # Blank line between subdir listings.
     actual = set([line.strip() for line in output.split(b'\n')])
     self.assertEqual(expected, actual)
@@ -746,10 +746,10 @@ class GsutilNamingTests(testcase.GsUtilUnitTestCase):
           'ls', ['-R', suri(src_bucket_uri, 'src_subdir') + final_char],
           return_stdout=True)
       expected = set([
-          suri(src_bucket_uri, 'src_subdir', ':').encode('utf-8'),
-          suri(src_bucket_uri, 'src_subdir', 'foo').encode('utf-8'),
-          suri(src_bucket_uri, 'src_subdir', 'nested', ':').encode('utf-8'),
-          suri(src_bucket_uri, 'src_subdir', 'nested', 'foo2').encode('utf-8')])
+          suri(src_bucket_uri, 'src_subdir', ':').encode(UTF8),
+          suri(src_bucket_uri, 'src_subdir', 'foo').encode(UTF8),
+          suri(src_bucket_uri, 'src_subdir', 'nested', ':').encode(UTF8),
+          suri(src_bucket_uri, 'src_subdir', 'nested', 'foo2').encode(UTF8)])
       expected.add(b'')  # Blank line between subdir listings.
       actual = set([line.strip() for line in output.split(b'\n')])
       self.assertEqual(expected, actual)
@@ -1175,7 +1175,7 @@ class GsutilNamingTests(testcase.GsUtilUnitTestCase):
                       contents=b'foo')
     stdout = self.RunCommand('ls', [suri(bucket_uri, object_name)],
                              return_stdout=True)
-    self.assertIn(object_name.encode('utf-8'), stdout)
+    self.assertIn(object_name.encode(UTF8), stdout)
 
   def testRecursiveListTrailingSlash(self):
     bucket_uri = self.CreateBucket()
@@ -1184,8 +1184,8 @@ class GsutilNamingTests(testcase.GsUtilUnitTestCase):
     stdout = self.RunCommand('ls', ['-R', suri(bucket_uri)], return_stdout=True)
     # Note: The suri function normalizes the URI, so the double slash gets
     # removed.
-    self.assertEqual(stdout.splitlines(), [(suri(obj_uri) + '/:').encode('utf-8'),
-                                           (suri(obj_uri) + '/').encode('utf-8')])
+    self.assertEqual(stdout.splitlines(), [(suri(obj_uri) + '/:').encode(UTF8),
+                                           (suri(obj_uri) + '/').encode(UTF8)])
 
   def FinalObjNameComponent(self, uri):
     """For gs://bucket/abc/def/ghi returns ghi."""

--- a/gslib/tests/test_requester_pays.py
+++ b/gslib/tests/test_requester_pays.py
@@ -27,6 +27,7 @@ from gslib.tests.testcase.integration_testcase import SkipForS3
 from gslib.tests.testcase.integration_testcase import SkipForXML
 from gslib.tests.util import ObjectToURI as suri
 from gslib.utils.retry_util import Retry
+from gslib.utils.constants import UTF8
 
 OBJECT_CONTENTS = b'innards'
 
@@ -69,7 +70,7 @@ class TestRequesterPays(testcase.GsUtilIntegrationTestCase):
                             return_stdout=True)
     if regex:
       if isinstance(regex, bytes):
-        regex = regex.decode('utf-8')
+        regex = regex.decode(UTF8)
       self.assertRegexpMatchesWithFlags(stdout, regex, flags=re.IGNORECASE)
 
   def _run_non_requester_pays_test(self, command_list):

--- a/gslib/tests/test_tracker_file.py
+++ b/gslib/tests/test_tracker_file.py
@@ -35,6 +35,7 @@ from gslib.tracker_file import HashRewriteParameters
 from gslib.tracker_file import ReadRewriteTrackerFile
 from gslib.tracker_file import WriteRewriteTrackerFile
 from gslib.utils import parallelism_framework_util
+from gslib.utils.constants import UTF8
 
 
 class TestTrackerFile(GsUtilUnitTestCase):
@@ -84,7 +85,7 @@ class TestTrackerFile(GsUtilUnitTestCase):
     objects = ['obj1', '42', 'obj2', '314159']
     contents = '\n'.join([random_prefix] + objects) + '\n'
     fpath = self.CreateTempFile(
-      file_name='foo', contents=contents.encode('utf-8'))
+      file_name='foo', contents=contents.encode(UTF8))
     expected_objects = [ObjectFromTracker(objects[2 * i], objects[2 * i + 1])
                         for i in range(0, len(objects) // 2)]
     (_, actual_prefix, actual_objects) = ReadParallelUploadTrackerFile(

--- a/gslib/tests/test_ui.py
+++ b/gslib/tests/test_ui.py
@@ -591,7 +591,7 @@ class TestUi(testcase.GsUtilIntegrationTestCase):
             'Tracker file %s should have been deleted.' % tracker_file_name)
         read_contents = self.RunGsUtil(['cat', suri(bucket_uri, 'foo')],
                                        return_stdout=True)
-        self.assertEqual(read_contents.encode('utf-8'), file_contents)
+        self.assertEqual(read_contents.encode(UTF8), file_contents)
         if '-m' in gsutil_flags:
           CheckUiOutputWithMFlag(self, stderr, 1, total_size=len(file_contents))
         else:
@@ -798,7 +798,7 @@ class TestUi(testcase.GsUtilIntegrationTestCase):
     obj_uri = suri(self.CreateObject(contents=b'foo'))
     acl_string = self.RunGsUtil(get_acl_prefix + [obj_uri],
                                 return_stdout=True)
-    inpath = self.CreateTempFile(contents=acl_string.encode('utf-8'))
+    inpath = self.CreateTempFile(contents=acl_string.encode(UTF8))
     stderr = self.RunGsUtil(set_acl_prefix + ['public-read', obj_uri],
                             return_stderr=True)
     CheckUiOutputWithMFlag(self, stderr, 1, metadata=True)
@@ -823,7 +823,7 @@ class TestUi(testcase.GsUtilIntegrationTestCase):
     obj_uri = suri(self.CreateObject(contents=b'foo'))
     acl_string = self.RunGsUtil(get_acl_prefix + [obj_uri],
                                 return_stdout=True)
-    inpath = self.CreateTempFile(contents=acl_string.encode('utf-8'))
+    inpath = self.CreateTempFile(contents=acl_string.encode(UTF8))
     stderr = self.RunGsUtil(set_acl_prefix + ['public-read', obj_uri],
                             return_stderr=True)
     CheckUiOutputWithNoMFlag(self, stderr, 1, metadata=True)

--- a/gslib/tests/test_update.py
+++ b/gslib/tests/test_update.py
@@ -40,6 +40,7 @@ from gslib.tests.util import ObjectToURI as suri
 from gslib.tests.util import unittest
 from gslib.utils import system_util
 from gslib.utils.boto_util import CERTIFICATE_VALIDATION_ENABLED
+from gslib.utils.constants import UTF8
 from gslib.utils.update_util import DisallowUpdateIfDataInGsutilDir
 
 
@@ -168,7 +169,7 @@ class UpdateTest(testcase.GsUtilIntegrationTestCase):
     os.unlink(os.path.join(gsutil_dst, 'userdata.txt'))
     self.assertEqual(p.returncode, 1)
     # Additional check for Windows since it has \r\n and string may have just \n
-    os_ls = os.linesep.encode('utf-8')
+    os_ls = os.linesep.encode(UTF8)
     if os_ls in stderr:
       stderr = stderr.replace(os_ls, b' ')
     elif b'\n' in stderr:
@@ -194,7 +195,7 @@ class UpdateTest(testcase.GsUtilIntegrationTestCase):
     p.stderr.close()
     self.assertEqual(p.returncode, 0, msg=(
         'Non-zero return code (%d) from gsutil update. stderr = \n%s' %
-        (p.returncode, stderr.decode('utf-8'))))
+        (p.returncode, stderr.decode(UTF8))))
 
     # Verify that version file was updated.
     dst_version_file = os.path.join(tmpdir_dst, 'gsutil', 'VERSION')

--- a/gslib/tests/testcase/base.py
+++ b/gslib/tests/testcase/base.py
@@ -206,7 +206,7 @@ class GsUtilTestCase(unittest.TestCase):
     if not os.path.isdir(os.path.dirname(fpath)):
       os.makedirs(os.path.dirname(fpath))
     if isinstance(fpath, six.binary_type):
-        fpath = fpath.decode('utf-8')
+        fpath = fpath.decode(UTF8)
 
     with open(fpath, 'wb') as f:
       contents = (contents if contents is not None

--- a/gslib/tests/testcase/integration_testcase.py
+++ b/gslib/tests/testcase/integration_testcase.py
@@ -882,9 +882,9 @@ class GsUtilIntegrationTestCase(base.GsUtilTestCase):
     if stdin is not None:
       if six.PY3:
         if not isinstance(stdin, bytes):
-          stdin = stdin.encode('utf-8')
+          stdin = stdin.encode(UTF8)
       else:
-        stdin = stdin.encode('utf-8')
+        stdin = stdin.encode(UTF8)
     # checking to see if test was invoked from a par file (bundled archive)
     # if not, add python executable path to ensure correct version of python
     # is used for testing

--- a/gslib/tests/testcase/unit_testcase.py
+++ b/gslib/tests/testcase/unit_testcase.py
@@ -40,6 +40,7 @@ from gslib.tests.testcase import base
 import gslib.tests.util as util
 from gslib.tests.util import unittest
 from gslib.tests.util import WorkingDirectory
+from gslib.utils.constants import UTF8
 
 
 class GsutilApiUnitTestClassMapFactory(object):
@@ -231,8 +232,8 @@ class GsUtilUnitTestCase(base.GsUtilTestCase):
         except UnicodeDecodeError:
           sys.stdout.seek(0)
           sys.stderr.seek(0)
-          stdout = sys.stdout.buffer.read().decode('utf-8')
-          stderr = sys.stderr.buffer.read().decode('utf-8')
+          stdout = sys.stdout.buffer.read().decode(UTF8)
+          stderr = sys.stderr.buffer.read().decode(UTF8)
       logging.getLogger(command_name).removeHandler(mock_log_handler)
       mock_log_handler.close()
 
@@ -378,7 +379,7 @@ class GsUtilUnitTestCase(base.GsUtilTestCase):
       test_objects = [self.MakeTempName('obj') for _ in range(test_objects)]
     for i, name in enumerate(test_objects):
       self.CreateObject(bucket_uri=bucket_uri, object_name=name,
-                        contents='test {}'.format(i).encode('utf-8'))
+                        contents='test {}'.format(i).encode(UTF8))
     return bucket_uri
 
   def CreateObject(self, bucket_uri=None, object_name=None, contents=None):

--- a/gslib/tests/util.py
+++ b/gslib/tests/util.py
@@ -42,6 +42,7 @@ from gslib.cloud_api import ResumableUploadException
 from gslib.lazy_wrapper import LazyWrapper
 import gslib.tests as gslib_tests
 from gslib.utils.boto_util import UsingCrcmodExtension
+from gslib.utils.constants import UTF8
 from gslib.utils.encryption_helper import Base64Sha256FromBase64EncryptionKey
 from gslib.utils.posix_util import GetDefaultMode
 from gslib.utils.system_util import IS_WINDOWS
@@ -482,7 +483,7 @@ def SetBotoConfigForTest(boto_config_list, use_existing_config=True):
         boto_value = boto_config[2]
         if six.PY3:
           if isinstance(boto_value, bytes):
-            boto_value = boto_value.decode('utf-8')
+            boto_value = boto_value.decode(UTF8)
         _SetBotoConfig(boto_config[0], boto_config[1], boto_value,
                        revert_configs)
       with open(tmp_filename, 'w') as tmp_file:

--- a/gslib/utils/boto_util.py
+++ b/gslib/utils/boto_util.py
@@ -43,6 +43,7 @@ from gslib.utils import system_util
 from gslib.utils.constants import DEFAULT_GCS_JSON_API_VERSION
 from gslib.utils.constants import DEFAULT_GSUTIL_STATE_DIR
 from gslib.utils.constants import SSL_TIMEOUT_SEC
+from gslib.utils.constants import UTF8
 from gslib.utils.unit_util import HumanReadableToBytes
 from gslib.utils.unit_util import ONE_MIB
 
@@ -509,7 +510,7 @@ def _PatchedShouldRetryMethod(self, response, chunked_transfer=False):
       self.etag = response.getheader('etag')
       md5 = self.md5
       if isinstance(md5, bytes):
-          md5 = md5.decode('utf-8')
+          md5 = md5.decode(UTF8)
 
       # If you use customer-provided encryption keys, the ETag value that
       # Amazon S3 returns in the response will not be the MD5 of the

--- a/gslib/utils/constants.py
+++ b/gslib/utils/constants.py
@@ -39,7 +39,6 @@ from gslib.utils.unit_util import ONE_KIB
 from gslib.utils.unit_util import ONE_MIB
 
 
-
 # Readable descriptions for httplib2 logging levels.
 DEBUGLEVEL_DUMP_REQUESTS = 3
 DEBUGLEVEL_DUMP_REQUESTS_AND_PAYLOADS = 4

--- a/gslib/utils/hashing_helper.py
+++ b/gslib/utils/hashing_helper.py
@@ -34,6 +34,7 @@ from gslib.utils.boto_util import UsingCrcmodExtension
 from gslib.utils.constants import DEFAULT_FILE_BUFFER_SIZE
 from gslib.utils.constants import MIN_SIZE_COMPUTE_LOGGING
 from gslib.utils.constants import TRANSFER_BUFFER_SIZE
+from gslib.utils.constants import UTF8
 
 
 SLOW_CRCMOD_WARNING = """
@@ -210,7 +211,7 @@ def CalculateHashesFromContents(fp, hash_dict, callback_processor=None):
       break
     if six.PY3:
       if isinstance(data, str):
-        data = data.encode('utf-8')
+        data = data.encode(UTF8)
     for hash_alg in six.itervalues(hash_dict):
       hash_alg.update(data)
     if callback_processor:
@@ -262,7 +263,7 @@ def CalculateMd5FromContents(fp):
 
 def Base64EncodeHash(digest_value):
   """Returns the base64-encoded version of the input hex digest value."""
-  return base64.encodestring(binascii.unhexlify(digest_value)).rstrip(b'\n').decode('utf-8')
+  return base64.encodestring(binascii.unhexlify(digest_value)).rstrip(b'\n').decode(UTF8)
 
 
 def Base64ToHexHash(base64_hash):
@@ -276,7 +277,7 @@ def Base64ToHexHash(base64_hash):
     Hex digest of the input argument.
   """
   return binascii.hexlify(
-    base64.decodestring(base64_hash.strip('\n"\'').encode('utf-8')))
+    base64.decodestring(base64_hash.strip('\n"\'').encode(UTF8)))
 
 
 def _CalculateB64EncodedHashFromContents(fp, hash_alg):
@@ -422,7 +423,7 @@ class HashingFileUploadWrapper(object):
 
     data = self._orig_fp.read(size)
     if isinstance(data, six.text_type):
-      data = data.encode('utf-8')
+      data = data.encode(UTF8)
     self._digesters_previous_mark = self._digesters_current_mark
     for alg in self._digesters:
       self._digesters_previous[alg] = self._digesters[alg].copy()
@@ -513,7 +514,7 @@ class HashingFileUploadWrapper(object):
     while bytes_this_round:
       data = self._orig_fp.read(bytes_this_round)
       if isinstance(data, six.text_type):
-        data = data.encode('utf-8')
+        data = data.encode(UTF8)
       bytes_remaining -= bytes_this_round
       for alg in self._digesters:
         self._digesters[alg].update(data)


### PR DESCRIPTION
Replaced instances of `'utf-8'` string literals with calls to `constants.UTF8`. This is mainly to make code internally consistent.

Manually ran integ tests on Linux with Python 3.5 and 2.7 after the changes to make sure nothing broke. Will watch travis and kokoro results too.