### PR TITLE
Fix setup.py to not package test and boto bloat.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -11,4 +11,9 @@ recursive-include gslib *
 recursive-include test *
 global-exclude .git*
 global-exclude *.pyc
+prune test
+prune gslib/vendored/boto/bin
+prune gslib/vendored/boto/docs
+prune gslib/vendored/boto/scripts
+prune gslib/vendored/boto/tests
 exclude gslib/commands/update.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -15,5 +15,4 @@ prune test
 prune gslib/vendored/boto/bin
 prune gslib/vendored/boto/docs
 prune gslib/vendored/boto/scripts
-prune gslib/vendored/boto/tests
 exclude gslib/commands/update.py

--- a/setup.py
+++ b/setup.py
@@ -132,9 +132,18 @@ setup(
         'Topic :: System :: Filesystems',
         'Topic :: Utilities',
     ],
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, <4',
+    # Gsutil supports Python 2.7, 3.5+
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4',
     platforms='any',
-    packages=find_packages(exclude=['third_party']),
+    packages=find_packages(
+        exclude=[
+            # Packages under third_party are installed separately as
+            # dependencies (see the "requires" list above). Note that we do not
+            # exclude vendored dependencies (under gslib/vendored), as our
+            # vendored versions may differ slightly from the official versions.
+            'third_party',
+        ],
+    ),
     include_package_data=True,
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
End-users don't need stuff in the top-level test/ directory; likewise, the only
directory needed under gslib/vendored/boto/ is the boto/ directory.

Internal notes for Googlers: These changes were also included in our
tarball build script in changelist 244894227.