### PR TITLE
Prefix invalid tabcomplete bucket name

### DIFF
--- a/gslib/tests/test_tabcomplete.py
+++ b/gslib/tests/test_tabcomplete.py
@@ -183,7 +183,7 @@ class TestTabComplete(testcase.GsUtilIntegrationTestCase):
     during tab completion may end in a dash and completion should still work.
     """
 
-    bucket_base_name = self.MakeTempName('bucket')
+    bucket_base_name = self.MakeTempName('bucket', prefix='aaa-')
     bucket_name = bucket_base_name + '-s'
     self.CreateBucket(bucket_name)
 

--- a/gslib/tests/testcase/base.py
+++ b/gslib/tests/testcase/base.py
@@ -109,7 +109,7 @@ class GsUtilTestCase(unittest.TestCase):
     """
     name = '{prefix}gsutil-test-{method}-{kind}'.format(
         prefix=prefix, method=self.GetTestMethodName(), kind=kind)
-    name = name[:MAX_BUCKET_LENGTH - 9]
+    name = name[:MAX_BUCKET_LENGTH - 13]
     name = '{name}-{rand}'.format(name=name, rand=self.MakeRandomTestString())
     total_name_len = len(name) + len(suffix)
     if suffix:


### PR DESCRIPTION
Per PR 766's description, some XML tests fail when over 1000 buckets are
present. This is one of the tests that does this, and we hoist the
bucket name close to the top of the list py prefixing it with "aaa-".
Also fixed MakeTempName to always accommodate enough room for "aaa-".