### PR TITLE
Add -w flag to kms encryption

### DIFF
--- a/gslib/commands/kms.py
+++ b/gslib/commands/kms.py
@@ -20,9 +20,11 @@ from __future__ import division
 from __future__ import unicode_literals
 
 import getopt
+import sys
 import textwrap
 
 from gslib import metrics
+from gslib.cloud_api import AccessDeniedException
 from gslib.command import Command
 from gslib.command_argument import CommandArgument
 from gslib.cs_api_map import ApiSelector
@@ -41,7 +43,7 @@ _AUTHORIZE_SYNOPSIS = """
 """
 
 _ENCRYPTION_SYNOPSIS = """
-  gsutil kms encryption [(-d|[-k kms_key])] bucket_url...
+  gsutil kms encryption [(-d|[-k kms_key])] [-w] bucket_url...
 """
 
 _SERVICEACCOUNT_SYNOPSIS = """
@@ -83,6 +85,17 @@ _ENCRYPTION_DESCRIPTION = """
 
     gsutil kms encryption \\
         -k projects/key-project/locations/us-east1/keyRings/key-ring/cryptoKeys/my-key \\
+        gs://my-bucket
+
+  Set the default KMS key for my-bucket, but display a warning rather than failing if 
+  gsutil is unable to verify that the specified key contains the correct IAM bindings 
+  for encryption/decryption. This is useful for users that do not have getIamPolicy
+  permission but know that the key has the correct IAM policy for encryption in the  
+  user's project.
+
+    gsutil kms encryption \\
+        -k projects/key-project/locations/us-east1/keyRings/key-ring/cryptoKeys/my-key \\
+        -w \\
         gs://my-bucket
 
   Show the default KMS key for my-bucket, if one is set:
@@ -138,7 +151,7 @@ class KmsCommand(Command):
       usage_synopsis=_SYNOPSIS,
       min_args=1,
       max_args=NO_MAX,
-      supported_sub_args='dk:p:',
+      supported_sub_args='dk:p:w',
       file_url_ok=False,
       provider_url_ok=False,
       urls_start_arg=1,
@@ -163,10 +176,14 @@ class KmsCommand(Command):
       },
   )
 
-  def _GatherSubOptions(self):
+  def _GatherSubOptions(self, subcommand_name):
     self.CheckArguments()
     self.clear_kms_key = False
     self.kms_key = None
+    self.warn_on_key_authorize_failure = False
+
+    print(self.args)
+    print(self.sub_opts)
 
     if self.sub_opts:
       for o, a in self.sub_opts:
@@ -177,6 +194,15 @@ class KmsCommand(Command):
           ValidateCMEK(self.kms_key)
         elif o == '-d':
           self.clear_kms_key = True
+        elif o == '-w':
+          self.warn_on_key_authorize_failure = True
+
+    if self.warn_on_key_authorize_failure and (
+        self.subcommand_name != 'encryption' or not self.kms_key):
+      raise CommandException('\n'.join(
+          textwrap.wrap(
+              'The "-w" option should only be specified for the "encryption" '
+              'subcommand and must be used with the "-k" option.')))
     # Determine the project (used in the serviceaccount and authorize
     # subcommands), either from the "-p" option's value or the default specified
     # in the user's Boto config file.
@@ -208,22 +234,36 @@ class KmsCommand(Command):
 
     kms_api = KmsApi(logger=self.logger)
     self.logger.debug('Getting IAM policy for %s', kms_key)
-    policy = kms_api.GetKeyIamPolicy(kms_key)
-    self.logger.debug('Current policy is %s', policy)
+    try:
+      policy = kms_api.GetKeyIamPolicy(kms_key)
+      self.logger.debug('Current policy is %s', policy)
 
-    # Check if the required binding is already present; if not, add it and
-    # update the key's IAM policy.
-    added_new_binding = False
-    binding = Binding(role='roles/cloudkms.cryptoKeyEncrypterDecrypter',
-                      members=['serviceAccount:%s' % service_account])
-    if binding not in policy.bindings:
-      policy.bindings.append(binding)
-      kms_api.SetKeyIamPolicy(kms_key, policy)
-      added_new_binding = True
-    return (service_account, added_new_binding)
+      # Check if the required binding is already present; if not, add it and
+      # update the key's IAM policy.
+      added_new_binding = False
+      binding = Binding(role='roles/cloudkms.cryptoKeyEncrypterDecrypter',
+                        members=['serviceAccount:%s' % service_account])
+      if binding not in policy.bindings:
+        policy.bindings.append(binding)
+        kms_api.SetKeyIamPolicy(kms_key, policy)
+        added_new_binding = True
+      return (service_account, added_new_binding)
+    except AccessDeniedException as e:
+      if self.warn_on_key_authorize_failure:
+        print('\n'.join(
+            textwrap.wrap(
+                'Warning: Unable to check the IAM policy for the specified '
+                'encryption key. Check that your Cloud Platform project\'s '
+                'service account has the "cloudkms.cryptoKeyEncrypterDecrypter" '
+                'role for the specified key. Without this role, you may not be '
+                'able to encrypt or decrypt objects using the key which will '
+                'prevent you from uploading or downloading objects.')))
+        return (service_account, False)
+      else:
+        raise
 
   def _Authorize(self):
-    self._GatherSubOptions()
+    self._GatherSubOptions('authorize')
     if not self.kms_key:
       raise CommandException('%s %s requires a key to be specified with -k' %
                              (self.command_name, self.subcommand_name))
@@ -263,6 +303,7 @@ class KmsCommand(Command):
           their corresponding service account.
     """
     bucket_project_number = bucket_metadata.projectNumber
+
     try:
       # newly_authorized will always be False if the project number is in our
       # cache dict, since we've already called _AuthorizeProject on it.
@@ -286,7 +327,7 @@ class KmsCommand(Command):
                                 provider=bucket_url.scheme)
 
   def _Encryption(self):
-    self._GatherSubOptions()
+    self._GatherSubOptions('encryption')
     # For each project, we should only make one API call to look up its
     # associated Cloud Storage-owned service account; subsequent lookups can be
     # pulled from this cache dict.

--- a/gslib/commands/kms.py
+++ b/gslib/commands/kms.py
@@ -250,9 +250,10 @@ class KmsCommand(Command):
             textwrap.wrap(
                 'Warning: Unable to check the IAM policy for the specified '
                 'encryption key. Check that your Cloud Platform project\'s '
-                'service account has the "cloudkms.cryptoKeyEncrypterDecrypter" '
-                'role for the specified key. Without this role, you may not be '
-                'able to encrypt or decrypt objects using the key which will '
+                'service account has the '
+                '"cloudkms.cryptoKeyEncrypterDecrypter" role for the '
+                'specified key. Without this role, you may not be able to '
+                'encrypt or decrypt objects using the key which will '
                 'prevent you from uploading or downloading objects.')))
         return (service_account, False)
       else:

--- a/gslib/commands/kms.py
+++ b/gslib/commands/kms.py
@@ -20,7 +20,6 @@ from __future__ import division
 from __future__ import unicode_literals
 
 import getopt
-import sys
 import textwrap
 
 from gslib import metrics
@@ -182,9 +181,6 @@ class KmsCommand(Command):
     self.kms_key = None
     self.warn_on_key_authorize_failure = False
 
-    print(self.args)
-    print(self.sub_opts)
-
     if self.sub_opts:
       for o, a in self.sub_opts:
         if o == '-p':
@@ -248,7 +244,7 @@ class KmsCommand(Command):
         kms_api.SetKeyIamPolicy(kms_key, policy)
         added_new_binding = True
       return (service_account, added_new_binding)
-    except AccessDeniedException as e:
+    except AccessDeniedException:
       if self.warn_on_key_authorize_failure:
         print('\n'.join(
             textwrap.wrap(
@@ -303,7 +299,6 @@ class KmsCommand(Command):
           their corresponding service account.
     """
     bucket_project_number = bucket_metadata.projectNumber
-
     try:
       # newly_authorized will always be False if the project number is in our
       # cache dict, since we've already called _AuthorizeProject on it.

--- a/gslib/commands/kms.py
+++ b/gslib/commands/kms.py
@@ -34,6 +34,7 @@ from gslib.kms_api import KmsApi
 from gslib.project_id import PopulateProjectId
 from gslib.third_party.kms_apitools.cloudkms_v1_messages import Binding
 from gslib.third_party.storage_apitools import storage_v1_messages as apitools_messages
+from gslib.utils import text_util
 from gslib.utils.constants import NO_MAX
 from gslib.utils.encryption_helper import ValidateCMEK
 
@@ -246,7 +247,7 @@ class KmsCommand(Command):
       return (service_account, added_new_binding)
     except AccessDeniedException:
       if self.warn_on_key_authorize_failure:
-        print('\n'.join(
+        text_util.print_to_fd('\n'.join(
             textwrap.wrap(
                 'Warning: Unable to check the IAM policy for the specified '
                 'encryption key. Check that your Cloud Platform project\'s '
@@ -310,12 +311,12 @@ class KmsCommand(Command):
           bucket_project_number, self.kms_key)
       svc_acct_for_project_num[bucket_project_number] = service_account
     if newly_authorized:
-      print('Authorized service account %s to use key:\n%s' %
+      text_util.print_to_fd('Authorized service account %s to use key:\n%s' %
             (service_account, self.kms_key))
 
     bucket_metadata.encryption = apitools_messages.Bucket.EncryptionValue(
         defaultKmsKeyName=self.kms_key)
-    print('Setting default KMS key for bucket %s...' %
+    text_util.print_to_fd('Setting default KMS key for bucket %s...' %
           str(bucket_url).rstrip('/'))
     self.gsutil_api.PatchBucket(bucket_url.bucket_name,
                                 bucket_metadata,

--- a/gslib/commands/kms.py
+++ b/gslib/commands/kms.py
@@ -312,12 +312,12 @@ class KmsCommand(Command):
       svc_acct_for_project_num[bucket_project_number] = service_account
     if newly_authorized:
       text_util.print_to_fd('Authorized service account %s to use key:\n%s' %
-            (service_account, self.kms_key))
+                            (service_account, self.kms_key))
 
     bucket_metadata.encryption = apitools_messages.Bucket.EncryptionValue(
         defaultKmsKeyName=self.kms_key)
     text_util.print_to_fd('Setting default KMS key for bucket %s...' %
-          str(bucket_url).rstrip('/'))
+                          str(bucket_url).rstrip('/'))
     self.gsutil_api.PatchBucket(bucket_url.bucket_name,
                                 bucket_metadata,
                                 fields=['encryption'],

--- a/gslib/tests/mock_cloud_api.py
+++ b/gslib/tests/mock_cloud_api.py
@@ -66,6 +66,8 @@ class MockObject(object):
 class MockBucket(object):
   """Defines a mock cloud storage provider bucket."""
 
+  get_tags = return []
+
   def __init__(self, bucket_name, versioned=False):
     self.root_object = apitools_messages.Bucket(
         name=bucket_name,

--- a/gslib/tests/mock_cloud_api.py
+++ b/gslib/tests/mock_cloud_api.py
@@ -66,8 +66,6 @@ class MockObject(object):
 class MockBucket(object):
   """Defines a mock cloud storage provider bucket."""
 
-  get_tags = return []
-
   def __init__(self, bucket_name, versioned=False):
     self.root_object = apitools_messages.Bucket(
         name=bucket_name,

--- a/gslib/tests/test_kms.py
+++ b/gslib/tests/test_kms.py
@@ -207,8 +207,7 @@ class TestKmsUnitTests(testcase.GsUtilUnitTestCase):
         'kms', ['encryption', '-k', self.dummy_keyname,
                 suri(bucket_uri)],
         return_stdout=True)
-    self.assertIn(
-        b'Setting default KMS key for bucket %s...' % suri(bucket_uri), stdout)
+    self.assertIn(b'Setting default KMS key for bucket', stdout)
 
   @mock.patch('gslib.boto_translation.CloudApi.GetProjectServiceAccount')
   @mock.patch('gslib.boto_translation.CloudApi.PatchBucket')
@@ -226,8 +225,7 @@ class TestKmsUnitTests(testcase.GsUtilUnitTestCase):
         'kms', ['encryption', '-k', self.dummy_keyname, '-w',
                 suri(bucket_uri)],
         return_stdout=True)
-    self.assertIn(
-        b'Setting default KMS key for bucket %s...' % suri(bucket_uri), stdout)
+    self.assertIn(b'Setting default KMS key for bucket', stdout)
 
   @mock.patch('gslib.boto_translation.CloudApi.GetProjectServiceAccount')
   @mock.patch('gslib.boto_translation.CloudApi.PatchBucket')

--- a/gslib/tests/test_kms.py
+++ b/gslib/tests/test_kms.py
@@ -20,8 +20,10 @@ from __future__ import division
 from __future__ import unicode_literals
 
 from random import randint
+import mock
 import unittest
 
+from gslib.cloud_api import AccessDeniedException
 from gslib.project_id import PopulateProjectId
 import gslib.tests.testcase as testcase
 from gslib.tests.testcase.integration_testcase import SkipForJSON
@@ -182,3 +184,68 @@ class TestKmsSubcommandsFailWhenXmlForced(testcase.GsUtilIntegrationTestCase):
   def testAuthorizeFailsWhenXmlForcedFromHmacInBotoConfig(self):
     self.DoTestSubcommandFailsWhenXmlForcedFromHmacInBotoConfig(
         ['kms', 'authorize', '-k', self.dummy_keyname, 'gs://dummybucket'])
+
+
+class TestKmsUnitTests(testcase.GsUtilUnitTestCase):
+  """Unit tests for gsutil kms."""
+
+  dummy_keyname = ('projects/my-project/locations/global/'
+                   'keyRings/my-keyring/cryptoKeys/my-key')
+
+  @mock.patch('gslib.boto_translation.CloudApi.GetProjectServiceAccount')
+  @mock.patch('gslib.boto_translation.CloudApi.PatchBucket')
+  @mock.patch('gslib.kms_api.KmsApi.GetKeyIamPolicy')
+  @mock.patch('gslib.kms_api.KmsApi.SetKeyIamPolicy')
+  def testEncryptionSetKeySucceedsWhenUpdateKeyPolicySucceeds(
+      self, mock_set_key_iam_policy, mock_get_key_iam_policy, mock_patch_bucket,
+      mock_get_project_service_account):
+    bucket_uri = self.CreateBucket()
+    mock_get_key_iam_policy.return_value.bindings = []
+    mock_get_project_service_account.return_value.email_address = 'dummy@google.com'
+
+    stdout = self.RunCommand(
+        'kms', ['encryption', '-k', self.dummy_keyname,
+                suri(bucket_uri)],
+        return_stdout=True)
+    self.assertIn(
+        b'Setting default KMS key for bucket %s...' % suri(bucket_uri), stdout)
+
+  @mock.patch('gslib.boto_translation.CloudApi.GetProjectServiceAccount')
+  @mock.patch('gslib.boto_translation.CloudApi.PatchBucket')
+  @mock.patch('gslib.kms_api.KmsApi.GetKeyIamPolicy')
+  @mock.patch('gslib.kms_api.KmsApi.SetKeyIamPolicy')
+  def testEncryptionSetKeySucceedsWhenUpdateKeyPolicyFailsWithWarningFlag(
+      self, mock_set_key_iam_policy, mock_get_key_iam_policy, mock_patch_bucket,
+      mock_get_project_service_account):
+    bucket_uri = self.CreateBucket()
+    mock_get_key_iam_policy.side_effect = AccessDeniedException(
+        'Permission denied')
+    mock_get_project_service_account.return_value.email_address = 'dummy@google.com'
+
+    stdout = self.RunCommand(
+        'kms', ['encryption', '-k', self.dummy_keyname, '-w',
+                suri(bucket_uri)],
+        return_stdout=True)
+    self.assertIn(
+        b'Setting default KMS key for bucket %s...' % suri(bucket_uri), stdout)
+
+  @mock.patch('gslib.boto_translation.CloudApi.GetProjectServiceAccount')
+  @mock.patch('gslib.boto_translation.CloudApi.PatchBucket')
+  @mock.patch('gslib.kms_api.KmsApi.GetKeyIamPolicy')
+  @mock.patch('gslib.kms_api.KmsApi.SetKeyIamPolicy')
+  def testEncryptionSetKeyFailsWhenUpdateKeyPolicyFailsWithoutWarningFlag(
+      self, mock_set_key_iam_policy, mock_get_key_iam_policy, mock_patch_bucket,
+      mock_get_project_service_account):
+    bucket_uri = self.CreateBucket()
+    mock_get_key_iam_policy.side_effect = AccessDeniedException(
+        'Permission denied')
+    mock_get_project_service_account.return_value.email_address = 'dummy@google.com'
+
+    try:
+      stdout = self.RunCommand(
+          'kms', ['encryption', '-k', self.dummy_keyname,
+                  suri(bucket_uri)],
+          return_stdout=True)
+      self.fail('Did not get expected AccessDeniedException')
+    except AccessDeniedException as e:
+      self.assertIn('Permission denied', e.reason)

--- a/gslib/tests/util.py
+++ b/gslib/tests/util.py
@@ -336,6 +336,21 @@ class GSMockBucketStorageUri(mock_storage_service.MockBucketStorageUri):
   def get_location(self, headers=None):
     return 'US'
 
+  def get_cors(self, headers=None):
+    return boto.gs.cors.Cors()
+
+  def get_encryption_config(self, headers=None):
+    return boto.gs.encryptionconfig.EncryptionConfig()
+
+  def get_lifecycle_config(self, headers=None):
+    return boto.gs.lifecycle.LifecycleConfig()
+
+  def get_website_config(self, headers=None):
+    return None
+
+  def get_versioning_config(self, headers=None):
+    return None
+
 
 TEST_BOTO_REMOVE_SECTION = 'TestRemoveSection'
 

--- a/gslib/tests/util.py
+++ b/gslib/tests/util.py
@@ -343,7 +343,7 @@ class GSMockBucketStorageUri(mock_storage_service.MockBucketStorageUri):
     return boto.gs.encryptionconfig.EncryptionConfig()
 
   def get_lifecycle_config(self, headers=None):
-    return boto.gs.lifecycle.LifecycleConfig()
+    return None
 
   def get_website_config(self, headers=None):
     return None


### PR DESCRIPTION
 -w flag can be used for warning instead of erroring on updating key permissions failure