### PR TITLE
Added time elapsed to 'Still running' messages.

### DIFF
--- a/gslib/commands/test.py
+++ b/gslib/commands/test.py
@@ -445,7 +445,12 @@ class TestCommand(Command):
             for proc_num in range(len(process_list)):
               if not process_done[proc_num]:
                 still_running.append(parallel_integration_tests[proc_num])
-            print('Still running: %s' % still_running)
+            elapsed = time.time() - parallel_start_time
+            print(('{sec} seconds elapsed since beginning parallel tests.\n'
+                   'Still running: {procs}').format(
+                       sec=str(int(elapsed)),
+                       procs=still_running,
+                   ))
             # TODO: Terminate still-running processes if they
             # hang for a long time.
           last_log_time = time.time()


### PR DESCRIPTION
For b/132281242

Long running tests periodically print a "Still running" reminder. It
would be helpful to know how long they have been running for. This
commit adds the seconds elapsed since the process started to the
message.