### PR TITLE
Made resumable upload test use bigger file

### DIFF
--- a/gslib/tests/test_cp.py
+++ b/gslib/tests/test_cp.py
@@ -3807,7 +3807,8 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
 
   def start_over_error_test_helper(self, http_error_num):
     bucket_uri = self.CreateBucket()
-    fpath = self.CreateTempFile(contents=b'a' * 2 * ONE_KIB)
+    fpath = self.CreateTempFile(contents=get_random_ascii_chars(
+        size=(ONE_MIB*4)))
     boto_config_for_test = ('GSUtil', 'resumable_threshold', str(ONE_KIB))
     if self.test_api == ApiSelector.JSON:
       test_callback_file = self.CreateTempFile(

--- a/gslib/tests/test_cp.py
+++ b/gslib/tests/test_cp.py
@@ -3807,6 +3807,8 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
 
   def start_over_error_test_helper(self, http_error_num):
     bucket_uri = self.CreateBucket()
+    # The bucket contents need to be fairly large to avoid the race condition
+    # where the contents finish uploading before we artifically halt the copy.
     rand_chars = get_random_ascii_chars(size=(ONE_MIB * 4))
     fpath = self.CreateTempFile(contents=rand_chars)
     boto_config_for_test = ('GSUtil', 'resumable_threshold', str(ONE_KIB))

--- a/gslib/tests/test_cp.py
+++ b/gslib/tests/test_cp.py
@@ -3807,7 +3807,7 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
 
   def start_over_error_test_helper(self, http_error_num):
     bucket_uri = self.CreateBucket()
-    # The bucket contents need to be fairly large to avoid the race condition
+    # The object contents need to be fairly large to avoid the race condition
     # where the contents finish uploading before we artifically halt the copy.
     rand_chars = get_random_ascii_chars(size=(ONE_MIB * 4))
     fpath = self.CreateTempFile(contents=rand_chars)

--- a/gslib/tests/test_cp.py
+++ b/gslib/tests/test_cp.py
@@ -3807,8 +3807,8 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
 
   def start_over_error_test_helper(self, http_error_num):
     bucket_uri = self.CreateBucket()
-    fpath = self.CreateTempFile(contents=get_random_ascii_chars(size=(ONE_MIB *
-                                                                      4)))
+    rand_chars = get_random_ascii_chars(size=(ONE_MIB * 4))
+    fpath = self.CreateTempFile(contents=rand_chars)
     boto_config_for_test = ('GSUtil', 'resumable_threshold', str(ONE_KIB))
     if self.test_api == ApiSelector.JSON:
       test_callback_file = self.CreateTempFile(

--- a/gslib/tests/test_cp.py
+++ b/gslib/tests/test_cp.py
@@ -3807,8 +3807,8 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
 
   def start_over_error_test_helper(self, http_error_num):
     bucket_uri = self.CreateBucket()
-    fpath = self.CreateTempFile(contents=get_random_ascii_chars(
-        size=(ONE_MIB*4)))
+    fpath = self.CreateTempFile(contents=get_random_ascii_chars(size=(ONE_MIB *
+                                                                      4)))
     boto_config_for_test = ('GSUtil', 'resumable_threshold', str(ONE_KIB))
     if self.test_api == ApiSelector.JSON:
       test_callback_file = self.CreateTempFile(


### PR DESCRIPTION
Sometimes the resumable upload test would fail because it couldn't
artifically halt the test before finishing uploading the entire test
file. Made the test file much larger with more entropy to help avoid
this race condition.