### PR TITLE
Adjust wildcard bucket names

### DIFF
--- a/gslib/tests/test_cors.py
+++ b/gslib/tests/test_cors.py
@@ -217,7 +217,7 @@ class TestCors(testcase.GsUtilIntegrationTestCase):
         [suri(bucket1_uri), suri(bucket2_uri)])
     self.assertTrue(
         common_prefix.startswith(
-            'gs://%sgsutil-test-test-set-wildcard-non-null-cors-' %
+            'gs://%sgsutil-test-test-set-wildcard-non' %
             random_prefix))
     wildcard = '%s*' % common_prefix
 

--- a/gslib/tests/test_ls.py
+++ b/gslib/tests/test_ls.py
@@ -261,7 +261,7 @@ class TestLs(testcase.GsUtilIntegrationTestCase):
         [suri(bucket1_uri), suri(bucket2_uri)])
     self.assertTrue(
         common_prefix.startswith(
-            '%s://%sgsutil-test-test-bucket-list-wildcard-bucket-' %
+            '%s://%sgsutil-test-test-bucket-list-wildcard' %
             (self.default_provider, random_prefix)))
     wildcard = '%s*' % common_prefix
 


### PR DESCRIPTION
In PR 826, I updated the temp bucket prefix logic to tuncate names a
little shorter to compensate for a specific test failure. This regressed
two other tests who had long statically defined names. These names were
shoretened to reflect the updated prefix logic.