### PR TITLE
Small doc edits

### DIFF
--- a/gslib/commands/bucketpolicyonly.py
+++ b/gslib/commands/bucketpolicyonly.py
@@ -68,9 +68,11 @@ _GET_DESCRIPTION = """
 """
 
 _DESCRIPTION = """
-  The ``bucketpolicyonly`` command is used to retrieve or configure the Bucket
-  Policy Only setting of Cloud Storage bucket(s). This command has two
-  sub-commands, ``get`` and ``set``.
+  The ``bucketpolicyonly`` command is used to retrieve or configure the
+  `Bucket Policy Only (Beta)
+  <https://cloud.google.com/storage/docs/bucket-policy-only>`_ setting of
+  Cloud Storage bucket(s). This command has two sub-commands, ``get`` and
+  ``set``.
 """ + _GET_DESCRIPTION + _SET_DESCRIPTION
 
 _DETAILED_HELP_TEXT = CreateHelpText(_SYNOPSIS, _DESCRIPTION)

--- a/gslib/commands/cp.py
+++ b/gslib/commands/cp.py
@@ -97,8 +97,8 @@ _DESCRIPTION_TEXT = """
     gsutil cp -r dir gs://my-bucket
 
   If you have a large number of files to transfer you might want to use the
-  gsutil -m option, to perform a parallel (multi-threaded/multi-processing)
-  copy:
+  top-level gsutil -m option (see "gsutil help command_opts"), to perform a
+  parallel (multi-threaded/multi-processing) copy:
 
     gsutil -m cp -r dir gs://my-bucket
 
@@ -252,8 +252,8 @@ _COPY_IN_CLOUD_TEXT = """
 
     gsutil cp -A gs://bucket1/obj gs://bucket2
 
-  The gsutil -m flag is disallowed when using the cp -A flag, to ensure that
-  version ordering is preserved.
+  The top-level gsutil -m flag is disallowed when using the cp -A flag, to
+  ensure that version ordering is preserved.
 """
 
 _CHECKSUM_VALIDATION_TEXT = """
@@ -382,8 +382,8 @@ _STREAMING_TRANSFERS_TEXT = """
   validation, use a non-streaming transfer, which performs integrity checking
   automatically.
 
-  Note: Streaming transfers are not allowed when the gsutil -m option is in
-  force.
+  Note: Streaming transfers are not allowed when the top-level gsutil -m flag
+  is used.
 """
 
 _SLICED_OBJECT_DOWNLOADS_TEXT = """
@@ -605,7 +605,7 @@ _OPTIONS_TEXT = """
 
                    gsutil -o "GSUtil:parallel_process_count=8" \\
                      -o "GSUtil:parallel_thread_count=1" \\
-                     -m cp -r /local/source/dir gs://bucket/path
+                     -m cp -j html -r /local/source/dir gs://bucket/path
 
   -J             Applies gzip transport encoding to file uploads. This option
                  works like the -j option described above, but it applies to

--- a/gslib/commands/notification.py
+++ b/gslib/commands/notification.py
@@ -142,10 +142,11 @@ _CREATE_DESCRIPTION = """
   create command will use the Cloud Pub/Sub topic
   "projects/default-project/topics/example-bucket".
 
-  In order to enable notifications, a special Cloud Storage service account
-  unique to each project must have the IAM permission "projects.topics.publish".
-  This command will check to see if that permission exists and, if not, will
-  attempt to grant it.
+  In order to enable notifications, a `special Cloud Storage service account
+  <https://cloud.google.com/storage/docs/projects#service-accounts>`_ unique to
+  each project must have the IAM permission "projects.topics.publish". This
+  command will check to see if that permission exists and, if not, will attempt
+  to grant it.
 
   You can create multiple notification configurations for a bucket, but their
   triggers cannot overlap such that a single event could send multiple


### PR DESCRIPTION
* Add the -j flag to the relevant example in `gsutil cp`.
* Clarify that `-m` is a top-level flag, not specific to `gsutil cp`.
* Offer links to additional conceptual information for the Bucket Policy Only and GCS-specific service account.
* These changes address the following user-reported issues: b/75005961, b/111501119, b/112908799, and b/131860498.


