### PR TITLE
Add process timeout for tests

### DIFF
--- a/gslib/tests/testcase/integration_testcase.py
+++ b/gslib/tests/testcase/integration_testcase.py
@@ -964,7 +964,11 @@ class GsUtilIntegrationTestCase(base.GsUtilTestCase):
                          stderr=subprocess.PIPE,
                          stdin=subprocess.PIPE,
                          env=envstr)
-    c_out = p.communicate(stdin)
+    comm_kwargs = {'input': stdin}
+    if six.PY3:
+      # TODO(b/135936279): Make this number configurable in .boto
+      comm_kwargs['timeout'] = 180
+    c_out = p.communicate(**comm_kwargs)
     try:
       c_out = [six.ensure_text(output) for output in c_out]
     except UnicodeDecodeError:


### PR DESCRIPTION
Per b/29278122 and b/135780661, adding a timeout to Popen.communicate()
to prevent tests from hanging forever. TODO b/135936279, we should add
the timeout value to the .boto config file.

Note: The timeout keyword argument is only available in Python 3.