### PR TITLE
Include all directory files in `update` test

### DIFF
--- a/gslib/tests/test_update.py
+++ b/gslib/tests/test_update.py
@@ -84,13 +84,12 @@ class UpdateTest(testcase.GsUtilIntegrationTestCase):
     # working files left in top-level directory by gsutil developers (like tags,
     # .git*, etc.)
     os.makedirs(gsutil_dst)
-    for comp in ('CHANGES.md', 'CHECKSUM', 'gslib', 'gsutil', 'gsutil.py',
-                 'LICENSE', 'MANIFEST.in', 'README.md', 'setup.py',
-                 'third_party', 'VERSION'):
-      cp_src_path = os.path.join(GSUTIL_DIR, comp)
-      cp_dst_path = os.path.join(gsutil_dst, comp)
-      func = shutil.copytree if os.path.isdir(cp_src_path) else shutil.copyfile
-      func(cp_src_path, cp_dst_path)
+    for comp in os.listdir(GSUTIL_DIR):
+      if '.git' not in comp:
+        cp_src_path = os.path.join(GSUTIL_DIR, comp)
+        cp_dst_path = os.path.join(gsutil_dst, comp)
+        func = shutil.copytree if os.path.isdir(cp_src_path) else shutil.copyfile
+        func(cp_src_path, cp_dst_path)
 
     # Create a fake version number in the source so we can verify it in the
     # destination.


### PR DESCRIPTION
The integration test for the update command copied only expected release
files when testing. This can miss regressions like in issue #809 .
Updated test logic to include everything in the gsutil directory except
the .git directory.