### PR TITLE
Apply HTTP monkey patch to Python 3.7.0

### DIFF
--- a/gslib/utils/system_util.py
+++ b/gslib/utils/system_util.py
@@ -252,9 +252,9 @@ def MonkeyPatchHttp():
   ver = sys.version_info
   # Checking for and applying monkeypatch to python versions 3.0 - 3.6.6
   if ver.major == 3:
-    if ver.minor < 6 or
+    if (ver.minor < 6 or
       (ver.minor == 6 and ver.micro < 7) or
-      (ver.minor == 7 and ver.micro == 0):
+      (ver.minor == 7 and ver.micro == 0)):
         _MonkeyPatchHttpForPython_3x()
 
 

--- a/gslib/utils/system_util.py
+++ b/gslib/utils/system_util.py
@@ -251,8 +251,11 @@ def IsRunningInteractively():
 def MonkeyPatchHttp():
   ver = sys.version_info
   # Checking for and applying monkeypatch to python versions 3.0 - 3.6.6
-  if (ver.major == 3 and (ver.minor < 6 or (ver.minor == 6 and ver.micro < 7))):
-    _MonkeyPatchHttpForPython_3x()
+  if (ver.major == 3 or
+    ver.minor < 6 or
+    (ver.minor == 7 and ver.micro == 0) or
+    (ver.minor == 6 and ver.micro < 7)):
+      _MonkeyPatchHttpForPython_3x()
 
 
 def _MonkeyPatchHttpForPython_3x():

--- a/gslib/utils/system_util.py
+++ b/gslib/utils/system_util.py
@@ -251,11 +251,11 @@ def IsRunningInteractively():
 def MonkeyPatchHttp():
   ver = sys.version_info
   # Checking for and applying monkeypatch to python versions 3.0 - 3.6.6
-  if (ver.major == 3 or
-    ver.minor < 6 or
-    (ver.minor == 7 and ver.micro == 0) or
-    (ver.minor == 6 and ver.micro < 7)):
-      _MonkeyPatchHttpForPython_3x()
+  if ver.major == 3:
+    if ver.minor < 6 or
+      (ver.minor == 6 and ver.micro < 7) or
+      (ver.minor == 7 and ver.micro == 0):
+        _MonkeyPatchHttpForPython_3x()
 
 
 def _MonkeyPatchHttpForPython_3x():


### PR DESCRIPTION
For b/131089489. HTTP headers print inconsistently between versions
of Python, which effects our test output when the -D flag is included.