### PR TITLE
Ensures we pass correct str type for content type.

### DIFF
--- a/gslib/tests/test_copy_helper_funcs.py
+++ b/gslib/tests/test_copy_helper_funcs.py
@@ -384,7 +384,7 @@ class TestCpFuncs(GsUtilUnitTestCase):
     # The file command should detect HTML in the real file.
     with SetBotoConfigForTest([('GSUtil', 'use_magicfile', 'True')]):
       _SetContentTypeFromFile(src_url_stub, dst_obj_metadata_mock)
-    self.assertEqual(b'text/html; charset=us-ascii',
+    self.assertEqual('text/html; charset=us-ascii',
                      dst_obj_metadata_mock.contentType)
 
     dst_obj_metadata_mock = mock.MagicMock(contentType=None)

--- a/gslib/utils/copy_helper.py
+++ b/gslib/utils/copy_helper.py
@@ -1647,6 +1647,7 @@ def _SetContentTypeFromFile(src_url, dst_obj_metadata):
                 '(returncode=%d).\n%s' % (real_file_path, p.returncode, error))
           # Parse output by removing line delimiter
           content_type = output.rstrip()
+          content_type = six.ensure_str(content_type)
         except OSError as e:  # 'file' executable may not always be present.
           raise CommandException(
               'Encountered OSError running "file -b --mime %s"\n%s' %


### PR DESCRIPTION
Fixes https://issuetracker.google.com/issues/136688879.

This was breaking internal builds where the subprocess that ran
`file` was returning a `bytes` instead of a `str` in stdout.

I was going to fix this in apitools:
https://github.com/google/apitools/pull/278
...but the call-site seems like a more appropriate place to do this.