### PR TITLE
Add mode attribute to {up,down}load wrapper classes

### DIFF
--- a/gslib/gcs_json_api.py
+++ b/gslib/gcs_json_api.py
@@ -1190,12 +1190,6 @@ class GcsJsonApi(CloudApi):
                                      end_byte=end_byte,
                                      serialization_data=serialization_data,
                                      decryption_tuple=decryption_tuple)
-      # If you are fighting a redacted exception spew in multiprocess/multithread
-      # calls, add your exception to HTTP_TRANSFER_EXCEPTIONS and put
-      # something like this immediately after the following except statement:
-      # import sys, traceback; sys.stderr.write('\n{}\n'.format(
-      #     traceback.format_exc())); sys.stderr.flush()
-      # This may hang, but you should get a stack trace spew after Ctrl-C.
       except HTTP_TRANSFER_EXCEPTIONS as e:
         self._ValidateHttpAccessTokenRefreshError(e)
         start_byte = download_stream.tell()
@@ -1206,6 +1200,24 @@ class GcsJsonApi(CloudApi):
           retries = 0
         retries += 1
         if retries > self.num_retries:
+          ##### DEBUG
+          # If you are fighting a redacted exception spew in
+          # multiprocess/multithread calls, add your exception to
+          # HTTP_TRANSFER_EXCEPTIONS and uncomment the following block.  This
+          # may hang, but you should get a stack trace spew after Ctrl-C.
+          #####
+          # import re, sys, traceback
+          # from gslib.utils import text_util
+          # message = 'some exception happened'
+          # stack_trace = traceback.format_exc()
+          # err = ('DEBUG: Exception stack trace:\n    %s\n%s\n' % (
+          #     re.sub('\\n', '\n    ', stack_trace),
+          #     message,
+          # ))
+          # dest_fd = sys.stderr
+          # text_util.print_to_fd(err, end='', file=dest_fd)
+          # dest_fd.flush()
+          ##### END DEBUG
           raise ResumableDownloadException(
               'Transfer failed after %d retries. Final exception: %s' %
               (self.num_retries, GetPrintableExceptionString(e)))

--- a/gslib/resumable_streaming_upload.py
+++ b/gslib/resumable_streaming_upload.py
@@ -64,6 +64,11 @@ class ResumableStreamingJsonUploadWrapper(object):
     self._buffer_end = 0
     self._position = 0
 
+  @property
+  def mode(self):
+    """Returns the mode of the underlying file descriptor, or None."""
+    return getattr(self._orig_fp, 'mode', None)
+
   def read(self, size=-1):  # pylint: disable=invalid-name
     """"Reads from the wrapped stream.
 

--- a/gslib/tests/test_cp.py
+++ b/gslib/tests/test_cp.py
@@ -3347,7 +3347,7 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
     boto_config_for_test = ('GSUtil', 'resumable_threshold', str(ONE_KIB))
     with SetBotoConfigForTest([boto_config_for_test]):
       stderr = self.RunGsUtil([
-          'cp', '--testcallbackfile', test_callback_file,
+          '-D', 'cp', '--testcallbackfile', test_callback_file,
           suri(object_uri),
           suri(fpath2)
       ],

--- a/gslib/tests/test_cp.py
+++ b/gslib/tests/test_cp.py
@@ -3347,7 +3347,7 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
     boto_config_for_test = ('GSUtil', 'resumable_threshold', str(ONE_KIB))
     with SetBotoConfigForTest([boto_config_for_test]):
       stderr = self.RunGsUtil([
-          '-D', 'cp', '--testcallbackfile', test_callback_file,
+          'cp', '--testcallbackfile', test_callback_file,
           suri(object_uri),
           suri(fpath2)
       ],

--- a/gslib/tests/test_rsync.py
+++ b/gslib/tests/test_rsync.py
@@ -73,6 +73,7 @@ if not UsingCrcmodExtension():
 
 class TestRsyncUnit(testcase.GsUtilUnitTestCase):
   """Unit tests for methods in the commands.rsync module."""
+
   def testUrlEncodeAndDecode(self):
     # Test special URL chars as well as unicode:
     decoded_url = 'gs://bkt/space fslash/plus+tilde~unicodeeè'

--- a/gslib/utils/copy_helper.py
+++ b/gslib/utils/copy_helper.py
@@ -2534,6 +2534,11 @@ class SlicedDownloadFileWrapper(object):
     self._start_byte = start_byte
     self._end_byte = end_byte
 
+  @property
+  def mode(self):
+    """Returns the mode of the underlying file descriptor, or None."""
+    return getattr(self._orig_fp, 'mode', None)
+
   def write(self, data):  # pylint: disable=invalid-name
     current_file_pos = self._orig_fp.tell()
     assert (self._start_byte <= current_file_pos and

--- a/gslib/utils/hashing_helper.py
+++ b/gslib/utils/hashing_helper.py
@@ -401,6 +401,11 @@ class HashingFileUploadWrapper(object):
     self._digesters_current_mark = 0
     self._hash_algs = hash_algs
 
+  @property
+  def mode(self):
+    """Returns the mode of the underlying file descriptor, or None."""
+    return getattr(self._orig_fp, 'mode', None)
+
   def read(self, size=-1):  # pylint: disable=invalid-name
     """"Reads from the wrapped file pointer and calculates hash digests.
 


### PR DESCRIPTION
This was causing a test to fail under Python 3. The underlying stream
was being treated as opened in text mode, rather than in binary mode,
because write_to_fd() could not determine its mode (and assumed text).
This caused sliced downloads to fail in
cp.TestCp.test_cp_resumable_download_gzip. Internal devs can see the
full failure stack trace and more details in this Issue Tracker issue:
https://issuetracker.google.com/issues/122963518#comment5