### PR TITLE
Acl doc updates

### DIFF
--- a/gslib/commands/acl.py
+++ b/gslib/commands/acl.py
@@ -77,7 +77,9 @@ _SET_DESCRIPTION = """
   recommended to use "acl ch", to avoid accidentally removing OWNER permissions.
   See the "acl ch" section for details.
 
-  See "gsutil help acls" for a list of all canned ACLs.
+  See `Predefined ACLs
+  <https://cloud.google.com/storage/docs/access-control/lists#predefined-acl>`_
+  for a list of canned ACLs.
 
   If you want to define more fine-grained control over your data, you can
   retrieve an ACL using the "acl get" command, save the output to a file, edit
@@ -196,7 +198,7 @@ _CH_DESCRIPTION = """
 
     gsutil acl ch -u foo@developer.gserviceaccount.com:W gs://example-bucket
 
-  Grant all users from the `Google Apps
+  Grant all users from the `G Suite
   <https://www.google.com/work/apps/business/>`_ domain my-domain.org READ
   access to the bucket gcs.my-domain.org:
 

--- a/gslib/commands/acl.py
+++ b/gslib/commands/acl.py
@@ -49,14 +49,14 @@ _GET_SYNOPSIS = """
 """
 
 _CH_SYNOPSIS = """
-  gsutil acl ch [-f] [-r] -u|-g|-d|-p <grant>... url...
+  gsutil acl ch [-f] [-r] <grant>... url...
 
   where each <grant> is one of the following forms:
 
     -u <id|email>:<perm>
     -g <id|email|domain|All|AllAuth>:<perm>
-    -p <viewers|editors|owners>-<project number>
-    -d <id|email|domain|All|AllAuth|<viewers|editors|owners>-<project number>>
+    -p <viewers|editors|owners>-<project number>:<perm>
+    -d <id|email|domain|All|AllAuth|<viewers|editors|owners>-<project number>>:<perm>
 """
 
 _GET_DESCRIPTION = """

--- a/gslib/commands/defacl.py
+++ b/gslib/commands/defacl.py
@@ -59,9 +59,11 @@ _SET_DESCRIPTION = """
   bucket, unless an ACL for that object is separately specified during upload.
 
   Similar to the "acl set" command, the file-or-canned_acl_name names either a
-  canned ACL or the path to a file that contains ACL text. (See "gsutil
-  help acl" for examples of editing and setting ACLs via the
-  acl command.)
+  canned ACL or the path to a file that contains ACL text. See "gsutil help
+  acl" for examples of editing and setting ACLs via the acl command. See
+  `Predefined ACLs
+  <https://cloud.google.com/storage/docs/access-control/lists#predefined-acl>`_
+  for a list of canned ACLs.
 
   Setting a default object ACL on a bucket provides a convenient way to ensure
   newly uploaded objects have a specific ACL. If you don't set the bucket's


### PR DESCRIPTION
Make some minor fixes to the ACL command documentation:

* Fix ACL command synopsis - member flags are included redundantly, and two grants are missing the ":<perm>" portion.
* Fix branding - "Google Apps" should be "G Suite".
Synopsis.
* Link to documentation on available canned ACLs in both the `acl` command and `defacl` command options.