### PR TITLE
Ensure wildcard test objects are unicode

### DIFF
--- a/gslib/tests/test_wildcard_iterator.py
+++ b/gslib/tests/test_wildcard_iterator.py
@@ -26,6 +26,7 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import unicode_literals
 
+import six
 import tempfile
 
 from gslib import wildcard_iterator
@@ -79,7 +80,7 @@ class CloudWildcardIteratorTests(testcase.GsUtilUnitTestCase):
   def testMatchingAllObjects(self):
     """Tests matching all objects, based on wildcard."""
     actual_obj_uri_strs = set(
-        str(u) for u in self._test_wildcard_iterator(
+        six.ensure_text(str(u)) for u in self._test_wildcard_iterator(
             self.test_bucket0_uri.clone_replace_name('**')).IterAll(
                 expand_top_level_buckets=True))
     self.assertEqual(self.test_bucket0_obj_uri_strs, actual_obj_uri_strs)


### PR DESCRIPTION
For b/130652889
Sponge logs: go/gsutil-pr746-sponge

Wildcard iterator test was struggling with JSON objects on Kokoro's Windows. This looked like a thing we solved before, but may have gotten auto-merged badly at some point.