### PR TITLE
Make quote_plus behave the same on Python 2 and 3.

### DIFF
--- a/gslib/commands/rsync.py
+++ b/gslib/commands/rsync.py
@@ -846,7 +846,7 @@ def _EncodeUrl(url_string):
   # in Python 2 or `bytes` in Python 3, it leads to surprising behavior for text
   # containing unicode chars.
   url_string = six.ensure_str(url_string)
-  return urllib.parse.quote_plus(url_string)
+  return urllib.parse.quote_plus(url_string, safe=b'~')
 
 
 def _DecodeUrl(enc_url_string):

--- a/gslib/tests/test_rsync.py
+++ b/gslib/tests/test_rsync.py
@@ -78,7 +78,7 @@ class TestRsyncUnit(testcase.GsUtilUnitTestCase):
     # Test special URL chars as well as unicode:
     decoded_url = 'gs://bkt/space fslash/plus+tilde~unicodeeè'
     encoded_url = (
-        'gs%3A%2F%2Fbkt%2Fspace+fslash%2Fplus%2Btilde%7Eunicodee%C3%A8')
+        'gs%3A%2F%2Fbkt%2Fspace+fslash%2Fplus%2Btilde~unicodee%C3%A8')
 
     # Encode accepts unicode, returns language-appropriate string type.
     self.assertEqual(rsync._EncodeUrl(six.ensure_text(decoded_url)),


### PR DESCRIPTION
The tilde behavior was changed between 2 and 3; this also bit us in
another issue, see #783.