### PR TITLE
XML >1k buckets test flake fix

### DIFF
--- a/gslib/tests/test_stat.py
+++ b/gslib/tests/test_stat.py
@@ -42,7 +42,6 @@ from gslib.tests.util import TEST_ENCRYPTION_KEY2
 from gslib.tests.util import TEST_ENCRYPTION_KEY2_SHA256_B64
 from gslib.tests.util import unittest
 from gslib.utils.retry_util import Retry
-from gslib.utils.text_util import get_prefix
 
 
 class TestStat(testcase.GsUtilIntegrationTestCase):
@@ -140,7 +139,8 @@ class TestStat(testcase.GsUtilIntegrationTestCase):
     self.assertIn('%s:' % suri(bucket_uri, 'notmissing'), stdout)
 
   def test_stat_bucket_wildcard(self):
-    bucket_uri = self.CreateBucket(bucket_name_prefix=get_prefix())
+    # Prefix is a workaround for XML API limitation, see PR 766 for details
+    bucket_uri = self.CreateBucket(bucket_name_prefix='aaa-')
     self.CreateObject(bucket_uri=bucket_uri, object_name='foo', contents=b'z')
     stat_string = suri(bucket_uri)[:-1] + '?/foo'
     self.RunGsUtil(['stat', stat_string])

--- a/gslib/tests/test_stat.py
+++ b/gslib/tests/test_stat.py
@@ -42,6 +42,7 @@ from gslib.tests.util import TEST_ENCRYPTION_KEY2
 from gslib.tests.util import TEST_ENCRYPTION_KEY2_SHA256_B64
 from gslib.tests.util import unittest
 from gslib.utils.retry_util import Retry
+from gslib.utils.text_util import get_prefix
 
 
 class TestStat(testcase.GsUtilIntegrationTestCase):
@@ -139,11 +140,11 @@ class TestStat(testcase.GsUtilIntegrationTestCase):
     self.assertIn('%s:' % suri(bucket_uri, 'notmissing'), stdout)
 
   def test_stat_bucket_wildcard(self):
-    bucket_uri = self.CreateBucket()
+    bucket_uri = self.CreateBucket(bucket_name_prefix=get_prefix())
     self.CreateObject(bucket_uri=bucket_uri, object_name='foo', contents=b'z')
-    stat_string = suri(bucket_uri) + '/?oo'
+    stat_string = suri(bucket_uri)[:-1] + '?/foo'
     self.RunGsUtil(['stat', stat_string])
-    stat_string2 = suri(bucket_uri) + '/*foo'
+    stat_string2 = suri(bucket_uri)[:-1] + '*/foo'
     self.RunGsUtil(['stat', stat_string2])
 
   def test_stat_object_wildcard(self):

--- a/gslib/tests/test_stat.py
+++ b/gslib/tests/test_stat.py
@@ -141,9 +141,9 @@ class TestStat(testcase.GsUtilIntegrationTestCase):
   def test_stat_bucket_wildcard(self):
     bucket_uri = self.CreateBucket()
     self.CreateObject(bucket_uri=bucket_uri, object_name='foo', contents=b'z')
-    stat_string = suri(bucket_uri)[:-1] + '?/foo'
+    stat_string = suri(bucket_uri) + '/?oo'
     self.RunGsUtil(['stat', stat_string])
-    stat_string2 = suri(bucket_uri)[:-1] + '*/foo'
+    stat_string2 = suri(bucket_uri) + '/*foo'
     self.RunGsUtil(['stat', stat_string2])
 
   def test_stat_object_wildcard(self):

--- a/gslib/tests/test_tabcomplete.py
+++ b/gslib/tests/test_tabcomplete.py
@@ -152,7 +152,7 @@ class TestTabComplete(testcase.GsUtilIntegrationTestCase):
     bucket_name = bucket_base_name + '-suffix'
     self.CreateBucket(bucket_name)
 
-    bucket_request = '%s://%s' % (self.default_provider, bucket_base_name)
+    bucket_request = '%s://%s' % (self.default_provider, bucket_name[:-2])
     expected_bucket_result = '//%s ' % bucket_name
 
     local_file = 'a_local_file'

--- a/gslib/tests/test_tabcomplete.py
+++ b/gslib/tests/test_tabcomplete.py
@@ -46,9 +46,9 @@ class TestTabComplete(testcase.GsUtilIntegrationTestCase):
   def test_single_bucket(self):
     """Tests tab completion matching a single bucket."""
 
-    bucket_name = self.MakeTempName('bucket')
-    # Workaround for XML API limitation, see PR 766 for details
-    self.CreateBucket(bucket_name, bucket_name_prefix='')
+    # Prefix is a workaround for XML API limitation, see PR 766 for details
+    bucket_name = self.MakeTempName('bucket', prefix='aaa-')
+    self.CreateBucket(bucket_name)
 
     request = '%s://%s' % (self.default_provider, bucket_name[:-2])
     expected_result = '//%s/' % bucket_name

--- a/gslib/tests/test_tabcomplete.py
+++ b/gslib/tests/test_tabcomplete.py
@@ -31,6 +31,7 @@ from gslib.tests.util import ARGCOMPLETE_AVAILABLE
 from gslib.tests.util import SetBotoConfigForTest
 from gslib.tests.util import unittest
 from gslib.tests.util import WorkingDirectory
+from gslib.utils.text_util import get_prefix
 from gslib.utils.boto_util import GetTabCompletionCacheFilename
 
 
@@ -47,7 +48,7 @@ class TestTabComplete(testcase.GsUtilIntegrationTestCase):
     """Tests tab completion matching a single bucket."""
 
     bucket_name = self.MakeTempName('bucket')
-    self.CreateBucket(bucket_name)
+    self.CreateBucket(bucket_name, bucket_name_prefix=get_prefix())
 
     request = '%s://%s' % (self.default_provider, bucket_name[:-2])
     expected_result = '//%s/' % bucket_name
@@ -59,7 +60,7 @@ class TestTabComplete(testcase.GsUtilIntegrationTestCase):
     """Tests bucket-only tab completion matching a single bucket."""
 
     bucket_name = self.MakeTempName('bucket')
-    self.CreateBucket(bucket_name)
+    self.CreateBucket(bucket_name, bucket_name_prefix=get_prefix())
 
     request = '%s://%s' % (self.default_provider, bucket_name[:-2])
     expected_result = '//%s ' % bucket_name
@@ -94,15 +95,14 @@ class TestTabComplete(testcase.GsUtilIntegrationTestCase):
   def test_multiple_buckets(self):
     """Tests tab completion matching multiple buckets."""
 
-    bucket_base_name = self.MakeTempName('bucket')
-    bucket1_name = bucket_base_name + '-suffix1'
-    self.CreateBucket(bucket1_name)
-    bucket2_name = bucket_base_name + '-suffix2'
-    self.CreateBucket(bucket2_name)
+    base_name = self.MakeTempName('bucket')
+    prefix = get_prefix()
+    self.CreateBucket(base_name, bucket_name_prefix=prefix, bucket_name_suffix='1')
+    self.CreateBucket(base_name, bucket_name_prefix=prefix, bucket_name_suffix='2')
 
-    request = '%s://%s' % (self.default_provider, bucket_base_name)
-    expected_result1 = '//%s/' % bucket1_name
-    expected_result2 = '//%s/' % bucket2_name
+    request = '%s://%s' % (self.default_provider, ''.join([prefix, base_name]))
+    expected_result1 = '//%s/' % ''.join([prefix, base_name, '1'])
+    expected_result2 = '//%s/' % ''.join([prefix, base_name, '2'])
 
     self.RunGsUtilTabCompletion(['ls', request], expected_results=[
         expected_result1, expected_result2])
@@ -145,7 +145,7 @@ class TestTabComplete(testcase.GsUtilIntegrationTestCase):
     """Tests tab completion for commands with subcommands."""
 
     bucket_name = self.MakeTempName('bucket')
-    self.CreateBucket(bucket_name)
+    self.CreateBucket(bucket_name, bucket_name_prefix=get_prefix())
 
     bucket_request = '%s://%s' % (self.default_provider, bucket_name[:-2])
     expected_bucket_result = '//%s ' % bucket_name

--- a/gslib/tests/test_tabcomplete.py
+++ b/gslib/tests/test_tabcomplete.py
@@ -31,7 +31,6 @@ from gslib.tests.util import ARGCOMPLETE_AVAILABLE
 from gslib.tests.util import SetBotoConfigForTest
 from gslib.tests.util import unittest
 from gslib.tests.util import WorkingDirectory
-from gslib.utils.text_util import get_prefix
 from gslib.utils.boto_util import GetTabCompletionCacheFilename
 
 
@@ -48,7 +47,8 @@ class TestTabComplete(testcase.GsUtilIntegrationTestCase):
     """Tests tab completion matching a single bucket."""
 
     bucket_name = self.MakeTempName('bucket')
-    self.CreateBucket(bucket_name, bucket_name_prefix=get_prefix())
+    # Workaround for XML API limitation, see PR 766 for details
+    self.CreateBucket(bucket_name, bucket_name_prefix='')
 
     request = '%s://%s' % (self.default_provider, bucket_name[:-2])
     expected_result = '//%s/' % bucket_name
@@ -59,8 +59,9 @@ class TestTabComplete(testcase.GsUtilIntegrationTestCase):
   def test_bucket_only_single_bucket(self):
     """Tests bucket-only tab completion matching a single bucket."""
 
-    bucket_name = self.MakeTempName('bucket')
-    self.CreateBucket(bucket_name, bucket_name_prefix=get_prefix())
+    bucket_name = self.MakeTempName('bucket', prefix='aaa-')
+    # Workaround for XML API limitation, see PR 766 for details
+    self.CreateBucket(bucket_name)
 
     request = '%s://%s' % (self.default_provider, bucket_name[:-2])
     expected_result = '//%s ' % bucket_name
@@ -96,7 +97,8 @@ class TestTabComplete(testcase.GsUtilIntegrationTestCase):
     """Tests tab completion matching multiple buckets."""
 
     base_name = self.MakeTempName('bucket')
-    prefix = get_prefix()
+    # Workaround for XML API limitation, see PR 766 for details
+    prefix = 'aaa-'
     self.CreateBucket(base_name, bucket_name_prefix=prefix, bucket_name_suffix='1')
     self.CreateBucket(base_name, bucket_name_prefix=prefix, bucket_name_suffix='2')
 
@@ -144,8 +146,8 @@ class TestTabComplete(testcase.GsUtilIntegrationTestCase):
   def test_subcommands(self):
     """Tests tab completion for commands with subcommands."""
 
-    bucket_name = self.MakeTempName('bucket')
-    self.CreateBucket(bucket_name, bucket_name_prefix=get_prefix())
+    bucket_name = self.MakeTempName('bucket', prefix='aaa-')
+    self.CreateBucket(bucket_name)
 
     bucket_request = '%s://%s' % (self.default_provider, bucket_name[:-2])
     expected_bucket_result = '//%s ' % bucket_name

--- a/gslib/tests/test_tabcomplete.py
+++ b/gslib/tests/test_tabcomplete.py
@@ -46,11 +46,10 @@ class TestTabComplete(testcase.GsUtilIntegrationTestCase):
   def test_single_bucket(self):
     """Tests tab completion matching a single bucket."""
 
-    bucket_base_name = self.MakeTempName('bucket')
-    bucket_name = bucket_base_name + '-suffix'
+    bucket_name = self.MakeTempName('bucket')
     self.CreateBucket(bucket_name)
 
-    request = '%s://%s' % (self.default_provider, bucket_base_name)
+    request = '%s://%s' % (self.default_provider, bucket_name[:-2])
     expected_result = '//%s/' % bucket_name
 
     self.RunGsUtilTabCompletion(['ls', request],
@@ -59,11 +58,10 @@ class TestTabComplete(testcase.GsUtilIntegrationTestCase):
   def test_bucket_only_single_bucket(self):
     """Tests bucket-only tab completion matching a single bucket."""
 
-    bucket_base_name = self.MakeTempName('bucket')
-    bucket_name = bucket_base_name + '-s'
+    bucket_name = self.MakeTempName('bucket')
     self.CreateBucket(bucket_name)
 
-    request = '%s://%s' % (self.default_provider, bucket_base_name)
+    request = '%s://%s' % (self.default_provider, bucket_name[:-2])
     expected_result = '//%s ' % bucket_name
 
     self.RunGsUtilTabCompletion(['rb', request],
@@ -72,12 +70,11 @@ class TestTabComplete(testcase.GsUtilIntegrationTestCase):
   def test_bucket_only_no_objects(self):
     """Tests that bucket-only tab completion doesn't match objects."""
 
-    object_base_name = self.MakeTempName('obj')
-    object_name = object_base_name + '-suffix'
+    object_name = self.MakeTempName('obj')
     object_uri = self.CreateObject(object_name=object_name, contents=b'data')
 
     request = '%s://%s/%s' % (
-        self.default_provider, object_uri.bucket_name, object_base_name)
+        self.default_provider, object_uri.bucket_name, object_name[:-2])
 
     self.RunGsUtilTabCompletion(['rb', request], expected_results=[])
 
@@ -113,12 +110,11 @@ class TestTabComplete(testcase.GsUtilIntegrationTestCase):
   def test_single_object(self):
     """Tests tab completion matching a single object."""
 
-    object_base_name = self.MakeTempName('obj')
-    object_name = object_base_name + '-suffix'
+    object_name = self.MakeTempName('obj')
     object_uri = self.CreateObject(object_name=object_name, contents=b'data')
 
     request = '%s://%s/%s' % (
-        self.default_provider, object_uri.bucket_name, object_base_name)
+        self.default_provider, object_uri.bucket_name, object_name[:-2])
     expected_result = '//%s/%s ' % (object_uri.bucket_name, object_name)
 
     self.RunGsUtilTabCompletion(['ls', request],
@@ -148,8 +144,7 @@ class TestTabComplete(testcase.GsUtilIntegrationTestCase):
   def test_subcommands(self):
     """Tests tab completion for commands with subcommands."""
 
-    bucket_base_name = self.MakeTempName('bucket')
-    bucket_name = bucket_base_name + '-suffix'
+    bucket_name = self.MakeTempName('bucket')
     self.CreateBucket(bucket_name)
 
     bucket_request = '%s://%s' % (self.default_provider, bucket_name[:-2])

--- a/gslib/tests/testcase/base.py
+++ b/gslib/tests/testcase/base.py
@@ -109,12 +109,12 @@ class GsUtilTestCase(unittest.TestCase):
     name = '{name}-{rand}'.format(name=name, rand=self.MakeRandomTestString())
     total_name_len = len(name) + len(suffix)
     if suffix:
-      if kind == 'bucket' and totalNameLen > MAX_BUCKET_LENGTH:
+      if kind == 'bucket' and total_name_len > MAX_BUCKET_LENGTH:
         self.fail(
           'Tried to create a psuedo-random bucket name with a specific '
           'suffix, but the generated name was too long and there was not '
           'enough room for the suffix. Please use shorter strings or perform '
-          'name randomization manually.\nRequested name: ' + name + prefix)
+          'name randomization manually.\nRequested name: ' + name + suffix)
       name += suffix
 
     if kind == 'bucket':

--- a/gslib/tests/testcase/base.py
+++ b/gslib/tests/testcase/base.py
@@ -93,7 +93,8 @@ class GsUtilTestCase(unittest.TestCase):
 
     Args:
       kind (str): A string indicating what kind of test name this is.
-      prefix (str): Prefix string to be used in the temporary name.
+      prefix (str): Prefix prepended to the temporary name.
+      suffix (str): Suffix string appended to end of temporary name.
 
     Returns:
       (str) The temporary name. If `kind` was "bucket", the temporary name may
@@ -102,12 +103,21 @@ class GsUtilTestCase(unittest.TestCase):
       providers (e.g. replacing "_" with "-", converting uppercase letters to
       lowercase, etc.).
     """
-    name = '{prefix}gsutil-test-{method}-{kind}{suffix}'.format(
-      prefix=prefix, method=self.GetTestMethodName(), kind=kind, suffix=suffix)
+    name = '{prefix}gsutil-test-{method}-{kind}'.format(
+      prefix=prefix, method=self.GetTestMethodName(), kind=kind)
     name = name[:MAX_BUCKET_LENGTH-9]
     name = '{name}-{rand}'.format(name=name, rand=self.MakeRandomTestString())
-    # As of March 2018, S3 no longer accepts underscores or uppercase letters in
-    # bucket names.
+    totalNameLen = len(name) + len(suffix)
+    if suffix:
+      if kind == 'bucket' and totalNameLen > MAX_BUCKET_LENGTH:
+        self.fail(
+          'Tried to create a psuedo-random bucket name with a specific '
+          'suffix, but the generated name was too long and there was not '
+          'enough room for the suffix. Please use shorter strings or perform '
+          'name randomization manually.\nRequested name: ' + name)
+      else:
+        name += suffix
+
     if kind == 'bucket':
       name = util.MakeBucketNameValid(name)
     return name

--- a/gslib/tests/testcase/base.py
+++ b/gslib/tests/testcase/base.py
@@ -88,7 +88,7 @@ class GsUtilTestCase(unittest.TestCase):
     """Creates a random string of hex characters 8 characters long."""
     return '%08x' % random.randrange(256**4)
 
-  def MakeTempName(self, kind, prefix=''):
+  def MakeTempName(self, kind, prefix='', suffix=''):
     """Creates a temporary name that is most-likely unique.
 
     Args:
@@ -102,8 +102,8 @@ class GsUtilTestCase(unittest.TestCase):
       providers (e.g. replacing "_" with "-", converting uppercase letters to
       lowercase, etc.).
     """
-    name = '{prefix}gsutil-test-{method}-{kind}'.format(
-      prefix=prefix, method=self.GetTestMethodName(), kind=kind)
+    name = '{prefix}gsutil-test-{method}-{kind}{suffix}'.format(
+      prefix=prefix, method=self.GetTestMethodName(), kind=kind, suffix=suffix)
     name = name[:MAX_BUCKET_LENGTH-9]
     name = '{name}-{rand}'.format(name=name, rand=self.MakeRandomTestString())
     # As of March 2018, S3 no longer accepts underscores or uppercase letters in

--- a/gslib/tests/testcase/base.py
+++ b/gslib/tests/testcase/base.py
@@ -107,16 +107,15 @@ class GsUtilTestCase(unittest.TestCase):
       prefix=prefix, method=self.GetTestMethodName(), kind=kind)
     name = name[:MAX_BUCKET_LENGTH-9]
     name = '{name}-{rand}'.format(name=name, rand=self.MakeRandomTestString())
-    totalNameLen = len(name) + len(suffix)
+    total_name_len = len(name) + len(suffix)
     if suffix:
       if kind == 'bucket' and totalNameLen > MAX_BUCKET_LENGTH:
         self.fail(
           'Tried to create a psuedo-random bucket name with a specific '
           'suffix, but the generated name was too long and there was not '
           'enough room for the suffix. Please use shorter strings or perform '
-          'name randomization manually.\nRequested name: ' + name)
-      else:
-        name += suffix
+          'name randomization manually.\nRequested name: ' + name + prefix)
+      name += suffix
 
     if kind == 'bucket':
       name = util.MakeBucketNameValid(name)

--- a/gslib/tests/testcase/integration_testcase.py
+++ b/gslib/tests/testcase/integration_testcase.py
@@ -493,7 +493,9 @@ class GsUtilIntegrationTestCase(base.GsUtilTestCase):
                    provider=None,
                    prefer_json_api=False,
                    versioning_enabled=False,
-                   bucket_policy_only=False):
+                   bucket_policy_only=False,
+                   bucket_name_prefix='',
+                   bucket_name_suffix=''):
     """Creates a test bucket.
 
     The bucket and all of its contents will be deleted after the test.
@@ -511,6 +513,8 @@ class GsUtilIntegrationTestCase(base.GsUtilTestCase):
           True.
       bucket_policy_only: If True, set the bucket's iamConfiguration's
           bucketPolicyOnly attribute to True.
+      name_prefix: Unicode string to be prepended to bucket_name
+      name_suffix: Unicode string to be appended to bucket_name
 
     Returns:
       StorageUri for the created bucket.
@@ -527,8 +531,18 @@ class GsUtilIntegrationTestCase(base.GsUtilTestCase):
       location = boto.config.get(
           'GSUtil', 'test_cmd_regional_bucket_location', 'us-central1')
 
+    bucket_name_prefix = six.ensure_text(bucket_name_prefix)
+    bucket_name_suffix = six.ensure_text(bucket_name_suffix)
+
     if bucket_name:
+      bucket_name = ''.join([bucket_name_prefix,
+                             bucket_name,
+                             bucket_name_suffix])
       bucket_name = util.MakeBucketNameValid(bucket_name)
+    else:
+      bucket_name = self.MakeTempName(''.join([bucket_name_prefix,
+                                               'bucket',
+                                               bucket_name_suffix]))
 
     if prefer_json_api and provider == 'gs':
       json_bucket = self.CreateBucketJson(bucket_name=bucket_name,
@@ -542,8 +556,6 @@ class GsUtilIntegrationTestCase(base.GsUtilTestCase):
           'gs://%s' % json_bucket.name.lower(),
           suppress_consec_slashes=False)
       return bucket_uri
-
-    bucket_name = bucket_name or self.MakeTempName('bucket')
 
     bucket_uri = boto.storage_uri('%s://%s' % (provider, bucket_name.lower()),
                                   suppress_consec_slashes=False)

--- a/gslib/tests/testcase/integration_testcase.py
+++ b/gslib/tests/testcase/integration_testcase.py
@@ -513,8 +513,8 @@ class GsUtilIntegrationTestCase(base.GsUtilTestCase):
           True.
       bucket_policy_only: If True, set the bucket's iamConfiguration's
           bucketPolicyOnly attribute to True.
-      name_prefix: Unicode string to be prepended to bucket_name
-      name_suffix: Unicode string to be appended to bucket_name
+      bucket_name_prefix: Unicode string to be prepended to bucket_name
+      bucket_name_suffix: Unicode string to be appended to bucket_name
 
     Returns:
       StorageUri for the created bucket.
@@ -540,9 +540,9 @@ class GsUtilIntegrationTestCase(base.GsUtilTestCase):
                              bucket_name_suffix])
       bucket_name = util.MakeBucketNameValid(bucket_name)
     else:
-      bucket_name = self.MakeTempName(''.join([bucket_name_prefix,
-                                               'bucket',
-                                               bucket_name_suffix]))
+      bucket_name = self.MakeTempName('bucket',
+                                      prefix=bucket_name_prefix,
+                                      suffix=bucket_name_suffix)
 
     if prefer_json_api and provider == 'gs':
       json_bucket = self.CreateBucketJson(bucket_name=bucket_name,

--- a/gslib/utils/text_util.py
+++ b/gslib/utils/text_util.py
@@ -35,7 +35,6 @@ from gslib.exception import CommandException
 from gslib.lazy_wrapper import LazyWrapper
 from gslib.utils.constants import UTF8
 from gslib.utils.constants import WINDOWS_1252
-from gslib.tests.util import USING_JSON_API
 from gslib.utils.system_util import IS_CP1252
 
 
@@ -409,23 +408,3 @@ def get_random_ascii_chars(size, seed=0):
   contents = six.ensure_binary(contents)
   random.seed()  # Reset the seed for any other tests.
   return contents
-
-def get_prefix():
-  """Get a prefix string 'aaa-' for bucket names if using XML API
-
-  Since XML API doesn't support searching for bucket name prefixes, and since it
-  also only returns the first 1,000 buckets alphabetically, we sometimes see integration
-  tests flake when more than 1,000 buckets exist.
-
-  This creative workaround makes sure that buckets use in tab completion and wildcard tests
-  are hoisted to the top of the list of buckets. This workaround is primarily for our own CI
-  and tests may still flake if you have more than 1,000 buckets that would be ordered before
-  'aaa-' and are using the XML API.
-
-  Returns:
-    String literal 'aaa-' if currently using XML API.
-  """
-  if USING_JSON_API:
-    return ''
-  return 'aaa-'
-

--- a/gslib/utils/text_util.py
+++ b/gslib/utils/text_util.py
@@ -35,6 +35,7 @@ from gslib.exception import CommandException
 from gslib.lazy_wrapper import LazyWrapper
 from gslib.utils.constants import UTF8
 from gslib.utils.constants import WINDOWS_1252
+from gslib.tests.util import USING_JSON_API
 from gslib.utils.system_util import IS_CP1252
 
 
@@ -408,3 +409,23 @@ def get_random_ascii_chars(size, seed=0):
   contents = six.ensure_binary(contents)
   random.seed()  # Reset the seed for any other tests.
   return contents
+
+def get_prefix():
+  """Get a prefix string 'aaa-' for bucket names if using XML API
+
+  Since XML API doesn't support searching for bucket name prefixes, and since it
+  also only returns the first 1,000 buckets alphabetically, we sometimes see integration
+  tests flake when more than 1,000 buckets exist.
+
+  This creative workaround makes sure that buckets use in tab completion and wildcard tests
+  are hoisted to the top of the list of buckets. This workaround is primarily for our own CI
+  and tests may still flake if you have more than 1,000 buckets that would be ordered before
+  'aaa-' and are using the XML API.
+
+  Returns:
+    String literal 'aaa-' if currently using XML API.
+  """
+  if USING_JSON_API:
+    return ''
+  return 'aaa-'
+


### PR DESCRIPTION
For b/131254662.
Some tests that rely on tab-complete will fail when using the XML
API and when there are more than 1,000 buckets present. This is because
XML API does not accept prefixes for bucket names, it just returns a full list
off all buckets that gsutil filters to make tab complete work.

Since the list returned it alphabetized, as a workaround to the API limitation,
we append 'aaa-' to effected tabcomplete and wildcard tests to hoist their buckets
to the top of the list returned by the API.