### PR TITLE
Added retry decorators to more tests

### DIFF
--- a/gslib/tests/test_cp.py
+++ b/gslib/tests/test_cp.py
@@ -621,6 +621,7 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
       self.assertIn('Skipping existing item: %s' % suri(f), stderr)
       self.assertEqual(f.read(), 'quux')
 
+  # TODO(b/135780661): Remove retry after bug resolved
   @Retry(AssertionError, tries=3, timeout_secs=1)
   def test_dest_bucket_not_exist(self):
     fpath = self.CreateTempFile(contents=b'foo')
@@ -1071,6 +1072,7 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
                             expected_status=1)
     self.assertIn('cannot be the destination for gsutil cp', stderr)
 
+  # TODO(b/135780661): Remove retry after bug resolved
   @Retry(AssertionError, tries=3, timeout_secs=1)
   def test_versioning_no_parallelism(self):
     """Tests that copy all-versions errors when parallelism is enabled."""

--- a/gslib/tests/test_cp.py
+++ b/gslib/tests/test_cp.py
@@ -621,6 +621,7 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
       self.assertIn('Skipping existing item: %s' % suri(f), stderr)
       self.assertEqual(f.read(), 'quux')
 
+  @Retry(AssertionError, tries=3, timeout_secs=1)
   def test_dest_bucket_not_exist(self):
     fpath = self.CreateTempFile(contents=b'foo')
     invalid_bucket_uri = ('%s://%s' %
@@ -1070,6 +1071,7 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
                             expected_status=1)
     self.assertIn('cannot be the destination for gsutil cp', stderr)
 
+  @Retry(AssertionError, tries=3, timeout_secs=1)
   def test_versioning_no_parallelism(self):
     """Tests that copy all-versions errors when parallelism is enabled."""
     stderr = self.RunGsUtil([

--- a/gslib/tests/test_iam.py
+++ b/gslib/tests/test_iam.py
@@ -615,6 +615,7 @@ class TestIamCh(TestIamIntegration):
     self.assertHas(bucket_iam_string, self.user, IAM_BUCKET_READ_ROLE)
     self.assertHas(bucket2_iam_string, self.user, IAM_BUCKET_READ_ROLE)
 
+  # TODO(b/135780661): Remove retry after bug resolved
   @Retry(AssertionError, tries=3, timeout_secs=1)
   def test_patch_multithreaded_error(self):
     """See TestIamSet.test_set_multithreaded_error."""
@@ -800,6 +801,7 @@ class TestIamSet(TestIamIntegration):
           return_stderr=True)
       self.assertIn('Estimated work for this command: objects: 1\n', stderr)
 
+  # TODO(b/135780661): Remove retry after bug resolved
   @Retry(AssertionError, tries=3, timeout_secs=1)
   def test_set_invalid_iam_bucket(self):
     """Ensures invalid content returns error on input check."""
@@ -1148,6 +1150,7 @@ class TestIamSet(TestIamIntegration):
     # The IAM policy has also been set on Bucket "bucket2".
     self.assertEqualsPoliciesString(set_iam_string, set_iam_string2)
 
+  # TODO(b/135780661): Remove retry after bug resolved
   @Retry(AssertionError, tries=3, timeout_secs=1)
   def test_set_multithreaded_error(self):
     """Tests fail-fast behavior of multithreaded iam set.

--- a/gslib/tests/test_iam.py
+++ b/gslib/tests/test_iam.py
@@ -615,6 +615,7 @@ class TestIamCh(TestIamIntegration):
     self.assertHas(bucket_iam_string, self.user, IAM_BUCKET_READ_ROLE)
     self.assertHas(bucket2_iam_string, self.user, IAM_BUCKET_READ_ROLE)
 
+  @Retry(AssertionError, tries=3, timeout_secs=1)
   def test_patch_multithreaded_error(self):
     """See TestIamSet.test_set_multithreaded_error."""
     stderr = self.RunGsUtil([
@@ -799,6 +800,7 @@ class TestIamSet(TestIamIntegration):
           return_stderr=True)
       self.assertIn('Estimated work for this command: objects: 1\n', stderr)
 
+  @Retry(AssertionError, tries=3, timeout_secs=1)
   def test_set_invalid_iam_bucket(self):
     """Ensures invalid content returns error on input check."""
     inpath = self.CreateTempFile(contents=b'badIam')
@@ -1146,6 +1148,7 @@ class TestIamSet(TestIamIntegration):
     # The IAM policy has also been set on Bucket "bucket2".
     self.assertEqualsPoliciesString(set_iam_string, set_iam_string2)
 
+  @Retry(AssertionError, tries=3, timeout_secs=1)
   def test_set_multithreaded_error(self):
     """Tests fail-fast behavior of multithreaded iam set.
 

--- a/gslib/tests/test_rsync.py
+++ b/gslib/tests/test_rsync.py
@@ -2535,6 +2535,7 @@ class TestRsync(testcase.GsUtilIntegrationTestCase):
 
     _Check2()
 
+  @Retry(AssertionError, tries=3, timeout_secs=1)
   def test_rsync_from_nonexistent_bucket(self):
     """Tests that rsync from a non-existent bucket subdir fails gracefully."""
     tmpdir = self.CreateTempDir()
@@ -2550,6 +2551,7 @@ class TestRsync(testcase.GsUtilIntegrationTestCase):
     # Dir should have un-altered content.
     self.assertEquals(listing, set(['/obj1', '/.obj2']))
 
+  @Retry(AssertionError, tries=3, timeout_secs=1)
   def test_rsync_to_nonexistent_bucket(self):
     """Tests that rsync from a non-existent bucket subdir fails gracefully."""
     tmpdir = self.CreateTempDir()

--- a/gslib/tests/test_rsync.py
+++ b/gslib/tests/test_rsync.py
@@ -2535,6 +2535,7 @@ class TestRsync(testcase.GsUtilIntegrationTestCase):
 
     _Check2()
 
+  # TODO(b/135780661): Remove retry after bug resolved
   @Retry(AssertionError, tries=3, timeout_secs=1)
   def test_rsync_from_nonexistent_bucket(self):
     """Tests that rsync from a non-existent bucket subdir fails gracefully."""
@@ -2551,6 +2552,7 @@ class TestRsync(testcase.GsUtilIntegrationTestCase):
     # Dir should have un-altered content.
     self.assertEquals(listing, set(['/obj1', '/.obj2']))
 
+  # TODO(b/135780661): Remove retry after bug resolved
   @Retry(AssertionError, tries=3, timeout_secs=1)
   def test_rsync_to_nonexistent_bucket(self):
     """Tests that rsync from a non-existent bucket subdir fails gracefully."""


### PR DESCRIPTION
Per b/135780661 and b/29278122, we sometimes see multiprocess testing on
nonexistent buckets hang. Timeouts have been added to the threads
running these tests, and now retry decorators are being added to the
tests themselves so they can attempt the test again after the previous
thread dies.