### PR TITLE
Move retry decorators into nested functions

### DIFF
--- a/gslib/tests/test_cors.py
+++ b/gslib/tests/test_cors.py
@@ -216,9 +216,8 @@ class TestCors(testcase.GsUtilIntegrationTestCase):
     common_prefix = posixpath.commonprefix(
         [suri(bucket1_uri), suri(bucket2_uri)])
     self.assertTrue(
-        common_prefix.startswith(
-            'gs://%sgsutil-test-test-set-wildcard-non' %
-            random_prefix))
+        common_prefix.startswith('gs://%sgsutil-test-test-set-wildcard-non' %
+                                 random_prefix))
     wildcard = '%s*' % common_prefix
 
     fpath = self.CreateTempFile(contents=self.cors_doc.encode(UTF8))

--- a/gslib/tests/test_cp.py
+++ b/gslib/tests/test_cp.py
@@ -621,16 +621,18 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
       self.assertIn('Skipping existing item: %s' % suri(f), stderr)
       self.assertEqual(f.read(), 'quux')
 
-  # TODO(b/135780661): Remove retry after bug resolved
-  @Retry(AssertionError, tries=3, timeout_secs=1)
   def test_dest_bucket_not_exist(self):
     fpath = self.CreateTempFile(contents=b'foo')
     invalid_bucket_uri = ('%s://%s' %
                           (self.default_provider, self.nonexistent_bucket_name))
-    stderr = self.RunGsUtil(['cp', fpath, invalid_bucket_uri],
-                            expected_status=1,
-                            return_stderr=True)
-    self.assertIn('does not exist', stderr)
+    # TODO(b/135780661): Remove retry after bug resolved
+    @Retry(AssertionError, tries=3, timeout_secs=1)
+    def _Check():
+      stderr = self.RunGsUtil(['cp', fpath, invalid_bucket_uri],
+                              expected_status=1,
+                              return_stderr=True)
+      self.assertIn('does not exist', stderr)
+    _Check()
 
   def test_copy_in_cloud_noclobber(self):
     bucket1_uri = self.CreateBucket()
@@ -1088,18 +1090,20 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
                             expected_status=1)
     self.assertIn('cannot be the destination for gsutil cp', stderr)
 
-  # TODO(b/135780661): Remove retry after bug resolved
-  @Retry(AssertionError, tries=3, timeout_secs=1)
   def test_versioning_no_parallelism(self):
     """Tests that copy all-versions errors when parallelism is enabled."""
-    stderr = self.RunGsUtil([
-        '-m', 'cp', '-A',
-        suri(self.nonexistent_bucket_name, 'foo'),
-        suri(self.nonexistent_bucket_name, 'bar')
-    ],
-                            expected_status=1,
-                            return_stderr=True)
-    self.assertIn('-m option is not supported with the cp -A flag', stderr)
+    # TODO(b/135780661): Remove retry after bug resolved
+    @Retry(AssertionError, tries=3, timeout_secs=1)
+    def _Check():
+      stderr = self.RunGsUtil([
+          '-m', 'cp', '-A',
+          suri(self.nonexistent_bucket_name, 'foo'),
+          suri(self.nonexistent_bucket_name, 'bar')
+      ],
+                              expected_status=1,
+                              return_stderr=True)
+      self.assertIn('-m option is not supported with the cp -A flag', stderr)
+    _Check()
 
   @SkipForS3('S3 lists versioned objects in reverse timestamp order.')
   def test_recursive_copying_versioned_bucket(self):

--- a/gslib/tests/test_cp.py
+++ b/gslib/tests/test_cp.py
@@ -632,6 +632,7 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
                               expected_status=1,
                               return_stderr=True)
       self.assertIn('does not exist', stderr)
+
     _Check()
 
   def test_copy_in_cloud_noclobber(self):
@@ -1103,6 +1104,7 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
                               expected_status=1,
                               return_stderr=True)
       self.assertIn('-m option is not supported with the cp -A flag', stderr)
+
     _Check()
 
   @SkipForS3('S3 lists versioned objects in reverse timestamp order.')

--- a/gslib/tests/test_iam.py
+++ b/gslib/tests/test_iam.py
@@ -638,7 +638,8 @@ class TestIamCh(TestIamIntegration):
                                           return_stdout=True)
 
       self.assertEqualsPoliciesString(self.object_iam_string, object_iam_string)
-      self.assertEqualsPoliciesString(self.object_iam_string, object2_iam_string)
+      self.assertEqualsPoliciesString(self.object_iam_string,
+                                      object2_iam_string)
 
     _Check1()
     _Check2()
@@ -823,14 +824,14 @@ class TestIamSet(TestIamIntegration):
     @Retry(AssertionError, tries=3, timeout_secs=1)
     def _Check2():
       # Tests that setting with a non-existent file will also return error.
-      stderr = self.RunGsUtil(['iam', 'set', 'nonexistent/path', self.bucket.uri],
-                              return_stderr=True,
-                              expected_status=1)
+      stderr = self.RunGsUtil(
+          ['iam', 'set', 'nonexistent/path', self.bucket.uri],
+          return_stderr=True,
+          expected_status=1)
       self.assertIn('ArgumentException', stderr)
 
     _Check1()
     _Check2()
-
 
   def test_get_invalid_bucket(self):
     """Ensures that invalid bucket names returns an error."""
@@ -1211,7 +1212,6 @@ class TestIamSet(TestIamIntegration):
 
     _Check1()
     _Check2()
-
 
   def test_set_valid_iam_single_unversioned_object(self):
     """Tests setting a valid IAM on an object."""

--- a/gslib/tests/test_rsync.py
+++ b/gslib/tests/test_rsync.py
@@ -2552,6 +2552,7 @@ class TestRsync(testcase.GsUtilIntegrationTestCase):
       listing = TailSet(tmpdir, self.FlatListDir(tmpdir))
       # Dir should have un-altered content.
       self.assertEquals(listing, set(['/obj1', '/.obj2']))
+
     _Check()
 
   def test_rsync_to_nonexistent_bucket(self):

--- a/gslib/tests/test_rsync.py
+++ b/gslib/tests/test_rsync.py
@@ -2535,8 +2535,6 @@ class TestRsync(testcase.GsUtilIntegrationTestCase):
 
     _Check2()
 
-  # TODO(b/135780661): Remove retry after bug resolved
-  @Retry(AssertionError, tries=3, timeout_secs=1)
   def test_rsync_from_nonexistent_bucket(self):
     """Tests that rsync from a non-existent bucket subdir fails gracefully."""
     tmpdir = self.CreateTempDir()
@@ -2544,16 +2542,18 @@ class TestRsync(testcase.GsUtilIntegrationTestCase):
     self.CreateTempFile(tmpdir=tmpdir, file_name='.obj2', contents=b'.obj2')
     bucket_url_str = '%s://%s' % (self.default_provider,
                                   self.nonexistent_bucket_name)
-    stderr = self.RunGsUtil(['rsync', '-d', bucket_url_str, tmpdir],
-                            expected_status=1,
-                            return_stderr=True)
-    self.assertIn('Caught non-retryable exception', stderr)
-    listing = TailSet(tmpdir, self.FlatListDir(tmpdir))
-    # Dir should have un-altered content.
-    self.assertEquals(listing, set(['/obj1', '/.obj2']))
+    # TODO(b/135780661): Remove retry after bug resolved
+    @Retry(AssertionError, tries=3, timeout_secs=1)
+    def _Check():
+      stderr = self.RunGsUtil(['rsync', '-d', bucket_url_str, tmpdir],
+                              expected_status=1,
+                              return_stderr=True)
+      self.assertIn('Caught non-retryable exception', stderr)
+      listing = TailSet(tmpdir, self.FlatListDir(tmpdir))
+      # Dir should have un-altered content.
+      self.assertEquals(listing, set(['/obj1', '/.obj2']))
+    _Check()
 
-  # TODO(b/135780661): Remove retry after bug resolved
-  @Retry(AssertionError, tries=3, timeout_secs=1)
   def test_rsync_to_nonexistent_bucket(self):
     """Tests that rsync from a non-existent bucket subdir fails gracefully."""
     tmpdir = self.CreateTempDir()
@@ -2561,13 +2561,16 @@ class TestRsync(testcase.GsUtilIntegrationTestCase):
     self.CreateTempFile(tmpdir=tmpdir, file_name='.obj2', contents=b'.obj2')
     bucket_url_str = '%s://%s' % (self.default_provider,
                                   self.nonexistent_bucket_name)
-    stderr = self.RunGsUtil(['rsync', '-d', bucket_url_str, tmpdir],
-                            expected_status=1,
-                            return_stderr=True)
-    self.assertIn('Caught non-retryable exception', stderr)
-    listing = TailSet(tmpdir, self.FlatListDir(tmpdir))
-    # Dir should have un-altered content.
-    self.assertEquals(listing, set(['/obj1', '/.obj2']))
+    # TODO(b/135780661): Remove retry after bug resolved
+    @Retry(AssertionError, tries=3, timeout_secs=1)
+    def _Check():
+      stderr = self.RunGsUtil(['rsync', '-d', bucket_url_str, tmpdir],
+                              expected_status=1,
+                              return_stderr=True)
+      self.assertIn('Caught non-retryable exception', stderr)
+      listing = TailSet(tmpdir, self.FlatListDir(tmpdir))
+      # Dir should have un-altered content.
+      self.assertEquals(listing, set(['/obj1', '/.obj2']))
 
   def test_bucket_to_bucket_minus_d_with_overwrite_and_punc_chars(self):
     """Tests that punc chars in filenames don't confuse sort order."""


### PR DESCRIPTION
This fixes an issue when running tests in Python 2.x. Also ran yapf on the test directory.