### PR TITLE
Remove use of the term "subdirectories".

### DIFF
--- a/gslib/commands/mv.py
+++ b/gslib/commands/mv.py
@@ -52,27 +52,30 @@ _DETAILED_HELP_TEXT = ("""
     gsutil mv ./dir gs://my_bucket
 
 
-<B>RENAMING BUCKET SUBDIRECTORIES</B>
-  You can use the gsutil mv command to rename subdirectories. For example,
-  the command:
+<B>RENAMING GROUPS OF OBJECTS</B>
+  You can use the gsutil mv command to rename all objects with a given prefix
+  to have a new prefix. This is accomplished by copying each object to a new
+  object with the desired name and deleting the old one. For example, the
+  command:
 
-    gsutil mv gs://my_bucket/olddir gs://my_bucket/newdir
+    gsutil mv gs://my_bucket/oldprefix gs://my_bucket/newprefix
 
-  would rename all objects and subdirectories under gs://my_bucket/olddir to be
-  under gs://my_bucket/newdir, otherwise preserving the subdirectory structure.
+  would rename all objects under gs://my_bucket/oldprefix to be under
+  gs://my_bucket/newprefix, otherwise preserving the naming structure.
 
   If you do a rename as specified above and you want to preserve ACLs, you
   should use the -p option (see OPTIONS).
 
-  Note that when using mv to rename bucket subdirectories you cannot specify
-  the source URL using wildcards. You need to spell out the complete name:
+  Note that when using mv to rename groups of objects with a common prefix
+  you cannot specify the source URL using wildcards. You need to spell out
+  the complete name:
 
-    gsutil mv gs://my_bucket/olddir gs://my_bucket/newdir
+    gsutil mv gs://my_bucket/oldprefix gs://my_bucket/newprefix
 
   If you have a large number of files to move you might want to use the
   gsutil -m option, to perform a multi-threaded/multi-processing move:
 
-    gsutil -m mv gs://my_bucket/olddir gs://my_bucket/newdir
+    gsutil -m mv gs://my_bucket/oldprefix gs://my_bucket/newprefix
 
 
 <B>NON-ATOMIC OPERATION</B>
@@ -125,7 +128,7 @@ class MvCommand(Command):
       help_name='mv',
       help_name_aliases=['move', 'rename'],
       help_type='command_help',
-      help_one_line_summary='Move/rename objects and/or subdirectories',
+      help_one_line_summary='Move/rename objects',
       help_text=_DETAILED_HELP_TEXT,
       subcommand_help_text={},
   )


### PR DESCRIPTION
While gsutil mimics a directory structure in some ways, it's more appropriate to think of it as common prefixes to object names.