### PR TITLE
Fix crash when showing help in a pager on Python 3. (#877)

### DIFF
--- a/gslib/commands/help.py
+++ b/gslib/commands/help.py
@@ -198,7 +198,7 @@ class HelpCommand(Command):
       if pager[0].endswith('less'):
         pager.append('-r')
       try:
-        Popen(pager, stdin=PIPE).communicate(input=help_str)
+        Popen(pager, stdin=PIPE, universal_newlines=True).communicate(input=help_str)
       except OSError as e:
         raise CommandException('Unable to open pager (%s): %s' %
                                (' '.join(pager), e))


### PR DESCRIPTION
Testing done: gsutil test -u