### PR TITLE
Update helptexts before release.

### DIFF
--- a/gslib/commands/acl.py
+++ b/gslib/commands/acl.py
@@ -112,16 +112,16 @@ _SET_DESCRIPTION = """
 <B>SET OPTIONS</B>
   The "set" sub-command has the following options
 
-    -R, -r      Performs "acl set" request recursively, to all objects under
-                the specified URL.
+  -R, -r      Performs "acl set" request recursively, to all objects under
+              the specified URL.
 
-    -a          Performs "acl set" request on all object versions.
+  -a          Performs "acl set" request on all object versions.
 
-    -f          Normally gsutil stops at the first error. The -f option causes
-                it to continue when it encounters errors. If some of the ACLs
-                couldn't be set, gsutil's exit status will be non-zero even if
-                this flag is set. This option is implicitly set when running
-                "gsutil -m acl...".
+  -f          Normally gsutil stops at the first error. The -f option causes
+              it to continue when it encounters errors. If some of the ACLs
+              couldn't be set, gsutil's exit status will be non-zero even if
+              this flag is set. This option is implicitly set when running
+              "gsutil -m acl...".
 """
 
 _CH_DESCRIPTION = """
@@ -260,21 +260,21 @@ _CH_DESCRIPTION = """
 <B>CH OPTIONS</B>
   The "ch" sub-command has the following options
 
-    -d          Remove all roles associated with the matching entity.
+  -d          Remove all roles associated with the matching entity.
 
-    -f          Normally gsutil stops at the first error. The -f option causes
-                it to continue when it encounters errors. With this option the
-                gsutil exit status will be 0 even if some ACLs couldn't be
-                changed.
+  -f          Normally gsutil stops at the first error. The -f option causes
+              it to continue when it encounters errors. With this option the
+              gsutil exit status will be 0 even if some ACLs couldn't be
+              changed.
 
-    -g          Add or modify a group entity's role.
+  -g          Add or modify a group entity's role.
 
-    -p          Add or modify a project viewers/editors/owners role.
+  -p          Add or modify a project viewers/editors/owners role.
 
-    -R, -r      Performs acl ch request recursively, to all objects under the
-                specified URL.
+  -R, -r      Performs acl ch request recursively, to all objects under the
+              specified URL.
 
-    -u          Add or modify a user entity's role.
+  -u          Add or modify a user entity's role.
 """
 
 _SYNOPSIS = (_SET_SYNOPSIS + _GET_SYNOPSIS.lstrip('\n') +

--- a/gslib/commands/bucketpolicyonly.py
+++ b/gslib/commands/bucketpolicyonly.py
@@ -32,7 +32,7 @@ from gslib.utils.constants import NO_MAX
 from gslib.utils.text_util import InsistOnOrOff
 
 _SET_SYNOPSIS = """
-  gsutil bucketpolicyonly set (on|off) bucket_url...
+  gsutil bucketpolicyonly set <on|off> bucket_url...
 """
 
 _GET_SYNOPSIS = """

--- a/gslib/commands/defacl.py
+++ b/gslib/commands/defacl.py
@@ -124,18 +124,18 @@ _CH_DESCRIPTION = """
 <B>CH OPTIONS</B>
   The "ch" sub-command has the following options
 
-    -d          Remove all roles associated with the matching entity.
+  -d          Remove all roles associated with the matching entity.
 
-    -f          Normally gsutil stops at the first error. The -f option causes
-                it to continue when it encounters errors. With this option the
-                gsutil exit status will be 0 even if some ACLs couldn't be
-                changed.
+  -f          Normally gsutil stops at the first error. The -f option causes
+              it to continue when it encounters errors. With this option the
+              gsutil exit status will be 0 even if some ACLs couldn't be
+              changed.
 
-    -g          Add or modify a group entity's role.
+  -g          Add or modify a group entity's role.
 
-    -p          Add or modify a project viewers/editors/owners role.
+  -p          Add or modify a project viewers/editors/owners role.
 
-    -u          Add or modify a user entity's role.
+  -u          Add or modify a user entity's role.
 """
 
 _SYNOPSIS = (_SET_SYNOPSIS + _GET_SYNOPSIS.lstrip('\n') +

--- a/gslib/commands/hmac.py
+++ b/gslib/commands/hmac.py
@@ -57,40 +57,47 @@ _UPDATE_SYNOPSIS = """
 _CREATE_DESCRIPTION = """
 <B>CREATE</B>
   The ``hmac create`` command creates an HMAC key for the specified service
-  account. The secret key material is only available upon creation, so be sure
-  to store the returned secret along with the access_id.
+  account:
 
     gsutil hmac create test.service.account@test_project.iam.gserviceaccount.com
+
+  The secret key material is only available upon creation, so be sure to store
+  the returned secret along with the access_id.
+
 <B>CREATE OPTIONS</B>
   The "create" sub-command has the following option
 
-      -p <project_id>             Specify a project in which to create a key.
+  -p <project_id>             Specify a project in which to create a key.
 """
 
 _DELETE_DESCRIPTION = """
 <B>DELETE</B>
-  The ``hmac delete`` command permanently deletes the specified HMAC key.
+  The ``hmac delete`` command permanently deletes the specified HMAC key:
+
+    gsutil hmac delete GOOG56JBMFZX6PMPTQ62VD2
+
   Note that keys must be updated to be in the INACTIVE state before they can be
   deleted.
 
-    gsutil hmac delete GOOG56JBMFZX6PMPTQ62VD2
 <B>DELETE OPTIONS</B>
   The "delete" sub-command has the following option
 
-      -p <project_id>             Specify a project from which to delete a key.
+  -p <project_id>             Specify a project from which to delete a key.
 """
 
 _GET_DESCRIPTION = """
 <B>GET</B>
-  The ``hmac get`` command retrieves the specified HMAC key's metadata.
+  The ``hmac get`` command retrieves the specified HMAC key's metadata:
+
+    gsutil hmac get GOOG56JBMFZX6PMPTQ62VD2
+
   Note that there is no option to retrieve a key's secret material after it has
   been created.
 
-    gsutil hmac get GOOG56JBMFZX6PMPTQ62VD2
 <B>GET OPTIONS</B>
   The "get" sub-command has the following option
 
-      -p <project_id>             Specify a project from which to get a key.
+  -p <project_id>             Specify a project from which to get a key.
 """
 
 _LIST_DESCRIPTION = """
@@ -102,36 +109,38 @@ _LIST_DESCRIPTION = """
 <B>LIST OPTIONS</B>
   The "list" sub-command has the following options
 
-      -a                          Show all keys, including recently deleted
-                                  keys.
+  -a                          Show all keys, including recently deleted
+                              keys.
 
-      -l                          Use long listing format. Shows each key's full
-                                  metadata excluding the secret.
+  -l                          Use long listing format. Shows each key's full
+                              metadata excluding the secret.
 
-      -p <project_id>             Specify a project from which to list keys.
+  -p <project_id>             Specify a project from which to list keys.
 
-      -u <service_account_email>  Filter keys for a single service account.
+  -u <service_account_email>  Filter keys for a single service account.
 """
 _UPDATE_DESCRIPTION = """
 <B>UPDATE</B>
-  The ``hmac update`` command sets the state of the specified key.
+  The ``hmac update`` command sets the state of the specified key:
+
+    gsutil hmac update -s INACTIVE -e M42da= GOOG56JBMFZX6PMPTQ62VD2
+
   Valid state arguments are ACTIVE and INACTIVE. To set a key to state DELETED
   use the "hmac delete" command on an INACTIVE key. If an etag is set in the
   command, it will only succeed if the provided etag matches the etag of the
   stored key.
 
-    gsutil hmac update -s INACTIVE -e M42da= GOOG56JBMFZX6PMPTQ62VD2
 <B>UPDATE OPTIONS</B>
   The "update" sub-command has the following options
 
-      -s (ACTIVE|INACTIVE)        Sets the state of the specified key to either
-                                  ACTIVE or INACTIVE.
+  -s <ACTIVE|INACTIVE>        Sets the state of the specified key to either
+                              ACTIVE or INACTIVE.
 
-      -e <etag>                   If provided, the update will only be performed
-                                  if the specified etag matches the etag of the
-                                  stored key.
+  -e <etag>                   If provided, the update will only be performed
+                              if the specified etag matches the etag of the
+                              stored key.
 
-      -p <project_id>             Specify a project in which to update a key.
+  -p <project_id>             Specify a project in which to update a key.
 """
 
 _SYNOPSIS = (_CREATE_SYNOPSIS + _DELETE_SYNOPSIS.lstrip('\n') +

--- a/gslib/commands/hmac.py
+++ b/gslib/commands/hmac.py
@@ -51,7 +51,7 @@ _LIST_SYNOPSIS = """
 """
 
 _UPDATE_SYNOPSIS = """
-  gsutil hmac update -s (ACTIVE|INACTIVE) [-e etag] [-p project] access_id
+  gsutil hmac update -s <ACTIVE|INACTIVE> [-e etag] [-p project] access_id
 """
 
 _CREATE_DESCRIPTION = """

--- a/gslib/commands/iam.py
+++ b/gslib/commands/iam.py
@@ -129,17 +129,17 @@ _SET_DESCRIPTION = """
 <B>SET OPTIONS</B>
   The ``set`` sub-command has the following options
 
-    -R, -r      Performs ``iam set`` recursively to all objects under the
-                specified bucket.
+  -R, -r      Performs ``iam set`` recursively to all objects under the
+              specified bucket.
 
-    -a          Performs ``iam set`` request on all object versions.
+  -a          Performs ``iam set`` request on all object versions.
 
-    -e <etag>   Performs the precondition check on each object with the
-                specified etag before setting the policy.
+  -e <etag>   Performs the precondition check on each object with the
+              specified etag before setting the policy.
 
-    -f          Default gsutil error handling is fail-fast. This flag
-                changes the request to fail-silent mode. This is implicitly
-                set when invoking the gsutil -m option.
+  -f          Default gsutil error handling is fail-fast. This flag
+              changes the request to fail-silent mode. This is implicitly
+              set when invoking the gsutil -m option.
 """
 
 _CH_DESCRIPTION = """
@@ -198,12 +198,12 @@ _CH_DESCRIPTION = """
 <B>CH OPTIONS</B>
   The ``ch`` sub-command has the following options
 
-    -R, -r      Performs ``iam ch`` recursively to all objects under the
-                specified bucket.
+  -R, -r      Performs ``iam ch`` recursively to all objects under the
+              specified bucket.
 
-    -f          Default gsutil error handling is fail-fast. This flag
-                changes the request to fail-silent mode. This is implicitly
-                set when invoking the gsutil -m option.
+  -f          Default gsutil error handling is fail-fast. This flag
+              changes the request to fail-silent mode. This is implicitly
+              set when invoking the gsutil -m option.
 """
 
 _SYNOPSIS = (_SET_SYNOPSIS + _GET_SYNOPSIS.lstrip('\n') +

--- a/gslib/commands/label.py
+++ b/gslib/commands/label.py
@@ -109,9 +109,9 @@ _CH_DESCRIPTION = """
 <B>CH OPTIONS</B>
   The "ch" sub-command has the following options
 
-    -l          Add or update a label with the specified key and value.
+  -l          Add or update a label with the specified key and value.
 
-    -d          Remove the label with the specified key.
+  -d          Remove the label with the specified key.
 """
 
 _SYNOPSIS = (_SET_SYNOPSIS + _GET_SYNOPSIS.lstrip('\n') +


### PR DESCRIPTION
This fixes the formatting so that options tables are displayed correctly
(without leading and trailing rows) and indents commands so that they're
rendered as `<pre>` divs in the generated docs.