### PR TITLE
Allow configuring compression level

### DIFF
--- a/gslib/commands/config.py
+++ b/gslib/commands/config.py
@@ -248,6 +248,7 @@ _DETAILED_HELP_TEXT = ("""
       sliced_object_download_threshold
       parallel_process_count
       parallel_thread_count
+      gzip_compression_level
       prefer_api
       resumable_threshold
       resumable_tracker_dir (deprecated in 4.6, use state_dir)
@@ -376,6 +377,9 @@ DEFAULT_SLICED_OBJECT_DOWNLOAD_MAX_COMPONENTS = 4
 # available. This restricts the number of compressed transport encoded uploads
 # running in parallel such that they don't consume more memory than set here.
 DEFAULT_MAX_UPLOAD_COMPRESSION_BUFFER_SIZE = '2G'
+
+# gzip compression level. This is simply making the python stdlib default explicit.
+DEFAULT_GZIP_COMPRESSION_LEVEL = 9
 
 CONFIG_BOTO_SECTION_CONTENT = """
 [Boto]
@@ -549,6 +553,12 @@ CONFIG_INPUTLESS_GSUTIL_SECTION_CONTENT = """
 # (e.g., "2G" to represent 2 gibibytes)
 #max_upload_compression_buffer_size = %(max_upload_compression_buffer_size)s
 
+# GZIP compression level, if using compression. Reducing this can have 
+# a dramatic impact on compression speed with minor size increases.
+# This is a value from 0-9, with 9 being max compression.
+# A good level to try is 6, which is the default used by the gzip tool.
+#gzip_compression_level = %(gzip_compression_level)s
+
 # 'task_estimation_threshold' controls how many files or objects gsutil
 # processes before it attempts to estimate the total work that will be
 # performed by the command. Estimation makes extra directory listing or API
@@ -655,7 +665,8 @@ content_language = en
        'max_component_count': MAX_COMPONENT_COUNT,
        'task_estimation_threshold': DEFAULT_TASK_ESTIMATION_THRESHOLD,
        'max_upload_compression_buffer_size': (
-           DEFAULT_MAX_UPLOAD_COMPRESSION_BUFFER_SIZE)}
+           DEFAULT_MAX_UPLOAD_COMPRESSION_BUFFER_SIZE),
+       'gzip_compression_level': DEFAULT_GZIP_COMPRESSION_LEVEL,}
 
 CONFIG_OAUTH2_CONFIG_CONTENT = """
 [OAuth2]

--- a/gslib/commands/config.py
+++ b/gslib/commands/config.py
@@ -1090,13 +1090,13 @@ class ConfigCommand(Command):
           '# In some cases, (e.g. VPC requests) the "host" HTTP header should\n'
           '# be different than the host used in the request URL.\n'
           '#%s_host_header = <alternate storage host header>\n'
-          % (host_key, host_key))
+          % (host_key, host_key, host_key))
       if host_key == 'gs':
         config_file.write(
             '#%s_json_host = <alternate JSON API storage host address>\n'
             '#%s_json_port = <alternate JSON API storage host port>\n'
             '#%s_json_host_header = <alternate JSON API storage host header>\n\n'
-            % (host_key, host_key))
+            % (host_key, host_key, host_key))
       config_file.write('\n')
 
     # Write the config file Boto section.

--- a/gslib/utils/copy_helper.py
+++ b/gslib/utils/copy_helper.py
@@ -51,6 +51,7 @@ from six.moves import range
 from apitools.base.protorpclite import protojson
 
 from boto import config
+
 import crcmod
 
 import gslib
@@ -72,6 +73,7 @@ from gslib.commands.config import DEFAULT_PARALLEL_COMPOSITE_UPLOAD_THRESHOLD
 from gslib.commands.config import DEFAULT_SLICED_OBJECT_DOWNLOAD_COMPONENT_SIZE
 from gslib.commands.config import DEFAULT_SLICED_OBJECT_DOWNLOAD_MAX_COMPONENTS
 from gslib.commands.config import DEFAULT_SLICED_OBJECT_DOWNLOAD_THRESHOLD
+from gslib.commands.config import DEFAULT_GZIP_COMPRESSION_LEVEL
 from gslib.cs_api_map import ApiSelector
 from gslib.daisy_chain_wrapper import DaisyChainWrapper
 from gslib.exception import CommandException
@@ -1856,7 +1858,9 @@ def _ApplyZippedUploadCompression(
       raise CommandException('Inadequate temp space available to compress '
                              '%s. See the CHANGING TEMP DIRECTORIES section '
                              'of "gsutil help cp" for more info.' % src_url)
-    gzip_fp = gzip.open(gzip_path, 'wb')
+    compression_level = config.getint('GSUtil', 'gzip_compression_level',
+                                      DEFAULT_GZIP_COMPRESSION_LEVEL)
+    gzip_fp = gzip.open(gzip_path, 'wb', compresslevel=compression_level)
     data = src_obj_filestream.read(GZIP_CHUNK_SIZE)
     while data:
       gzip_fp.write(data)


### PR DESCRIPTION
The current gzip compression level is 9, the python stdlib default, which is rather high. Reducing it to a more reasonable value - like 6, the default used by the gzip tool - improves compression speed substantially without losing much space.

In my use case, this improves gsutil end-to-end upload performance about one order of magnitude, though I suspect this will vary depending on compressibility of the files, which is why I'm not proposing changing the default.

With current defaults, uploading a 256MiB database file:
```
$ time ./gsutil cp -Z ~/Downloads/testfile-256Mi gs://jake-compressiontest
Copying file:///home/jake/Downloads/testfile-256Mi [Content-Type=application/octet-stream]...
Compressing file:///home/jake/Downloads/testfile-256Mi (to tmp)...
/ [1 files][ 28.1 MiB/ 28.1 MiB]                                                
Operation completed over 1 objects/28.1 MiB.                                     

real	1m22.710s
user	1m17.232s
sys	0m0.404s
```

With compression set to 6:
```
$ time ./gsutil -o "GSUtil:gzip_compression_level=6" cp -Z ~/Downloads/testfile-256Mi gs://jake-compressiontest/lvl6
Copying file:///home/jake/Downloads/testfile-256Mi [Content-Type=application/octet-stream]...
Compressing file:///home/jake/Downloads/testfile-256Mi (to tmp)...
/ [1 files][ 28.3 MiB/ 28.3 MiB]                                                
Operation completed over 1 objects/28.3 MiB.                                     

real	0m12.101s
user	0m6.844s
sys	0m0.296s
```