### PR TITLE
Update rsync.py

### DIFF
--- a/gslib/commands/rsync.py
+++ b/gslib/commands/rsync.py
@@ -1046,7 +1046,7 @@ class _DiffIterator(object):
                      crc32c, md5)
     """
     (encoded_url, size, time_created, atime, mtime, mode, uid, gid, crc32c,
-     md5) = line.split()
+     md5) = line.rsplit(None, 9)
     return (
         _DecodeUrl(encoded_url),
         int(size),


### PR DESCRIPTION
Fixed a bug in rsync when the file name contains spaces (would throw an exception if encounter such a file). The fix is to split only the rest of the arguments (changed split to rsplit with exact number of arguments).