### PR TITLE
Don't keep the pycache files when updating.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,7 +10,8 @@ include setup.py
 recursive-include gslib *
 recursive-include test *
 global-exclude .git*
-global-exclude *.pyc
+global-exclude *.py[co]
+global-exclude __pycache__
 prune test
 prune gslib/vendored/boto/bin
 prune gslib/vendored/boto/docs


### PR DESCRIPTION
This includes the update command (and its tests) and when building an
sdist release.  The MANIFEST.in changes were modeled after django's
MANIFEST.in file after reading a thread where they encountered this.

Fixes https://issuetracker.google.com/issues/136424742