### PR TITLE
Edit link to cloud.google.com page

### DIFF
--- a/gslib/commands/hmac.py
+++ b/gslib/commands/hmac.py
@@ -149,7 +149,7 @@ _SYNOPSIS = (_CREATE_SYNOPSIS + _DELETE_SYNOPSIS.lstrip('\n') +
 
 _DESCRIPTION = """
   The hmac command is used to interact with service account `HMAC keys
-  <cloud.google.com/storage/docs/authentication/hmackeys>`_.
+  <https://cloud.google.com/storage/docs/authentication/hmackeys>`_.
 
   The hmac command has five sub-commands:
 """ + '\n'.join([


### PR DESCRIPTION
The current format creates a broken link when this file is generated in the cloud.google.com documentation (see the first link at https://cloud.google.com/storage/docs/gsutil/commands/hmac).

Prepending the link with https:// is consistent with other gsutil files and should prevent link breakage on cloud.google.com