### PR TITLE
Only run yapf on one Python 3 version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,6 @@ install:
 script:
   - gsutil version -l
   - gsutil test -u
-  - yapf -dr .
+  - if [[ "$TRAVIS_PYTHON_VERSION" =~ 3.6 ]]; then yapf -dr . ; fi
   - test/run_pylint.sh
 


### PR DESCRIPTION
Yapf preferences differ between Python 2.7 and 3.X, resulting in it
sometimes being impossible for a presubmit to pass if yapf is run on both.