### PR TITLE
Make SkipForXML skip if running tests against S3.

### DIFF
--- a/gslib/boto_translation.py
+++ b/gslib/boto_translation.py
@@ -992,7 +992,8 @@ class BotoTranslation(CloudApi):
                             gzip_encoded=False):
     """See CloudApi class for function doc strings."""
     if gzip_encoded:
-      raise NotImplementedError('XML API does not suport gzip-encoded uploads.')
+      raise NotImplementedError(
+          'XML API does not support gzip-encoded uploads.')
     if self.provider == 's3':
       # Resumable uploads are not supported for s3.
       return self.UploadObject(upload_stream,

--- a/gslib/tests/testcase/integration_testcase.py
+++ b/gslib/tests/testcase/integration_testcase.py
@@ -77,7 +77,8 @@ LOGGER = logging.getLogger('integration-test')
 # TODO: Replace tests which looks for test_api == ApiSelector.(XML|JSON) with
 # these decorators.
 def SkipForXML(reason):
-  if not USING_JSON_API:
+  """Skips the test if running S3 tests, or if prefer_api isn't set to json."""
+  if not USING_JSON_API or RUN_S3_TESTS:
     return unittest.skip(reason)
   else:
     return lambda func: func


### PR DESCRIPTION
This was causing some perfdiag tests to fail, since we were trying to gzip encode a portion of the payload in an API request that didn't support it.