### PR TITLE
improve error messaging around the help text monitor

### DIFF
--- a/gslib/help_provider.py
+++ b/gslib/help_provider.py
@@ -68,14 +68,28 @@ class HelpProvider(object):
 def SanityCheck(help_provider, help_name_map):
   """Helper for checking that a HelpProvider has minimally adequate content."""
   # Sanity check the content.
-  assert (len(help_provider.help_spec.help_name) > 1 and
-          len(help_provider.help_spec.help_name) < MAX_HELP_NAME_LEN)
+  help_name_len = len(help_provider.help_spec.help_name)
+  assert (help_name_len > 1 and help_name_len < MAX_HELP_NAME_LEN
+         ), 'The help name "{text}" must be less then {max}'.format(
+             text=help_provider.help_spec.help_name, max=MAX_HELP_NAME_LEN)
   for hna in help_provider.help_spec.help_name_aliases:
     assert hna
   one_line_summary_len = len(help_provider.help_spec.help_one_line_summary)
-  assert (one_line_summary_len > MIN_ONE_LINE_SUMMARY_LEN and
-          one_line_summary_len < MAX_ONE_LINE_SUMMARY_LEN)
-  assert len(help_provider.help_spec.help_text) > 10
+  assert (one_line_summary_len >= MIN_ONE_LINE_SUMMARY_LEN), (
+      'The one line summary "{text}" with a length of {length} must be ' +
+      'more then {min} characters').format(
+          text=help_provider.help_spec.help_one_line_summary,
+          length=one_line_summary_len,
+          min=MIN_ONE_LINE_SUMMARY_LEN)
+  assert (one_line_summary_len <= MAX_ONE_LINE_SUMMARY_LEN), (
+      'The one line summary "{text}" with a length of {length} must be ' +
+      'less then {max} characters').format(
+          text=help_provider.help_spec.help_one_line_summary,
+          length=one_line_summary_len,
+          max=MAX_ONE_LINE_SUMMARY_LEN)
+  assert len(help_provider.help_spec.help_text
+            ) > 10, 'The length of "{text}" must be less then 10'.format(
+                text=help_provider.help_spec.help_text)
 
   # Ensure there are no dupe help names or aliases across commands.
   name_check_list = [help_provider.help_spec.help_name]


### PR DESCRIPTION
While working on adding additional features, I noticed lacking information in the formatting errors thrown by the help_provider. This will provide more context and details when a contributor runs into these errors.