### PR TITLE
Add file with whitespace in name to rsync tests

### DIFF
--- a/gslib/tests/test_rsync.py
+++ b/gslib/tests/test_rsync.py
@@ -2835,7 +2835,6 @@ class TestRsync(testcase.GsUtilIntegrationTestCase):
 
     _Check()
 
-
   def test_rsync_files_with_whitespace(self):
     """Test to ensure filenames with whitespace can be rsynced"""
     filename = 'foo bar baz.txt'
@@ -2853,7 +2852,6 @@ class TestRsync(testcase.GsUtilIntegrationTestCase):
     listing2 = TailSet(suri(bucket_uri), self.FlatListBucket(bucket_uri))
     self.assertEquals(set(listing1), expected_list_results)
     self.assertEquals(set(listing2), expected_list_results)
-
 
   @SkipForS3('No compressed transport encoding support for S3.')
   @SkipForXML('No compressed transport encoding support for the XML API.')

--- a/gslib/tests/test_rsync.py
+++ b/gslib/tests/test_rsync.py
@@ -2835,6 +2835,26 @@ class TestRsync(testcase.GsUtilIntegrationTestCase):
 
     _Check()
 
+
+  def test_rsync_files_with_whitespace(self):
+    """Test to ensure filenames with whitespace can be rsynced"""
+    filename = 'foo bar baz.txt'
+    local_uris = []
+    bucket_uri = self.CreateBucket()
+    tmpdir = self.CreateTempDir()
+    contents = 'File from rsync test: test_rsync_files_with_whitespace'
+    local_file = self.CreateTempFile(tmpdir, contents, filename)
+
+    expected_list_results = frozenset(['/foo bar baz.txt'])
+
+    """Tests rsync works as expected."""
+    self.RunGsUtil(['rsync', '-r', tmpdir, suri(bucket_uri)])
+    listing1 = TailSet(tmpdir, self.FlatListDir(tmpdir))
+    listing2 = TailSet(suri(bucket_uri), self.FlatListBucket(bucket_uri))
+    self.assertEquals(set(listing1), expected_list_results)
+    self.assertEquals(set(listing2), expected_list_results)
+
+
   @SkipForS3('No compressed transport encoding support for S3.')
   @SkipForXML('No compressed transport encoding support for the XML API.')
   @SequentialAndParallelTransfer

--- a/gslib/tests/test_update.py
+++ b/gslib/tests/test_update.py
@@ -84,13 +84,12 @@ class UpdateTest(testcase.GsUtilIntegrationTestCase):
     # working files left in top-level directory by gsutil developers (like tags,
     # .git*, etc.)
     os.makedirs(gsutil_dst)
-    for comp in ('CHANGES.md', 'CHECKSUM', 'gslib', 'gsutil', 'gsutil.py',
-                 'LICENSE', 'MANIFEST.in', 'README.md', 'setup.py',
-                 'third_party', 'VERSION'):
-      cp_src_path = os.path.join(GSUTIL_DIR, comp)
-      cp_dst_path = os.path.join(gsutil_dst, comp)
-      func = shutil.copytree if os.path.isdir(cp_src_path) else shutil.copyfile
-      func(cp_src_path, cp_dst_path)
+    for comp in os.listdir(GSUTIL_DIR):
+      if '.git' not in comp:
+        cp_src_path = os.path.join(GSUTIL_DIR, comp)
+        cp_dst_path = os.path.join(gsutil_dst, comp)
+        func = shutil.copytree if os.path.isdir(cp_src_path) else shutil.copyfile
+        func(cp_src_path, cp_dst_path)
 
     # Create a fake version number in the source so we can verify it in the
     # destination.

--- a/gslib/tests/test_update.py
+++ b/gslib/tests/test_update.py
@@ -88,7 +88,8 @@ class UpdateTest(testcase.GsUtilIntegrationTestCase):
       if '.git' not in comp:
         cp_src_path = os.path.join(GSUTIL_DIR, comp)
         cp_dst_path = os.path.join(gsutil_dst, comp)
-        func = shutil.copytree if os.path.isdir(cp_src_path) else shutil.copyfile
+        func = shutil.copytree if os.path.isdir(
+            cp_src_path) else shutil.copyfile
         func(cp_src_path, cp_dst_path)
 
     # Create a fake version number in the source so we can verify it in the


### PR DESCRIPTION
For bugs:
https://github.com/GoogleCloudPlatform/gsutil/issues/807
b/135474885

Added a test case whith a file containing whitespace. A regression was
found that rsync tests didn't catch where split was called and
improperly parsed arguments when a file with whitespace was present.