### PR TITLE
Prefer ensure_text() over explicit decode()

### DIFF
--- a/gslib/commands/ls.py
+++ b/gslib/commands/ls.py
@@ -520,7 +520,7 @@ class LsCommand(Command):
 
     def MaybePrintBucketHeader(blr):
       if len(self.args) > 1:
-        text_util.print_to_fd('%s:' % blr.url_string.decode(UTF8))
+        text_util.print_to_fd('%s:' % six.ensure_text(blr.url_string))
 
     print_bucket_header = MaybePrintBucketHeader
 
@@ -581,7 +581,8 @@ class LsCommand(Command):
         # URL names a bucket, object, or object subdir ->
         # list matching object(s) / subdirs.
         def _PrintPrefixLong(blr):
-          text_util.print_to_fd('%-33s%s' % ('', blr.url_string.decode(UTF8)))
+          text_util.print_to_fd('%-33s%s' %
+                                ('', six.ensure_text(blr.url_string)))
 
         if listing_style == ListingStyle.SHORT:
           # ls helper by default readies us for a short listing.


### PR DESCRIPTION
If a `BucketListingRef`'s url string is already unicode, we shouldn't call
`decode()` on it. The `six.ensure_text()` call will only try to decode the
string-like object if it's a `bytes` type in Python 3, leaving it alone
if it's already `unicode`.

Should fix https://issuetracker.google.com/issues/138223113.