### PR TITLE
Removed flaky assert

### DIFF
--- a/gslib/tests/test_ui.py
+++ b/gslib/tests/test_ui.py
@@ -178,8 +178,6 @@ def CheckBrokenUiOutputWithMFlag(test_case, content, num_objects, total_size=0,
     metadata: Indicates whether this is a metadata operation.
   """
   description_string = _FindAppropriateDescriptionString(metadata)
-  # We must not have begun our UI with 0% of our data transferred.
-  test_case.assertIn('0% Done', content)
   # We must not have transferred 100% of our data.
   test_case.assertNotIn('100% Done', content)
   # 0 files should be completed.


### PR DESCRIPTION
For b/131325628. We noticed in the CI pipeline on Windows that the test
test_ui_resumable_download_break_with_m_flag tended to flake fairly
frequently due to a race condition where the artifical download halt
signal was sent before the "0% Done" text was printed. Discussing with
Matt we agreed this assert didn't add very much value, and was fine to
simply remove.