### PR TITLE
Test `help` command for all commands.

### DIFF
--- a/gslib/tests/test_help.py
+++ b/gslib/tests/test_help.py
@@ -26,6 +26,7 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import unicode_literals
 
+from gslib.command import Command
 import gslib.tests.testcase as testcase
 
 
@@ -73,3 +74,11 @@ class HelpIntegrationTests(testcase.GsUtilIntegrationTestCase):
   def test_help_wrong_num_args(self):
     stderr = self.RunGsUtil(['cp'], return_stderr=True, expected_status=1)
     self.assertIn('Usage:', stderr)
+
+  def test_help_runs_for_all_commands(self):
+    # This test is particularly helpful because the `help` command can fail
+    # under unusual circumstances (e.g. someone adds a new command and they make
+    # the "one-line" summary longer than the defined character limit).
+    for command in Command.__subclasses__():
+      # Raises exception if the exit code is non-zero.
+      self.RunGsUtil(['help', command.command_spec.command_name])


### PR DESCRIPTION
This will also be run against new commands added in the future, since
the list of commands is obtained by a call to `Command.__subclasses__()`.

Context: I found that the new hmac command failed when I tried to run
the help command against it.