### PR TITLE
Fix Iam Bucket URL Regex

### DIFF
--- a/gslib/commands/iam.py
+++ b/gslib/commands/iam.py
@@ -53,7 +53,6 @@ from gslib.utils.iam_helper import IsEqualBindings
 from gslib.utils.iam_helper import PatchBindings
 from gslib.utils.iam_helper import SerializeBindingsTuple
 from gslib.utils.retry_util import Retry
-from gslib.utils.text_util import IsBucketNameValid
 
 _SET_SYNOPSIS = """
   gsutil iam set [-afRr] [-e <etag>] file url ...
@@ -216,6 +215,7 @@ _get_help_text = CreateHelpText(_GET_SYNOPSIS, _GET_DESCRIPTION)
 _set_help_text = CreateHelpText(_SET_SYNOPSIS, _SET_DESCRIPTION)
 _ch_help_text = CreateHelpText(_CH_SYNOPSIS, _CH_DESCRIPTION)
 
+STORAGE_URI_REGEX = re.compile(r'[a-z]+://.+')
 
 IAM_CH_CONDITIONS_WORKAROUND_MSG = (
     'To change the IAM policy of a resource that has bindings containing '
@@ -480,7 +480,7 @@ class IamCommand(Command):
     # expecting to come across the -r, -f flags here.
     it = iter(self.args)
     for token in it:
-      if IsBucketNameValid(token):
+      if STORAGE_URI_REGEX.match(token):
         patterns.append(token)
         break
       if token == '-d':

--- a/gslib/commands/iam.py
+++ b/gslib/commands/iam.py
@@ -53,6 +53,7 @@ from gslib.utils.iam_helper import IsEqualBindings
 from gslib.utils.iam_helper import PatchBindings
 from gslib.utils.iam_helper import SerializeBindingsTuple
 from gslib.utils.retry_util import Retry
+from gslib.utils.text_util import IsBucketNameValid
 
 _SET_SYNOPSIS = """
   gsutil iam set [-afRr] [-e <etag>] file url ...
@@ -214,40 +215,6 @@ _DETAILED_HELP_TEXT = CreateHelpText(_SYNOPSIS, _DESCRIPTION)
 _get_help_text = CreateHelpText(_GET_SYNOPSIS, _GET_DESCRIPTION)
 _set_help_text = CreateHelpText(_SET_SYNOPSIS, _SET_DESCRIPTION)
 _ch_help_text = CreateHelpText(_CH_SYNOPSIS, _CH_DESCRIPTION)
-
-def _IsBucketNameValid(bucket_name):
-  """Check if string meets all bucket name requirements.
-
-  Requirements for bucket names defined at:
-  https://cloud.google.com/storage/docs/naming
-
-  Args:
-    Unicode tring, name of bucket. Full name, including provider prefix, i.e.:
-    'gs://my-bucket-name'
-  Returns:
-    Boolean, whether the bucket name is valid or not.
-  """
-
-  def _StripAllowedSymbols(s):
-    """Remove from a string the symbols '-', '_', and '.'"""
-    return ''.join((char for char in s if char not in ['-', '_', '.']))
-
-  if not '://' in bucket_name:
-    return False
-
-  prefix, url = bucket_name.split('://')
-
-  return all([
-    prefix.isalpha(),
-    prefix.islower(),
-    len(url) > 2,
-    len(url) < 64,
-    url[0].isalnum(),
-    url[-1].isalnum(),
-    not url.startswith('goog'),
-    not url.isupper(),
-    _StripAllowedSymbols(url).isalnum()
-  ])
 
 
 IAM_CH_CONDITIONS_WORKAROUND_MSG = (
@@ -513,7 +480,7 @@ class IamCommand(Command):
     # expecting to come across the -r, -f flags here.
     it = iter(self.args)
     for token in it:
-      if _IsBucketNameValid(token):
+      if IsBucketNameValid(token):
         patterns.append(token)
         break
       if token == '-d':

--- a/gslib/commands/iam.py
+++ b/gslib/commands/iam.py
@@ -215,7 +215,7 @@ _get_help_text = CreateHelpText(_GET_SYNOPSIS, _GET_DESCRIPTION)
 _set_help_text = CreateHelpText(_SET_SYNOPSIS, _SET_DESCRIPTION)
 _ch_help_text = CreateHelpText(_CH_SYNOPSIS, _CH_DESCRIPTION)
 
-STORAGE_URI_REGEX = re.compile(r'[a-z]+://[a-z].*')
+STORAGE_URI_REGEX = re.compile(r'[a-z]+://[a-z0-9].*')
 
 IAM_CH_CONDITIONS_WORKAROUND_MSG = (
     'To change the IAM policy of a resource that has bindings containing '

--- a/gslib/utils/text_util.py
+++ b/gslib/utils/text_util.py
@@ -303,6 +303,42 @@ def PrintableStr(input_val):
   """
   return input_val
 
+
+def IsBucketNameValid(bucket_name):
+  """Check if string meets all bucket name requirements.
+
+  Requirements for bucket names defined at:
+  https://cloud.google.com/storage/docs/naming
+
+  Args:
+    Unicode tring, name of bucket. Full name, including provider prefix, i.e.:
+    'gs://my-bucket-name'
+  Returns:
+    Boolean, whether the bucket name is valid or not.
+  """
+
+  def _StripAllowedSymbols(s):
+    """Remove from a string the symbols '-', '_', and '.'"""
+    return ''.join((char for char in s if char not in ['-', '_', '.']))
+
+  if not '://' in bucket_name:
+    return False
+
+  prefix, url = bucket_name.split('://')
+
+  return all([
+    prefix.isalpha(),
+    prefix.islower(),
+    len(url) > 2,
+    len(url) < 64,
+    url[0].isalnum(),
+    url[-1].isalnum(),
+    not url.startswith('goog'),
+    not url.isupper(),
+    _StripAllowedSymbols(url).isalnum()
+  ])
+
+
 def print_to_fd(*objects, **kwargs):
   """A Python 2/3 compatible analogue to the print function.
 
@@ -340,7 +376,7 @@ def print_to_fd(*objects, **kwargs):
 
     return expected_keywords.values()
 
-  
+
   def _get_byte_strings(*objects):
     """Gets a `bytes` string for each item in a list of printable objects."""
     byte_objects = []
@@ -357,7 +393,7 @@ def print_to_fd(*objects, **kwargs):
         # will throw a TypeError.
         byte_objects.append(six.ensure_binary(item))
     return byte_objects
-    
+
   sep, end, file = _get_args(**kwargs)
   sep = six.ensure_binary(sep)
   end = six.ensure_binary(end)

--- a/gslib/utils/text_util.py
+++ b/gslib/utils/text_util.py
@@ -325,6 +325,10 @@ def IsBucketNameValid(bucket_name):
     return False
 
   prefix, url = bucket_name.split('://')
+  url = url.rstrip()
+
+  if url[-1] == '/':
+    url = url[:-1]
 
   return all([
     prefix.isalpha(),

--- a/gslib/utils/text_util.py
+++ b/gslib/utils/text_util.py
@@ -334,7 +334,6 @@ def IsBucketNameValid(bucket_name):
     prefix.isalpha(),
     prefix.islower(),
     len(url) > 2,
-    len(url) < 64,
     url[0].isalnum(),
     url[-1].isalnum(),
     not url.startswith('goog'),

--- a/gslib/utils/text_util.py
+++ b/gslib/utils/text_util.py
@@ -326,6 +326,9 @@ def IsBucketNameValid(bucket_name):
 
   prefix, url = bucket_name.split('://')
   url = url.rstrip()
+  
+  if url[-1] == '/':	
+    url = url[:-1]
 
   return all([
     prefix.isalpha(),

--- a/gslib/utils/text_util.py
+++ b/gslib/utils/text_util.py
@@ -304,44 +304,6 @@ def PrintableStr(input_val):
   return input_val
 
 
-def IsBucketNameValid(bucket_name):
-  """Check if string meets all bucket name requirements.
-
-  Requirements for bucket names defined at:
-  https://cloud.google.com/storage/docs/naming
-
-  Args:
-    Unicode tring, name of bucket. Full name, including provider prefix, i.e.:
-    'gs://my-bucket-name'
-  Returns:
-    Boolean, whether the bucket name is valid or not.
-  """
-
-  def _StripAllowedSymbols(s):
-    """Remove '-', '_', '/', and '.' from given string."""
-    return ''.join((char for char in s if char not in ['/', '-', '_', '.']))
-
-  if not '://' in bucket_name:
-    return False
-
-  prefix, url = bucket_name.split('://')
-  url = url.rstrip()
-  
-  if url[-1] == '/':	
-    url = url[:-1]
-
-  return all([
-    prefix.isalpha(),
-    prefix.islower(),
-    len(url) > 2,
-    url[0].isalnum(),
-    url[-1].isalnum(),
-    not url.startswith('goog'),
-    not url.isupper(),
-    _StripAllowedSymbols(url).isalnum()
-  ])
-
-
 def print_to_fd(*objects, **kwargs):
   """A Python 2/3 compatible analogue to the print function.
 

--- a/gslib/utils/text_util.py
+++ b/gslib/utils/text_util.py
@@ -318,8 +318,8 @@ def IsBucketNameValid(bucket_name):
   """
 
   def _StripAllowedSymbols(s):
-    """Remove from a string the symbols '-', '_', and '.'"""
-    return ''.join((char for char in s if char not in ['-', '_', '.']))
+    """Remove '-', '_', '/', and '.' from given string."""
+    return ''.join((char for char in s if char not in ['/', '-', '_', '.']))
 
   if not '://' in bucket_name:
     return False

--- a/gslib/utils/text_util.py
+++ b/gslib/utils/text_util.py
@@ -327,9 +327,6 @@ def IsBucketNameValid(bucket_name):
   prefix, url = bucket_name.split('://')
   url = url.rstrip()
 
-  if url[-1] == '/':
-    url = url[:-1]
-
   return all([
     prefix.isalpha(),
     prefix.islower(),


### PR DESCRIPTION
Reported in bug #770 , iam operations fail on buckets whose names don't
contain any letters. For example, bucket with a UID name that contains
only digits and dashes will throw an exception, since the iam command
will try to parse it as a binding rather than a URL.

See also b/132080434