### PR TITLE
Merge hex and url encoding changes

### DIFF
--- a/gslib/commands/rsync.py
+++ b/gslib/commands/rsync.py
@@ -836,25 +836,28 @@ def _EncodeUrl(url_string):
   We use this for all URL encodings.
 
   Args:
-    url_string: String URL to encode.
+    url_string (unicode): String URL to encode.
 
   Returns:
-    encoded URL.
+    (str) A string encoded using urllib's `quote_plus()` method.
   """
-  url = urllib.parse.unquote_plus(url_string)
-  if six.PY2:
-    url = url.encode(constants.UTF8)
-  return url
+  # N.B.: `quote_plus()` raises an error for unicode characters like è if you
+  # don't pass it the language-appropriate string type. If you pass it `unicode`
+  # in Python 2 or `bytes` in Python 3, it leads to surprising behavior for text
+  # containing unicode chars.
+  url_string = six.ensure_str(url_string)
+  return urllib.parse.quote_plus(url_string)
 
 
 def _DecodeUrl(enc_url_string):
-  """Inverts encoding from EncodeUrl.
+  """Inverts encoding from `_EncodeUrl()`.
 
   Args:
-    enc_url_string: String URL to decode.
+    enc_url_string (str): String containing UTF-8-decodable characters that were
+        encoded using urllib's `quote_plus()`.
 
   Returns:
-    decoded URL.
+    (unicode) A decoded URL.
   """
   url = urllib.parse.unquote_plus(enc_url_string)
   if six.PY2:

--- a/gslib/tests/test_rsync.py
+++ b/gslib/tests/test_rsync.py
@@ -24,6 +24,7 @@ import os
 import six
 
 import crcmod
+from gslib.commands import rsync
 from gslib.project_id import PopulateProjectId
 import gslib.tests.testcase as testcase
 from gslib.tests.testcase.integration_testcase import SkipForGS
@@ -68,6 +69,22 @@ if six.PY3:
 NO_CHANGES = 'Building synchronization state...\nStarting synchronization...\n'
 if not UsingCrcmodExtension(crcmod):
   NO_CHANGES = SLOW_CRCMOD_RSYNC_WARNING + '\n' + NO_CHANGES
+
+
+class TestRsyncUnit(testcase.GsUtilUnitTestCase):
+  """Unit tests for methods in the commands.rsync module."""
+  def testUrlEncodeAndDecode(self):
+    # Test special URL chars as well as unicode:
+    decoded_url = 'gs://bkt/space fslash/plus+tilde~unicodeeè'
+    encoded_url = (
+        'gs%3A%2F%2Fbkt%2Fspace+fslash%2Fplus%2Btilde%7Eunicodee%C3%A8')
+
+    # Encode accepts unicode, returns language-appropriate string type.
+    self.assertEqual(rsync._EncodeUrl(six.ensure_text(decoded_url)),
+                     six.ensure_str(encoded_url))
+    # Decode accepts language-appropriate string type, returns unicode.
+    self.assertEqual(rsync._DecodeUrl(six.ensure_str(encoded_url)),
+                     six.ensure_text(decoded_url))
 
 
 # TODO: Add inspection to the retry wrappers in this test suite where the state

--- a/gslib/tests/test_util.py
+++ b/gslib/tests/test_util.py
@@ -42,6 +42,7 @@ from gslib.utils.unit_util import HumanReadableWithDecimalPlaces
 from gslib.utils.unit_util import PrettyTime
 import httplib2
 
+import six
 from six import add_move, MovedModule
 add_move(MovedModule('mock', 'mock', 'unittest.mock'))
 from six.moves import mock
@@ -314,6 +315,14 @@ class TestUtil(testcase.GsUtilUnitTestCase):
     self.assertEqual('0 B', HumanReadableWithDecimalPlaces(0, 0))
     self.assertEqual('0.00 B', HumanReadableWithDecimalPlaces(0, 2))
     self.assertEqual('0.00000 B', HumanReadableWithDecimalPlaces(0, 5))
+
+  def testAmzGenerationTypeConversions(self):
+    amz_gen_as_str = six.ensure_str('9PpsRjBGjBh90IvIS96dgRc_UL6NyGqD')
+    amz_gen_as_long = 25923956239092482442895228561437790190304192615858167521375267910356975448388
+    self.assertEqual(text_util.DecodeLongAsString(amz_gen_as_long),
+                     amz_gen_as_str)
+    self.assertEqual(text_util.EncodeStringAsLong(amz_gen_as_str),
+                     amz_gen_as_long)
 
   def DoTestAddQueryParamToUrl(self, url, param_name, param_val, expected_url):
     new_url = text_util.AddQueryParamToUrl(url, param_name, param_val)

--- a/gslib/utils/text_util.py
+++ b/gslib/utils/text_util.py
@@ -19,6 +19,8 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import unicode_literals
 
+import binascii
+import codecs
 import os
 import sys
 import io
@@ -148,10 +150,8 @@ def DecodeLongAsString(long_to_convert):
   Returns:
     String decoded from the input long.
   """
-  if isinstance(long_to_convert, basestring):
-    # Already converted.
-    return long_to_convert
-  return hex(long_to_convert)[2:-1].decode('hex')
+  unhexed = binascii.unhexlify(hex(long_to_convert)[2:].rstrip('L'))
+  return six.ensure_str(unhexed)
 
 
 def EncodeStringAsLong(string_to_convert):
@@ -166,7 +166,10 @@ def EncodeStringAsLong(string_to_convert):
   Returns:
     Long that represents the input string.
   """
-  return long(string_to_convert.encode('hex'), 16)
+  hex_bytestr = codecs.encode(six.ensure_binary(string_to_convert), 'hex_codec')
+  # Note that `long`/`int` accepts either `bytes` or `unicode` as the
+  # first arg in both py2 and py3:
+  return long(hex_bytestr, 16)
 
 
 def FixWindowsEncodingIfNeeded(input_str):


### PR DESCRIPTION
Not sure why the hex stuff is showing up in the diff too; it's already in the GoogleCloudPlatform/py3-release-support branch.