### PR TITLE
Support for socks proxy added

### DIFF
--- a/gslib/commands/config.py
+++ b/gslib/commands/config.py
@@ -912,7 +912,7 @@ class ConfigCommand(Command):
                                         'proxy host')
     self._WriteConfigLineMaybeCommented(
         config_file, 'proxy_type', config.get_value('Boto', 'proxy_type', None),
-        'proxy type')
+        'proxy type (socks4, socks5, http)')
     self._WriteConfigLineMaybeCommented(
         config_file, 'proxy_port', config.get_value('Boto', 'proxy_port', None),
         'proxy port')

--- a/gslib/commands/config.py
+++ b/gslib/commands/config.py
@@ -556,7 +556,7 @@ CONFIG_INPUTLESS_GSUTIL_SECTION_CONTENT = """
 # (e.g., "2G" to represent 2 gibibytes)
 #max_upload_compression_buffer_size = %(max_upload_compression_buffer_size)s
 
-# GZIP compression level, if using compression. Reducing this can have 
+# GZIP compression level, if using compression. Reducing this can have
 # a dramatic impact on compression speed with minor size increases.
 # This is a value from 0-9, with 9 being max compression.
 # A good level to try is 6, which is the default used by the gzip tool.
@@ -864,7 +864,7 @@ class ConfigCommand(Command):
     self._PromptForProxyConfigVarAndMaybeSaveToBotoConfig(
         'proxy_rdns',
         'Should DNS lookups be resolved by your proxy? (Y if your site '
-        'disallows client DNS lookups)? ',
+        'disallows client DNS lookups; NOT supported for socks)? ',
         convert_to_bool=True)
 
   def _WriteConfigLineMaybeCommented(self, config_file, name, value, desc):
@@ -912,7 +912,7 @@ class ConfigCommand(Command):
                                         'proxy host')
     self._WriteConfigLineMaybeCommented(
         config_file, 'proxy_type', config.get_value('Boto', 'proxy_type', None),
-        'proxy type (socks4, socks5, http)')
+        'proxy type (socks4, socks5, http) | Defaults to http')
     self._WriteConfigLineMaybeCommented(
         config_file, 'proxy_port', config.get_value('Boto', 'proxy_port', None),
         'proxy port')
@@ -925,7 +925,7 @@ class ConfigCommand(Command):
     self._WriteConfigLineMaybeCommented(
         config_file, 'proxy_rdns', config.get_value('Boto', 'proxy_rdns',
                                                     False),
-        'let proxy server perform DNS lookups')
+        'let proxy server perform DNS lookups; Not supported for socks proxy types')
 
   # pylint: disable=dangerous-default-value,too-many-statements
   def _WriteBotoConfigFile(self,

--- a/gslib/commands/config.py
+++ b/gslib/commands/config.py
@@ -925,7 +925,7 @@ class ConfigCommand(Command):
     self._WriteConfigLineMaybeCommented(
         config_file, 'proxy_rdns', config.get_value('Boto', 'proxy_rdns',
                                                     False),
-        'let proxy server perform DNS lookups; Not supported for socks proxy types')
+        'let proxy server perform DNS lookups; socks proxy not supported')
 
   # pylint: disable=dangerous-default-value,too-many-statements
   def _WriteBotoConfigFile(self,

--- a/gslib/commands/config.py
+++ b/gslib/commands/config.py
@@ -217,6 +217,7 @@ _DETAILED_HELP_TEXT = ("""
 
     [Boto]
       proxy
+      proxy_type
       proxy_port
       proxy_user
       proxy_pass
@@ -853,6 +854,8 @@ class ConfigCommand(Command):
     self._PromptForProxyConfigVarAndMaybeSaveToBotoConfig(
         'proxy', 'What is your proxy host? ')
     self._PromptForProxyConfigVarAndMaybeSaveToBotoConfig(
+        'proxy_type', 'What is your proxy type (socks4, socks5, http)? ')
+    self._PromptForProxyConfigVarAndMaybeSaveToBotoConfig(
         'proxy_port', 'What is your proxy port? ')
     self._PromptForProxyConfigVarAndMaybeSaveToBotoConfig(
         'proxy_user', 'What is your proxy user (leave blank if not used)? ')
@@ -907,6 +910,9 @@ class ConfigCommand(Command):
     self._WriteConfigLineMaybeCommented(config_file, 'proxy',
                                         config.get_value('Boto', 'proxy', None),
                                         'proxy host')
+    self._WriteConfigLineMaybeCommented(
+        config_file, 'proxy_type', config.get_value('Boto', 'proxy_type', None),
+        'proxy type')
     self._WriteConfigLineMaybeCommented(
         config_file, 'proxy_port', config.get_value('Boto', 'proxy_port', None),
         'proxy port')

--- a/gslib/utils/boto_util.py
+++ b/gslib/utils/boto_util.py
@@ -495,21 +495,25 @@ def SetProxyInfo():
   """
   #Defining proxy_type based on httplib2 library, accounting for None entry too.
   proxy_type_spec = {'socks4':1,'socks5':2,'http':3,'https':3}
-  
+
   #proxy_type defaults to 'http (3)' for backwards compatibility
   proxy_type = proxy_type_spec.get(config.get('Boto', 'proxy_type', None)) or 3
   proxy_host = config.get('Boto', 'proxy', None)
-  
-  #For proxy_info below, proxy_rdns fails for socks4 and socks5 so restricting use 
+
+  #For proxy_info below, proxy_rdns fails for socks4 and socks5 so restricting use
   #to http only
-  proxy_info = httplib2.ProxyInfo(    
+  proxy_info = httplib2.ProxyInfo(
       proxy_host=proxy_host,
-      proxy_type=proxy_type, 
+      proxy_type=proxy_type,
       proxy_port=config.getint('Boto', 'proxy_port', 0),
       proxy_user=config.get('Boto', 'proxy_user', None),
       proxy_pass=config.get('Boto', 'proxy_pass', None),
       proxy_rdns=config.getbool('Boto', 'proxy_rdns',
                             True if proxy_type==3 else False))
+
+  #Added to force socks proxies not to use rdns
+  if not (proxy_info.proxy_type == 3):
+      proxy_info.proxy_rdns = False
 
   if not (proxy_info.proxy_host and proxy_info.proxy_port):
     # Fall back to using the environment variable. Use only http proxies

--- a/gslib/utils/boto_util.py
+++ b/gslib/utils/boto_util.py
@@ -485,7 +485,7 @@ def ResumableThreshold():
   return config.getint('GSUtil', 'resumable_threshold', 8 * ONE_MIB)
 
 def SetProxyInfo():
-    """Sets proxy info from boto and environment and converts to httplib2.ProxyInfo.
+  """Sets proxy info from boto and environment and converts to httplib2.ProxyInfo.
 
   Args:
     None.

--- a/gslib/utils/boto_util.py
+++ b/gslib/utils/boto_util.py
@@ -508,7 +508,7 @@ def SetProxyInfo():
       proxy_port=config.getint('Boto', 'proxy_port', 0),
       proxy_user=config.get('Boto', 'proxy_user', None),
       proxy_pass=config.get('Boto', 'proxy_pass', None),
-      proxy_rdns=config.get('Boto', 'proxy_rdns',
+      proxy_rdns=config.getbool('Boto', 'proxy_rdns',
                             True if proxy_type==3 else False))
 
   if not (proxy_info.proxy_host and proxy_info.proxy_port):
@@ -517,7 +517,7 @@ def SetProxyInfo():
       if proxy_env_var in os.environ and os.environ[proxy_env_var]:
         proxy_info = ProxyInfoFromEnvironmentVar(proxy_env_var)
         # Assume proxy_rnds is True if a proxy environment variable exists.
-        proxy_info.proxy_rdns = config.get('Boto', 'proxy_rdns', True)
+        proxy_info.proxy_rdns = config.getbool('Boto', 'proxy_rdns', True)
         break
 
   return proxy_info

--- a/gslib/utils/boto_util.py
+++ b/gslib/utils/boto_util.py
@@ -484,6 +484,7 @@ def ProxyInfoFromEnvironmentVar(proxy_env_var):
 def ResumableThreshold():
   return config.getint('GSUtil', 'resumable_threshold', 8 * ONE_MIB)
 
+
 def SetProxyInfo():
   """Sets proxy info from boto and environment and converts to httplib2.ProxyInfo.
 
@@ -494,7 +495,7 @@ def SetProxyInfo():
     httplib2.ProxyInfo constructed from boto or environment variable string.
   """
   #Defining proxy_type based on httplib2 library, accounting for None entry too.
-  proxy_type_spec = {'socks4':1,'socks5':2,'http':3,'https':3}
+  proxy_type_spec = {'socks4': 1, 'socks5': 2, 'http': 3, 'https': 3}
 
   #proxy_type defaults to 'http (3)' for backwards compatibility
   proxy_type = proxy_type_spec.get(config.get('Boto', 'proxy_type', None)) or 3
@@ -509,14 +510,14 @@ def SetProxyInfo():
       proxy_user=config.get('Boto', 'proxy_user', None),
       proxy_pass=config.get('Boto', 'proxy_pass', None),
       proxy_rdns=config.getbool('Boto', 'proxy_rdns',
-                            True if proxy_type==3 else False))
+                                True if proxy_type == 3 else False))
 
   #Added to force socks proxies not to use rdns
   if not (proxy_info.proxy_type == 3):
-      proxy_info.proxy_rdns = False
+    proxy_info.proxy_rdns = False
 
   if not (proxy_info.proxy_host and proxy_info.proxy_port):
-    # Fall back to using the environment variable. Use only http proxies
+    # Fall back to using the environment variable. Use only http proxies.
     for proxy_env_var in ['http_proxy', 'https_proxy', 'HTTPS_PROXY']:
       if proxy_env_var in os.environ and os.environ[proxy_env_var]:
         proxy_info = ProxyInfoFromEnvironmentVar(proxy_env_var)
@@ -525,6 +526,7 @@ def SetProxyInfo():
         break
 
   return proxy_info
+
 
 def UsingCrcmodExtension():
   boto_opt = boto.config.get('GSUtil', 'test_assume_fast_crcmod', None)

--- a/gslib/utils/boto_util.py
+++ b/gslib/utils/boto_util.py
@@ -496,9 +496,10 @@ def SetProxyInfo():
   """
   #Defining proxy_type based on httplib2 library, accounting for None entry too.
   proxy_type_spec = {'socks4': 1, 'socks5': 2, 'http': 3, 'https': 3}
+  boto_proxy_val = config.get('Boto', 'proxy_type', None)
 
   #proxy_type defaults to 'http (3)' for backwards compatibility
-  proxy_type = proxy_type_spec.get(config.get('Boto', 'proxy_type', None)) or 3
+  proxy_type = proxy_type_spec.get(boto_proxy_val) or proxy_type_spec['http']
   proxy_host = config.get('Boto', 'proxy', None)
 
   #For proxy_info below, proxy_rdns fails for socks4 and socks5 so restricting use
@@ -509,11 +510,12 @@ def SetProxyInfo():
       proxy_port=config.getint('Boto', 'proxy_port', 0),
       proxy_user=config.get('Boto', 'proxy_user', None),
       proxy_pass=config.get('Boto', 'proxy_pass', None),
-      proxy_rdns=config.getbool('Boto', 'proxy_rdns',
-                                True if proxy_type == 3 else False))
+      proxy_rdns=config.getbool(
+          'Boto', 'proxy_rdns',
+          True if proxy_type == proxy_type_spec['http'] else False))
 
   #Added to force socks proxies not to use rdns
-  if not (proxy_info.proxy_type == 3):
+  if not (proxy_info.proxy_type == proxy_type_spec['http']):
     proxy_info.proxy_rdns = False
 
   if not (proxy_info.proxy_host and proxy_info.proxy_port):


### PR DESCRIPTION
The summary of changes made are listed below:

- Created a new Boto proxy variable proxy_type, where end users can specify one of (socks4, sock5 or http) proxy
- For backwards compatibility, proxy type configuration still defaults to http when proxy_type is not set.
- Created a new function SetProxyInfo() and moved proxy setting code from GetNewHttp(http_class=httplib2.Http, **kwargs) to the new function. Makes for a cleaner code.
- Third party library was throwing exceptions when rdns was enabled for socks proxy, so I limited rdns support to http/https proxies.
- For environment variables, only http/https is supported, pretty much did not to touch that part of the code.
- 

Fixes the following issue: gsutil socks proxy support needed #881