### PR TITLE
Remove test dir from test_update

### DIFF
--- a/gslib/commands/signurl.py
+++ b/gslib/commands/signurl.py
@@ -540,7 +540,7 @@ class UrlSignCommand(Command):
         # computing the string to sign when checking the signature.
         gcs_path = '{0}/{1}'.format(
             url.bucket_name,
-            urllib.parse.quote(url.object_name.encode(UTF8), safe='/~'))
+            urllib.parse.quote(url.object_name.encode(UTF8), safe=b'/~'))
 
       if region == _AUTO_DETECT_REGION:
         if url.bucket_name in region_cache:

--- a/gslib/tests/test_update.py
+++ b/gslib/tests/test_update.py
@@ -85,7 +85,7 @@ class UpdateTest(testcase.GsUtilIntegrationTestCase):
     # .git*, etc.)
     os.makedirs(gsutil_dst)
     for comp in ('CHANGES.md', 'CHECKSUM', 'gslib', 'gsutil', 'gsutil.py',
-                 'LICENSE', 'MANIFEST.in', 'README.md', 'setup.py', 'test',
+                 'LICENSE', 'MANIFEST.in', 'README.md', 'setup.py',
                  'third_party', 'VERSION'):
       cp_src_path = os.path.join(GSUTIL_DIR, comp)
       cp_dst_path = os.path.join(gsutil_dst, comp)


### PR DESCRIPTION
The presence of many new scripts in the test directory upset and confused our pre-release tests. In this PR we're asking it not to look in this folder since it's all CI stuff that is tested separately anyways.

There was also a small bug with an earlier PR that introduced a regression for signing URLs in Python 2.x. Added a fix for this as well.