### PR TITLE
Install Py 3.7.2 on Windows when using JSON

### DIFF
--- a/test/ci/kokoro/windows/run_integ_tests.bat
+++ b/test/ci/kokoro/windows/run_integ_tests.bat
@@ -25,6 +25,11 @@ type %BOTO_CONFIG%
 
 cd %GsutilRepoDir%
 git submodule update --init --recursive
+
+rem Workaround for b/131089489 where Kokoro's preinstalled Py 3.7.0 encounters errors
+if "%PYMAJOR%" == "3" if "%PYMINOR%" == "7" if "%API%" == "json" (
+    choco install python --no-progress --version 3.7.2 -my
+)
 %PipPath% install crcmod
 
 rem Print config info prior to running tests


### PR DESCRIPTION
Workaround for b/131089489 where the preinstalled version of Python
3.7.0 on Kokoro behaves unexpectedly with the JSON API. The issue
doesn't occur on public Python 3.7.0 with Windows and JSON; it appears
to be isolated to Kokoro.

Unexpected behavior was in `-D` flag tests, headers were being printed in an
order inconsistent with other versions of 3.7.x or with local 3.7.0. Adding the workaround
to the Kokoro test runner seemed like a better place than in the test, since the test
doesn't seem to fail in any other environments except Kokoro Windows with Python 3.7.0
and using the JSON API.

Manual Kokoro test run pointing at `chocoPy` test branch with these changes.
go/chocoPyLogs