### PR TITLE
Improve logic for detecting PKCS 12 keys

### DIFF
--- a/gslib/gcs_json_credentials.py
+++ b/gslib/gcs_json_credentials.py
@@ -259,7 +259,8 @@ def _MaybeTextFile(filename):
   Returns:
     Boolean: True if the first 1024 bytes seem to indicate a text file
   """
-  textchars = bytearray({7,8,9,10,12,13,27} | set(range(0x20, 0x100)) - {0x7f})
+  textchars = bytearray({7, 8, 9, 10, 12, 13, 27} |
+                        set(range(0x20, 0x100)) - {0x7f})
   return lambda bytes: bool(bytes.translate(None, textchars))
 
 
@@ -272,8 +273,8 @@ def _MaybeP12File(filename):
     Boolean: True if file has expected ending and isn't text file
   """
   return not _MaybeTextFile(filename) and any(
-    filename.lower().endswith('.p12'),
-    filename.lower().endswith('.pfx'),
+      filename.lower().endswith('.p12'),
+      filename.lower().endswith('.pfx'),
   )
 
 
@@ -328,7 +329,7 @@ def _GetOauth2ServiceAccountCredentials():
     if json_key_dict:
       # Key file is in JSON format.
       for json_entry in ('client_id', 'client_email', 'private_key_id',
-                        'private_key'):
+                         'private_key'):
         if json_entry not in json_key_dict:
           raise Exception('The JSON private key file at %s '
                           'did not contain the required entry: %s' %

--- a/gslib/gcs_json_credentials.py
+++ b/gslib/gcs_json_credentials.py
@@ -269,12 +269,7 @@ def _GetOauth2ServiceAccountCredentials():
     pass
 
   if keyfile_is_utf8:
-    json_key_dict = None
-    try:
-      json_key_dict = json.loads(private_key)
-    except ValueError:
-      raise Exception('Could not parse JSON keyfile "%s" as valid JSON' %
-                      private_key_filename)
+    json_key_dict = json.loads(private_key)
     if json_key_dict:
       # Key file is in JSON format.
       for json_entry in ('client_id', 'client_email', 'private_key_id',

--- a/gslib/gcs_json_credentials.py
+++ b/gslib/gcs_json_credentials.py
@@ -30,6 +30,7 @@ import json
 import logging
 import os
 import io
+import six
 import traceback
 
 # pylint: disable=g-bad-import-order
@@ -128,7 +129,7 @@ def GetCredentialStoreKey(credentials, api_version):
   # interchangeable.  This applies for all credentials that store a token URI.
   if getattr(credentials, 'token_uri', None):
     key_parts.append(credentials.token_uri)
-
+  key_parts = [six.ensure_text(part) for part in key_parts]
   return '-'.join(key_parts)
 
 

--- a/gslib/gcs_json_credentials.py
+++ b/gslib/gcs_json_credentials.py
@@ -25,7 +25,6 @@ from __future__ import division
 from __future__ import unicode_literals
 
 import base64
-import binascii
 import json
 import logging
 import os
@@ -249,68 +248,6 @@ def _HasGceCreds():
   return config.has_option('GoogleCompute', 'service_account')
 
 
-def _MaybeTextFile(filename):
-  """Check if text file based on file(1)
-
-  Implementation stolen shamelessly from:
-  https://stackoverflow.com/a/7392391/2873090
-
-  Args:
-    filename: String describing a path to a file
-  Returns:
-    Boolean: True if the first 1024 bytes seem to indicate a text file
-  """
-  textchars = bytearray({7, 8, 9, 10, 12, 13, 27} |
-                        set(range(0x20, 0x100)) - {0x7f})
-  return lambda bytes: bool(bytes.translate(None, textchars))
-
-
-def _MaybeP12File(filename):
-  """Check if file has expected ending .p12 or .pfx and isn't text file
-
-  Args:
-    filename: String describing a path to a file
-  Returns:
-    Boolean: True if file has expected ending and isn't text file
-  """
-  return not _MaybeTextFile(filename) and any(
-      filename.lower().endswith('.p12'),
-      filename.lower().endswith('.pfx'),
-  )
-
-
-def _ProbablyP12File(filename):
-  """Checks first hextet of file to see if it matches .p12 file header
-
-  Anecdotally, .p12 files appear to always start with hextet 0x3082. Check
-  the first hextet to see if it matches this pattern.
-
-  This isn't explicitly verified in the PKCS 12 spec, but testing several valid
-  PKCS 12 files, this appears to be the case.
-
-  TODO: Consult with SMEs to verify this assumption is correct. If so, remove
-        the _MaybeP12File() function and rename this function.
-
-  Args:
-    filename: String describing a path to a file
-  Returns:
-    Boolean: True if file starts with 0x3082
-  """
-  p12_header = b'3082'
-  with open(filename, 'rb') as f:
-    hextet = binascii.hexlify(bytearray(f.read(2)))
-  return p12_header == hextet
-
-
-def _GetPrivateKey(filename):
-  if _MaybeP12File(filename) or _ProbablyP12File(filename):
-    with open(filename, 'rb') as private_key_file:
-      return (True, private_key_file.read())
-  else:
-    with io.open(filename, 'r', encoding=UTF8) as private_key_file:
-      return (False, private_key_file.read())
-
-
 def _GetOauth2ServiceAccountCredentials():
   """Retrieves OAuth2 service account credentials for a private key file."""
   if not _HasOauth2ServiceAccountCreds():
@@ -319,9 +256,19 @@ def _GetOauth2ServiceAccountCredentials():
   provider_token_uri = _GetProviderTokenUri()
   service_client_id = config.get('Credentials', 'gs_service_client_id', '')
   private_key_filename = config.get('Credentials', 'gs_service_key_file', '')
-  pkcs12_key, private_key = _GetPrivateKey(private_key_filename)
 
-  if not pkcs12_key:
+  with io.open(private_key_filename, 'rb') as private_key_file:
+    private_key = private_key_file.read()
+
+  keyfile_is_utf8 = False
+  try:
+    private_key = private_key.decode(UTF8)
+    # P12 keys won't be encoded as UTF8 bytes.
+    keyfile_is_utf8 = True
+  except UnicodeDecodeError:
+    pass
+
+  if keyfile_is_utf8:
     json_key_dict = None
     try:
       json_key_dict = json.loads(private_key)

--- a/gslib/gcs_json_credentials.py
+++ b/gslib/gcs_json_credentials.py
@@ -273,7 +273,8 @@ def _GetOauth2ServiceAccountCredentials():
     try:
       json_key_dict = json.loads(private_key)
     except ValueError:
-      pass
+      raise Exception('Could not parse JSON keyfile "%s" as valid JSON' %
+                      private_key_filename)
     if json_key_dict:
       # Key file is in JSON format.
       for json_entry in ('client_id', 'client_email', 'private_key_id',

--- a/gslib/gcs_json_credentials.py
+++ b/gslib/gcs_json_credentials.py
@@ -269,22 +269,20 @@ def _GetOauth2ServiceAccountCredentials():
     pass
 
   if keyfile_is_utf8:
-    json_key_dict = None
     try:
       json_key_dict = json.loads(private_key)
     except ValueError:
       raise Exception('Could not parse JSON keyfile "%s" as valid JSON' %
                       private_key_filename)
-    if json_key_dict:
-      # Key file is in JSON format.
-      for json_entry in ('client_id', 'client_email', 'private_key_id',
-                         'private_key'):
-        if json_entry not in json_key_dict:
-          raise Exception('The JSON private key file at %s '
-                          'did not contain the required entry: %s' %
-                          (private_key_filename, json_entry))
-      return ServiceAccountCredentials.from_json_keyfile_dict(
-          json_key_dict, scopes=DEFAULT_SCOPES, token_uri=provider_token_uri)
+    # Key file is in JSON format.
+    for json_entry in ('client_id', 'client_email', 'private_key_id',
+                       'private_key'):
+      if json_entry not in json_key_dict:
+        raise Exception('The JSON private key file at %s '
+                        'did not contain the required entry: %s' %
+                        (private_key_filename, json_entry))
+    return ServiceAccountCredentials.from_json_keyfile_dict(
+        json_key_dict, scopes=DEFAULT_SCOPES, token_uri=provider_token_uri)
   else:
     # Key file is in P12 format.
     if HAS_CRYPTO:

--- a/gslib/gcs_json_credentials.py
+++ b/gslib/gcs_json_credentials.py
@@ -293,12 +293,18 @@ def _GetOauth2ServiceAccountCredentials():
                                  GOOGLE_OAUTH2_DEFAULT_FILE_PASSWORD)
       # We use _from_p12_keyfile_contents to avoid reading the key file
       # again unnecessarily.
-      return ServiceAccountCredentials.from_p12_keyfile_buffer(
-          service_client_id,
-          BytesIO(private_key),
-          private_key_password=key_file_pass,
-          scopes=DEFAULT_SCOPES,
-          token_uri=provider_token_uri)
+      try:
+        return ServiceAccountCredentials.from_p12_keyfile_buffer(
+            service_client_id,
+            BytesIO(private_key),
+            private_key_password=key_file_pass,
+            scopes=DEFAULT_SCOPES,
+            token_uri=provider_token_uri)
+      except Exception as e:
+        raise Exception(
+            'OpenSSL unable to parse PKCS 12 key {}.'
+            'Please verify key integrity. Error message:\n{}'.format(
+                private_key_filename, str(e)))
 
 
 def _GetOauth2UserAccountCredentials():

--- a/gslib/gcs_json_credentials.py
+++ b/gslib/gcs_json_credentials.py
@@ -269,7 +269,12 @@ def _GetOauth2ServiceAccountCredentials():
     pass
 
   if keyfile_is_utf8:
-    json_key_dict = json.loads(private_key)
+    json_key_dict = None
+    try:
+      json_key_dict = json.loads(private_key)
+    except ValueError:
+      raise Exception('Could not parse JSON keyfile "%s" as valid JSON' %
+                      private_key_filename)
     if json_key_dict:
       # Key file is in JSON format.
       for json_entry in ('client_id', 'client_email', 'private_key_id',


### PR DESCRIPTION
When attempting to load a PKCS 12 key in Python 3, `io.open` would
throw an error since it tried to apply UTF-8 text encoding to the
key file, which was not a compatible text file.

Changes tested using .p12 key from our pre-release tests.