### PR TITLE
Fix rm wildcard bug with >1,000 buckets

### DIFF
--- a/gslib/tests/test_rm.py
+++ b/gslib/tests/test_rm.py
@@ -422,6 +422,7 @@ class TestRm(testcase.GsUtilIntegrationTestCase):
     buri_base = 'gsutil-test-%s' % self.GetTestMethodName()
     buri_base = buri_base[:MAX_BUCKET_LENGTH-20]
     buri_base = '%s-%s' % (buri_base, self.MakeRandomTestString())
+    buri_base = 'aaa-' + buri_base
     buri_base = util.MakeBucketNameValid(buri_base)
     buri1 = self.CreateBucket(bucket_name='%s-tbuck1' % buri_base)
     buri2 = self.CreateBucket(bucket_name='%s-tbuck2' % buri_base)


### PR DESCRIPTION
For b/131254662. When more than 1,000 buckets exist, the XML API returns
only the first 1,000. To workaround this, we prefix the bucket names
with 'aaa-' to help ensure these buckets will be in the first 1,000.