### PR TITLE
Fixes nits for .par bundles.

### DIFF
--- a/gslib/__init__.py
+++ b/gslib/__init__.py
@@ -126,7 +126,7 @@ def _GetFileContents(filename):
 
   Returns:
     A tuple containing the absolute path to the requested file and the file's
-    contents. If the file is not actually on disk, the file path will be None.
+    contents as a string (or None if the file doesn't exist).
   """
   fpath = os.path.join(PROGRAM_FILES_DIR, filename)
   if os.path.isfile(fpath):
@@ -135,7 +135,11 @@ def _GetFileContents(filename):
   else:
     content = pkgutil.get_data('gslib', filename)
     fpath = None
-  return (fpath, content.strip())
+  if content is not None:
+    if sys.version_info.major > 2 and isinstance(content, bytes):
+      content = content.decode('utf-8')
+    content = content.strip()
+  return (fpath, content)
 
 
 # Get the version file and store it.

--- a/gslib/tests/test_metrics.py
+++ b/gslib/tests/test_metrics.py
@@ -48,6 +48,7 @@ from gslib.tests.testcase.integration_testcase import SkipForS3
 from gslib.tests.util import HAS_S3_CREDS
 from gslib.tests.util import ObjectToURI as suri
 from gslib.tests.util import SetBotoConfigForTest
+from gslib.tests.util import SkipForParFile
 from gslib.tests.util import unittest
 from gslib.third_party.storage_apitools import storage_v1_messages as apitools_messages
 from gslib.thread_message import FileMessage
@@ -139,6 +140,7 @@ class RetryableErrorsQueue(object):
       metrics.LogRetryableError(status_item)
 
 
+@SkipForParFile('Do not try spawning the interpreter nested in the archive.')
 @mock.patch('time.time', new=mock.MagicMock(return_value=0))
 class TestMetricsUnitTests(testcase.GsUtilUnitTestCase):
   """Unit tests for analytics data collection."""
@@ -607,6 +609,7 @@ class _ResumableUploadRetryHandler(object):
       raise self._exception_to_raise(*self._exception_args)
 
 
+@SkipForParFile('Do not try spawning the interpreter nested in the archive.')
 class TestMetricsIntegrationTests(testcase.GsUtilIntegrationTestCase):
   """Integration tests for analytics data collection."""
 

--- a/gslib/tests/util.py
+++ b/gslib/tests/util.py
@@ -632,6 +632,13 @@ def InvokedFromParFile():
   return 'zipimport' in loader.__class__.__module__
 
 
+def SkipForParFile(reason):
+  if InvokedFromParFile():
+    return unittest.skip(reason)
+  else:
+    return lambda func: func
+
+
 # Custom test callbacks must be pickleable, and therefore at global scope.
 class HaltingCopyCallbackHandler(object):
   """Test callback handler for intentionally stopping a resumable transfer."""

--- a/gslib/utils/boto_util.py
+++ b/gslib/utils/boto_util.py
@@ -93,6 +93,7 @@ def ConfigureCertsFile():
         if not certs_data:
           raise CommandException('Certificates file not found. Please '
                                  'reinstall gsutil from scratch')
+        certs_data = six.ensure_str(certs_data)
         fd, fname = tempfile.mkstemp(suffix='.txt', prefix='gsutil-cacerts')
         f = os.fdopen(fd, 'w')
         f.write(certs_data)


### PR DESCRIPTION
Where appropriate, we now transform bytes from pkgutil.get_data into unicode
strings in Python 3 (this fixes issues where checksum and version strings
weren't the expected types - in the .par build, these were bytes (as the
documentation seems to indicate `get_data()` will return), but when run
locally under Python 3, they were unicode; these casts only happen when
the data should be converted to unicode and isn't already unicode).

Also, we now skip the metrics tests when running from a par file, since
the interpreter is nested within the archive (but it's needed to spawn
the metrics subprocess).