### PR TITLE
Replace sys.stderr.write with print_to_fd

### DIFF
--- a/gslib/tests/testcase/unit_testcase.py
+++ b/gslib/tests/testcase/unit_testcase.py
@@ -41,6 +41,8 @@ import gslib.tests.util as util
 from gslib.tests.util import unittest
 from gslib.tests.util import WorkingDirectory
 from gslib.utils.constants import UTF8
+from gslib.utils.text_util import get_utf8able_str
+from gslib.utils.text_util import print_to_fd
 
 
 class GsutilApiUnitTestClassMapFactory(object):
@@ -127,8 +129,8 @@ class GsUtilUnitTestCase(base.GsUtilTestCase):
         stderr = sys.stderr.buffer.read()
     [six.ensure_text(string) for string in self.accumulated_stderr]
     [six.ensure_text(string) for string in self.accumulated_stdout]
-    stdout = six.ensure_text(stdout)
-    stderr = six.ensure_text(stderr)
+    stdout = six.ensure_text(get_utf8able_str(stdout))
+    stderr = six.ensure_text(get_utf8able_str(stderr))
     stdout += ''.join(self.accumulated_stdout)
     stderr += ''.join(self.accumulated_stderr)
     sys.stdout.close()
@@ -140,17 +142,17 @@ class GsUtilUnitTestCase(base.GsUtilTestCase):
 
     _id = six.ensure_text(self.id())
     if self.is_debugging and stdout:
-      sys.stderr.write('==== stdout {} ====\n'.format(_id))
-      sys.stderr.write(six.ensure_text(stdout))
-      sys.stderr.write('==== end stdout ====\n')
+      print_to_fd('==== stdout {} ====\n'.format(_id), file=sys.stderr)
+      print_to_fd(stdout, file=sys.stderr)
+      print_to_fd('==== end stdout ====\n', file=sys.stderr)
     if self.is_debugging and stderr:
-      sys.stderr.write('==== stderr {} ====\n'.format(_id))
-      sys.stderr.write(six.ensure_text(stderr))
-      sys.stderr.write('==== end stderr ====\n')
+      print_to_fd('==== stderr {} ====\n'.format(_id), file=sys.stderr)
+      print_to_fd(stderr, file=sys.stderr)
+      print_to_fd('==== end stderr ====\n', file=sys.stderr)
     if self.is_debugging and log_output:
-      sys.stderr.write('==== log output {} ====\n'.format(_id))
-      sys.stderr.write(six.ensure_text(log_output))
-      sys.stderr.write('==== end log output ====\n')
+      print_to_fd('==== log output {} ====\n'.format(_id), file=sys.stderr)
+      print_to_fd(log_output, file=sys.stderr)
+      print_to_fd('==== end log output ====\n', file=sys.stderr)
 
   def RunCommand(self,
                  command_name,
@@ -195,7 +197,7 @@ class GsUtilUnitTestCase(base.GsUtilTestCase):
 
     command_line = six.ensure_text(' '.join([command_name] + args))
     if self.is_debugging:
-      self.stderr_save.write('\nRunCommand of {}\n'.format(command_line))
+      print_to_fd('\nRunCommand of {}\n'.format(command_line), file=self.stderr_save)
 
     # Save and truncate stdout and stderr for the lifetime of RunCommand. This
     # way, we can return just the stdout and stderr that was output during the
@@ -251,20 +253,20 @@ class GsUtilUnitTestCase(base.GsUtilTestCase):
 
       _id = six.ensure_text(self.id())
       if self.is_debugging and log_output:
-        self.stderr_save.write('==== logging RunCommand {} {} ====\n'.format(
-            _id, command_line))
-        self.stderr_save.write(six.ensure_text(log_output))
-        self.stderr_save.write('\n==== end logging ====\n')
+        print_to_fd('==== logging RunCommand {} {} ====\n'.format(
+            _id, command_line), file=self.stderr_save)
+        print_to_fd(log_output, file=self.stderr_save)
+        print_to_fd('\n==== end logging ====\n', file=self.stderr_save)
       if self.is_debugging and stdout:
-        self.stderr_save.write('==== stdout RunCommand {} {} ====\n'.format(
-            _id, command_line))
-        self.stderr_save.write(six.ensure_text(stdout))
-        self.stderr_save.write('==== end stdout ====\n')
+        print_to_fd('==== stdout RunCommand {} {} ====\n'.format(
+            _id, command_line), file=self.stderr_save)
+        print_to_fd(stdout, file=self.stderr_save)
+        print_to_fd('==== end stdout ====\n', file=self.stderr_save)
       if self.is_debugging and stderr:
-        self.stderr_save.write('==== stderr RunCommand {} {} ====\n'.format(
-            _id, command_line))
-        self.stderr_save.write(six.ensure_text(stderr))
-        self.stderr_save.write('==== end stderr ====\n')
+        print_to_fd('==== stderr RunCommand {} {} ====\n'.format(
+            _id, command_line), file=self.stderr_save)
+        print_to_fd(stderr, file=self.stderr_save)
+        print_to_fd('==== end stderr ====\n', file=self.stderr_save)
 
       # Reset stdout and stderr files, so that we won't print them out again
       # in tearDown if debugging is enabled.

--- a/gslib/tests/testcase/unit_testcase.py
+++ b/gslib/tests/testcase/unit_testcase.py
@@ -27,6 +27,7 @@ import tempfile
 import six
 
 import boto
+from boto.utils import get_utf8able_str
 from gslib import project_id
 from gslib import wildcard_iterator
 from gslib.boto_translation import BotoTranslation
@@ -41,7 +42,6 @@ import gslib.tests.util as util
 from gslib.tests.util import unittest
 from gslib.tests.util import WorkingDirectory
 from gslib.utils.constants import UTF8
-from gslib.utils.text_util import get_utf8able_str
 from gslib.utils.text_util import print_to_fd
 
 

--- a/gslib/tests/testcase/unit_testcase.py
+++ b/gslib/tests/testcase/unit_testcase.py
@@ -197,7 +197,8 @@ class GsUtilUnitTestCase(base.GsUtilTestCase):
 
     command_line = six.ensure_text(' '.join([command_name] + args))
     if self.is_debugging:
-      print_to_fd('\nRunCommand of {}\n'.format(command_line), file=self.stderr_save)
+      print_to_fd('\nRunCommand of {}\n'.format(command_line),
+                  file=self.stderr_save)
 
     # Save and truncate stdout and stderr for the lifetime of RunCommand. This
     # way, we can return just the stdout and stderr that was output during the
@@ -254,17 +255,20 @@ class GsUtilUnitTestCase(base.GsUtilTestCase):
       _id = six.ensure_text(self.id())
       if self.is_debugging and log_output:
         print_to_fd('==== logging RunCommand {} {} ====\n'.format(
-            _id, command_line), file=self.stderr_save)
+            _id, command_line),
+                    file=self.stderr_save)
         print_to_fd(log_output, file=self.stderr_save)
         print_to_fd('\n==== end logging ====\n', file=self.stderr_save)
       if self.is_debugging and stdout:
         print_to_fd('==== stdout RunCommand {} {} ====\n'.format(
-            _id, command_line), file=self.stderr_save)
+            _id, command_line),
+                    file=self.stderr_save)
         print_to_fd(stdout, file=self.stderr_save)
         print_to_fd('==== end stdout ====\n', file=self.stderr_save)
       if self.is_debugging and stderr:
         print_to_fd('==== stderr RunCommand {} {} ====\n'.format(
-            _id, command_line), file=self.stderr_save)
+            _id, command_line),
+                    file=self.stderr_save)
         print_to_fd(stderr, file=self.stderr_save)
         print_to_fd('==== end stderr ====\n', file=self.stderr_save)
 

--- a/gslib/utils/text_util.py
+++ b/gslib/utils/text_util.py
@@ -404,3 +404,35 @@ def get_random_ascii_chars(size, seed=0):
   contents = six.ensure_binary(contents)
   random.seed()  # Reset the seed for any other tests.
   return contents
+
+
+def get_utf8able_str(s, errors='strict'):
+    """Returns a UTF8-encodable string in PY3, UTF8 bytes in PY2.
+
+    This method is similar to six's `ensure_str()`, except it also
+    makes sure that any bytes passed in can be decoded using the
+    utf-8 codec (and raises a UnicodeDecodeError if not). If the
+    object isn't a string, this method will attempt to coerce it
+    to a string with `str()`. Objects without `__str__` property
+    or `__repr__` property will raise an exception.
+    """
+    if not isinstance(s, (six.text_type, six.binary_type)):
+        s = str(s)
+    if six.PY2:
+        # We want to return utf-8 encoded bytes.
+        if isinstance(s, six.text_type):
+            return s.encode('utf-8', errors)
+        if isinstance(s, six.binary_type):
+            # Verify the bytes can be represented in utf-8
+            s.decode('utf-8')
+            return s
+    else:
+        # We want to return a unicode/str object.
+        if isinstance(s, six.text_type):
+            return s
+        if isinstance(s, six.binary_type):
+            s = s.decode('utf-8')
+            return s
+    raise TypeError('not expecting type "%s"' % type(s))
+
+

--- a/gslib/utils/text_util.py
+++ b/gslib/utils/text_util.py
@@ -405,34 +405,3 @@ def get_random_ascii_chars(size, seed=0):
   random.seed()  # Reset the seed for any other tests.
   return contents
 
-
-def get_utf8able_str(s, errors='strict'):
-    """Returns a UTF8-encodable string in PY3, UTF8 bytes in PY2.
-
-    This method is similar to six's `ensure_str()`, except it also
-    makes sure that any bytes passed in can be decoded using the
-    utf-8 codec (and raises a UnicodeDecodeError if not). If the
-    object isn't a string, this method will attempt to coerce it
-    to a string with `str()`. Objects without `__str__` property
-    or `__repr__` property will raise an exception.
-    """
-    if not isinstance(s, (six.text_type, six.binary_type)):
-        s = str(s)
-    if six.PY2:
-        # We want to return utf-8 encoded bytes.
-        if isinstance(s, six.text_type):
-            return s.encode('utf-8', errors)
-        if isinstance(s, six.binary_type):
-            # Verify the bytes can be represented in utf-8
-            s.decode('utf-8')
-            return s
-    else:
-        # We want to return a unicode/str object.
-        if isinstance(s, six.text_type):
-            return s
-        if isinstance(s, six.binary_type):
-            s = s.decode('utf-8')
-            return s
-    raise TypeError('not expecting type "%s"' % type(s))
-
-

--- a/gslib/utils/text_util.py
+++ b/gslib/utils/text_util.py
@@ -404,4 +404,3 @@ def get_random_ascii_chars(size, seed=0):
   contents = six.ensure_binary(contents)
   random.seed()  # Reset the seed for any other tests.
   return contents
-


### PR DESCRIPTION
For Python 2/3 compatibility, print_to_fd offers us more flexibility
when trying to write various string types to an arbitrary file
descriptor.

Also added get_utf8able_str function to try to ensure strings being
printed are in the right encoding, which cropped up a few times in
recent pre-release test runs where the deubg flag is included.