### PR TITLE
Make signurl work with objects containing tildes.

### DIFF
--- a/gslib/commands/signurl.py
+++ b/gslib/commands/signurl.py
@@ -539,7 +539,8 @@ class UrlSignCommand(Command):
         # Need to url encode the object name as Google Cloud Storage does when
         # computing the string to sign when checking the signature.
         gcs_path = '{0}/{1}'.format(
-            url.bucket_name, urllib.parse.quote(url.object_name.encode(UTF8)))
+            url.bucket_name,
+            urllib.parse.quote(url.object_name.encode(UTF8), safe='/~'))
 
       if region == _AUTO_DETECT_REGION:
         if url.bucket_name in region_cache:


### PR DESCRIPTION
Fixes https://issuetracker.google.com/issues/133019153

Per the docs, the tilde character should not be percent-encoded:

When defining the path to the resource, you must percent encode the
following reserved characters: ?=!#$&'()*+,:;@[]."

https://cloud.google.com/storage/docs/access-control/signing-urls-manually

Note that Python 3's urllib quote method ignores the tilde, but Python
2's does not:
- Py2 docs: "Letters, digits, and the characters '_.-' are never quoted."
- Py3 docs: "Letters, digits, and the characters '_.-~' are never quoted."