### PR TITLE
Link CORS command page to related GCS docs.

### DIFF
--- a/gslib/commands/cors.py
+++ b/gslib/commands/cors.py
@@ -84,7 +84,9 @@ _DESCRIPTION = ("""
 
   The cors command has two sub-commands:
 """ + '\n'.join([_GET_DESCRIPTION, _SET_DESCRIPTION]) + """
-For more info about CORS, see http://www.w3.org/TR/cors/.
+For more info about CORS generally, see https://www.w3.org/TR/cors/.
+For more info about CORS in Cloud Storage, see the 
+`CORS concept page <https://cloud.google.com/storage/docs/configuring-cors>`_.
 """)
 
 _DETAILED_HELP_TEXT = CreateHelpText(_SYNOPSIS, _DESCRIPTION)


### PR DESCRIPTION
Users have been asking for more information on this page, so we can at least point them to the main GCS docs for additional material.