### PR TITLE
Switch ubla command to use the uniform bucket-level access api

### DIFF
--- a/gslib/commands/ls.py
+++ b/gslib/commands/ls.py
@@ -378,6 +378,9 @@ class LsCommand(Command):
     if bucket.iamConfiguration and bucket.iamConfiguration.bucketPolicyOnly:
       enabled = bucket.iamConfiguration.bucketPolicyOnly.enabled
       fields['bucket_policy_only_enabled'] = enabled
+    if bucket.iamConfiguration and bucket.iamConfiguration.uniformBucketLevelAccess:
+      enabled = bucket.iamConfiguration.uniformBucketLevelAccess.enabled
+      fields['uniform_bucket_level_access_enabled'] = enabled
 
     # For field values that are multiline, add indenting to make it look
     # prettier.

--- a/gslib/commands/mb.py
+++ b/gslib/commands/mb.py
@@ -218,6 +218,7 @@ class MbCommand(Command):
   def RunCommand(self):
     """Command entry point for the mb command."""
     bucket_policy_only = None
+    uniform_bucket_level_access = None
     location = None
     storage_class = None
     seconds = None
@@ -247,6 +248,12 @@ class MbCommand(Command):
       iam_config = bucket_metadata.iamConfiguration
       iam_config.bucketPolicyOnly = BucketPolicyOnlyValue()
       iam_config.bucketPolicyOnly.enabled = bucket_policy_only
+
+    if uniform_bucket_level_access:
+      bucket_metadata.iamConfiguration = IamConfigurationValue()
+      iam_config = bucket_metadata.iamConfiguration
+      iam_config.uniformBucketLevelAccess = UniformBucketLevelAccessValue()
+      iam_config.uniformBucketLevelAccess.enabled = uniformBucketLevelAccess
 
     for bucket_url_str in self.args:
       bucket_url = StorageUrlFromString(bucket_url_str)

--- a/gslib/commands/ubla.py
+++ b/gslib/commands/ubla.py
@@ -51,7 +51,7 @@ _SET_DESCRIPTION = """
 
     gsutil ubla set on gs://redbucket gs://bluebucket
 
-  Configure your buckets to NOT uniform bucket-level access:
+  Configure your buckets to NOT use uniform bucket-level access:
 
     gsutil ubla set off gs://redbucket gs://bluebucket
 """

--- a/gslib/commands/ubla.py
+++ b/gslib/commands/ubla.py
@@ -1,0 +1,231 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""This module provides the command to gsutil."""
+
+from __future__ import absolute_import
+from __future__ import print_function
+
+import getopt
+import textwrap
+
+from gslib import metrics
+from gslib.command import Command
+from gslib.command_argument import CommandArgument
+from gslib.cs_api_map import ApiSelector
+from gslib.exception import CommandException
+from gslib.exception import NO_URLS_MATCHED_TARGET
+from gslib.help_provider import CreateHelpText
+from gslib.third_party.storage_apitools import storage_v1_messages as apitools_messages
+from gslib.utils.constants import NO_MAX
+from gslib.utils.text_util import InsistOnOrOff
+
+_SET_SYNOPSIS = """
+  gsutil ubla set <on|off> bucket_url...
+"""
+
+_GET_SYNOPSIS = """
+  gsutil ubla get bucket_url...
+"""
+
+_SYNOPSIS = _SET_SYNOPSIS + _GET_SYNOPSIS.lstrip('\n')
+
+_SET_DESCRIPTION = """
+<B>SET</B>
+  The ``ubla set`` command enables or disables uniform
+  bucket-level access for Google Cloud Storage bucket(s).
+
+<B>SET EXAMPLES</B>
+  Configure your buckets to use uniform bucket-level access:
+
+    gsutil ubla set on gs://redbucket gs://bluebucket
+
+  Configure your buckets to NOT uniform bucket-level access:
+
+    gsutil ubla set off gs://redbucket gs://bluebucket
+"""
+
+_GET_DESCRIPTION = """
+<B>GET</B>
+  The ``ubla get`` command shows whether uniform bucket-level access is enabled
+  for the specified Cloud Storage bucket(s).
+
+<B>GET EXAMPLES</B>
+  Check if your buckets are using uniform bucket-level access:
+
+    gsutil ubla get gs://redbucket gs://bluebucket
+"""
+
+_DESCRIPTION = """
+  The ``ubla`` command is used to retrieve or configure the
+  `Access controls (Beta)
+  <https://cloud.google.com/storage/docs/bucket-policy-only>`_ setting of
+  Cloud Storage bucket(s). This command has two sub-commands, ``get`` and
+  ``set``.
+""" + _GET_DESCRIPTION + _SET_DESCRIPTION
+
+_DETAILED_HELP_TEXT = CreateHelpText(_SYNOPSIS, _DESCRIPTION)
+_set_help_text = CreateHelpText(_SET_SYNOPSIS, _SET_DESCRIPTION)
+_get_help_text = CreateHelpText(_GET_SYNOPSIS, _GET_DESCRIPTION)
+
+# Aliases to make these more likely to fit on one line.
+IamConfigurationValue = apitools_messages.Bucket.IamConfigurationValue
+uniformBucketLevelAccessValue = IamConfigurationValue.BucketPolicyOnlyValue
+
+
+class UblaCommand(Command):
+  """Implements the gsutil ubla command."""
+
+  command_spec = Command.CreateCommandSpec(
+      'ubla',
+      command_name_aliases='uniformbucketlevelaccess',
+      usage_synopsis=_SYNOPSIS,
+      min_args=2,
+      max_args=NO_MAX,
+      supported_sub_args='',
+      file_url_ok=False,
+      provider_url_ok=False,
+      urls_start_arg=2,
+      gs_api_support=[ApiSelector.JSON],
+      gs_default_api=ApiSelector.JSON,
+      argparse_arguments={
+          'get': [CommandArgument.MakeNCloudURLsArgument(1),],
+          'set': [
+              CommandArgument('mode', choices=['on', 'off']),
+              CommandArgument.MakeZeroOrMoreCloudBucketURLsArgument()
+          ],
+      })
+  # Help specification. See help_provider.py for documentation.
+  help_spec = Command.HelpSpec(
+      help_name='ubla',
+      help_name_aliases=['uniformbucketlevelaccess'],
+      help_type='command_help',
+      help_one_line_summary='Configure Uniform bucket-level access',
+      help_text=_DETAILED_HELP_TEXT,
+      subcommand_help_text={
+          'get': _get_help_text,
+          'set': _set_help_text,
+      },
+  )
+
+  def _ValidateBucketListingRefAndReturnBucketName(self, blr):
+    if blr.storage_url.scheme != 'gs':
+      raise CommandException(
+          'The %s command can only be used with gs:// bucket URLs.' %
+          self.command_name)
+
+  def _GetUbla(self, blr):
+    """Gets the Uniform bucket-level access setting for a bucket."""
+    self._ValidateBucketListingRefAndReturnBucketName(blr)
+    bucket_url = blr.storage_url
+
+    bucket_metadata = self.gsutil_api.GetBucket(bucket_url.bucket_name,
+                                                fields=['iamConfiguration'],
+                                                provider=bucket_url.scheme)
+    iam_config = bucket_metadata.iamConfiguration
+    # TODO(mynameisrafe): Replace bucketPolicyOnly with uniformBucketLevelAccess
+    # when the property is live.
+    uniform_bucket_level_access = iam_config.bucketPolicyOnly
+
+    fields = {
+        'bucket': str(bucket_url).rstrip('/'),
+        'enabled': uniform_bucket_level_access.enabled
+    }
+
+    locked_time_line = ''
+    if uniform_bucket_level_access.lockedTime:
+      fields['locked_time'] = uniform_bucket_level_access.lockedTime
+      locked_time_line = '  LockedTime: {locked_time}\n'
+
+    if uniform_bucket_level_access:
+      print(('Uniform bucket-level access setting for {bucket}:\n'
+             '  Enabled: {enabled}\n' + locked_time_line).format(**fields))
+
+  def _SetUbla(self, blr, setting_arg):
+    """Sets the Uniform bucket-level access setting for a bucket on or off."""
+    self._ValidateBucketListingRefAndReturnBucketName(blr)
+    bucket_url = blr.storage_url
+
+    iam_config = IamConfigurationValue()
+    # TODO(mynameisrafe): Replace bucketPolicyOnly with uniformBucketLevelAccess
+    # when the property is live.
+    iam_config.bucketPolicyOnly = uniformBucketLevelAccessValue()
+    iam_config.bucketPolicyOnly.enabled = (setting_arg == 'on')
+
+    bucket_metadata = apitools_messages.Bucket(iamConfiguration=iam_config)
+
+    setting_verb = 'Enabling' if setting_arg == 'on' else 'Disabling'
+    print('%s Uniform bucket-level access for %s...' %
+          (setting_verb, str(bucket_url).rstrip('/')))
+
+    self.gsutil_api.PatchBucket(bucket_url.bucket_name,
+                                bucket_metadata,
+                                fields=['iamConfiguration'],
+                                provider=bucket_url.scheme)
+    return 0
+
+  def _Ubla(self):
+    """Handles ubla command on a Cloud Storage bucket."""
+    subcommand = self.args.pop(0)
+
+    if subcommand not in ('get', 'set'):
+      raise CommandException('ubla only supports get|set')
+
+    subcommand_func = None
+    subcommand_args = []
+    setting_arg = None
+
+    if subcommand == 'get':
+      subcommand_func = self._GetUbla
+    elif subcommand == 'set':
+      subcommand_func = self._SetUbla
+      setting_arg = self.args.pop(0)
+      InsistOnOrOff(setting_arg,
+                    'Only on and off values allowed for set option')
+      subcommand_args.append(setting_arg)
+
+    # Iterate over bucket args, performing the specified subsubcommand.
+    some_matched = False
+    url_args = self.args
+    if not url_args:
+      self.RaiseWrongNumberOfArgumentsException()
+    for url_str in url_args:
+      # Throws a CommandException if the argument is not a bucket.
+      bucket_iter = self.GetBucketUrlIterFromArg(url_str)
+      for bucket_listing_ref in bucket_iter:
+        some_matched = True
+        subcommand_func(bucket_listing_ref, *subcommand_args)
+
+    if not some_matched:
+      raise CommandException(NO_URLS_MATCHED_TARGET % list(url_args))
+    return 0
+
+  def RunCommand(self):
+    """Command entry point for the ubla command."""
+    if self.gsutil_api.GetApiSelector(provider='gs') != ApiSelector.JSON:
+      raise CommandException('\n'.join(
+          textwrap.wrap(
+              'The "%s" command can only be used with the Cloud Storage JSON API.'
+              % self.command_name)))
+
+    action_subcommand = self.args[0]
+    self.ParseSubOpts(check_args=True)
+
+    if action_subcommand == 'get' or action_subcommand == 'set':
+      metrics.LogCommandParams(sub_opts=self.sub_opts)
+      metrics.LogCommandParams(subcommands=[action_subcommand])
+      self._Ubla()
+    else:
+      raise CommandException('Invalid subcommand "%s", use get|set instead.' %
+                             action_subcommand)

--- a/gslib/commands/ubla.py
+++ b/gslib/commands/ubla.py
@@ -81,7 +81,7 @@ _get_help_text = CreateHelpText(_GET_SYNOPSIS, _GET_DESCRIPTION)
 
 # Aliases to make these more likely to fit on one line.
 IamConfigurationValue = apitools_messages.Bucket.IamConfigurationValue
-uniformBucketLevelAccessValue = IamConfigurationValue.BucketPolicyOnlyValue
+uniformBucketLevelAccessValue = IamConfigurationValue.UniformBucketLevelAccessValue
 
 
 class UblaCommand(Command):
@@ -134,9 +134,7 @@ class UblaCommand(Command):
                                                 fields=['iamConfiguration'],
                                                 provider=bucket_url.scheme)
     iam_config = bucket_metadata.iamConfiguration
-    # TODO(mynameisrafe): Replace bucketPolicyOnly with uniformBucketLevelAccess
-    # when the property is live.
-    uniform_bucket_level_access = iam_config.bucketPolicyOnly
+    uniform_bucket_level_access = iam_config.uniformBucketLevelAccess
 
     fields = {
         'bucket': str(bucket_url).rstrip('/'),
@@ -158,10 +156,8 @@ class UblaCommand(Command):
     bucket_url = blr.storage_url
 
     iam_config = IamConfigurationValue()
-    # TODO(mynameisrafe): Replace bucketPolicyOnly with uniformBucketLevelAccess
-    # when the property is live.
-    iam_config.bucketPolicyOnly = uniformBucketLevelAccessValue()
-    iam_config.bucketPolicyOnly.enabled = (setting_arg == 'on')
+    iam_config.uniformBucketLevelAccess = uniformBucketLevelAccessValue()
+    iam_config.uniformBucketLevelAccess.enabled = (setting_arg == 'on')
 
     bucket_metadata = apitools_messages.Bucket(iamConfiguration=iam_config)
 

--- a/gslib/tests/test_ls.py
+++ b/gslib/tests/test_ls.py
@@ -218,6 +218,21 @@ class TestLs(testcase.GsUtilIntegrationTestCase):
       # Check that for bucket policy only fields.
       self._AssertBucketPolicyOnly(False, stdout)
 
+  def test_bucket_with_Lb_uniform_bucket_level_access(self):
+    if self.test_api == ApiSelector.JSON:
+      bucket_uri = self.CreateBucket(uniform_bucket_level_access=True,
+                                     prefer_json_api=True)
+      stdout = self.RunGsUtil(['ls', '-Lb', suri(bucket_uri)],
+                              return_stdout=True)
+      self._AssertUniformBucketLevelAccess(True, stdout)
+
+  def _AssertUniformBucketLevelAccess(self, value, stdout):
+    uniform_bucket_level_access_re = re.compile(
+        r'^\s*Uniform Bucket Level Access enabled:\s+(?P<bpo_val>.+)$', re.MULTILINE)
+    uniform_bucket_level_access_match = re.search(uniform_bucket_level_access_re, stdout)
+    uniform_bucket_level_access_val = uniform_bucket_level_access_match.group('bpo_val')
+    self.assertEqual(str(value), uniform_bucket_level_access_val)
+
   def test_bucket_with_Lb_bucket_policy_only(self):
     if self.test_api == ApiSelector.JSON:
       bucket_uri = self.CreateBucket(bucket_policy_only=True,

--- a/gslib/tests/test_ubla.py
+++ b/gslib/tests/test_ubla.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration tests for ubla command."""
+
+from __future__ import absolute_import
+import re
+
+from gslib.cs_api_map import ApiSelector
+import gslib.tests.testcase as testcase
+from gslib.tests.util import ObjectToURI as suri
+from gslib.tests.util import unittest
+from gslib.utils.retry_util import Retry
+
+
+class TestUbla(testcase.GsUtilIntegrationTestCase):
+  """Integration tests for ubla command."""
+
+  _set_ubla_cmd = ['ubla', 'set']
+  _get_ubla_cmd = ['ubla', 'get']
+  def _AssertEnabled(self, bucket_uri, value):
+    stdout = self.RunGsUtil(self._get_ubla_cmd + [suri(bucket_uri)],
+                            return_stdout=True)
+    uniform_bucket_level_access_re = re.compile(r'^\s*Enabled:\s+(?P<enabled_val>.+)$', re.MULTILINE)
+    uniform_bucket_level_access_match = re.search(uniform_bucket_level_access_re, stdout)
+    uniform_bucket_level_access_val = uniform_bucket_level_access_match.group('enabled_val')
+    self.assertEqual(str(value), uniform_bucket_level_access_val)
+
+  def test_off_on_default_buckets(self):
+    if self.test_api == ApiSelector.XML:
+      return unittest.skip('XML API has no concept of Uniform bucket-level access')
+    bucket_uri = self.CreateBucket()
+    self._AssertEnabled(bucket_uri, False)
+
+  def test_turning_off_on_enabled_buckets(self):
+    if self.test_api == ApiSelector.XML:
+      return unittest.skip('XML API has no concept of Uniform bucket-level access')
+    # TODO(mynameisrafe): Replace bucket_policy_only with uniform_bucket_level_access  when the property is live.
+    bucket_uri = self.CreateBucket(bucket_policy_only=True,
+                                   prefer_json_api=True)
+    self._AssertEnabled(bucket_uri, True)
+
+    self.RunGsUtil(self._set_ubla_cmd + ['off', suri(bucket_uri)])
+    self._AssertEnabled(bucket_uri, False)
+
+  def test_turning_on(self):
+    if self.test_api == ApiSelector.XML:
+      return unittest.skip('XML API has no concept of Uniform bucket-level access')
+
+    bucket_uri = self.CreateBucket()
+    self.RunGsUtil(self._set_ubla_cmd + ['on', suri(bucket_uri)])
+
+    self._AssertEnabled(bucket_uri, True)
+
+  def test_turning_on_and_off(self):
+    if self.test_api == ApiSelector.XML:
+      return unittest.skip('XML API has no concept of Uniform bucket-level access')
+
+    bucket_uri = self.CreateBucket()
+
+    self.RunGsUtil(self._set_ubla_cmd + ['on', suri(bucket_uri)])
+    self._AssertEnabled(bucket_uri, True)
+
+    self.RunGsUtil(self._set_ubla_cmd + ['off', suri(bucket_uri)])
+    self._AssertEnabled(bucket_uri, False)
+
+  def testTooFewArgumentsFails(self):
+    """Ensures ubla commands fail with too few arguments."""
+    # No arguments for set, but valid subcommand.
+    stderr = self.RunGsUtil(self._set_ubla_cmd,
+                            return_stderr=True,
+                            expected_status=1)
+    self.assertIn('command requires at least', stderr)
+
+    # No arguments for get, but valid subcommand.
+    stderr = self.RunGsUtil(self._get_ubla_cmd,
+                            return_stderr=True,
+                            expected_status=1)
+    self.assertIn('command requires at least', stderr)
+
+    # Neither arguments nor subcommand.
+    stderr = self.RunGsUtil(['ubla'],
+                            return_stderr=True,
+                            expected_status=1)
+    self.assertIn('command requires at least', stderr)

--- a/gslib/tests/test_ubla.py
+++ b/gslib/tests/test_ubla.py
@@ -29,23 +29,29 @@ class TestUbla(testcase.GsUtilIntegrationTestCase):
 
   _set_ubla_cmd = ['ubla', 'set']
   _get_ubla_cmd = ['ubla', 'get']
+
   def _AssertEnabled(self, bucket_uri, value):
     stdout = self.RunGsUtil(self._get_ubla_cmd + [suri(bucket_uri)],
                             return_stdout=True)
-    uniform_bucket_level_access_re = re.compile(r'^\s*Enabled:\s+(?P<enabled_val>.+)$', re.MULTILINE)
-    uniform_bucket_level_access_match = re.search(uniform_bucket_level_access_re, stdout)
-    uniform_bucket_level_access_val = uniform_bucket_level_access_match.group('enabled_val')
+    uniform_bucket_level_access_re = re.compile(
+        r'^\s*Enabled:\s+(?P<enabled_val>.+)$', re.MULTILINE)
+    uniform_bucket_level_access_match = re.search(
+        uniform_bucket_level_access_re, stdout)
+    uniform_bucket_level_access_val = uniform_bucket_level_access_match.group(
+        'enabled_val')
     self.assertEqual(str(value), uniform_bucket_level_access_val)
 
   def test_off_on_default_buckets(self):
     if self.test_api == ApiSelector.XML:
-      return unittest.skip('XML API has no concept of Uniform bucket-level access')
+      return unittest.skip(
+          'XML API has no concept of Uniform bucket-level access')
     bucket_uri = self.CreateBucket()
     self._AssertEnabled(bucket_uri, False)
 
   def test_turning_off_on_enabled_buckets(self):
     if self.test_api == ApiSelector.XML:
-      return unittest.skip('XML API has no concept of Uniform bucket-level access')
+      return unittest.skip(
+          'XML API has no concept of Uniform bucket-level access')
     # TODO(mynameisrafe): Replace bucket_policy_only with uniform_bucket_level_access  when the property is live.
     bucket_uri = self.CreateBucket(bucket_policy_only=True,
                                    prefer_json_api=True)
@@ -56,7 +62,8 @@ class TestUbla(testcase.GsUtilIntegrationTestCase):
 
   def test_turning_on(self):
     if self.test_api == ApiSelector.XML:
-      return unittest.skip('XML API has no concept of Uniform bucket-level access')
+      return unittest.skip(
+          'XML API has no concept of Uniform bucket-level access')
 
     bucket_uri = self.CreateBucket()
     self.RunGsUtil(self._set_ubla_cmd + ['on', suri(bucket_uri)])
@@ -65,7 +72,8 @@ class TestUbla(testcase.GsUtilIntegrationTestCase):
 
   def test_turning_on_and_off(self):
     if self.test_api == ApiSelector.XML:
-      return unittest.skip('XML API has no concept of Uniform bucket-level access')
+      return unittest.skip(
+          'XML API has no concept of Uniform bucket-level access')
 
     bucket_uri = self.CreateBucket()
 
@@ -90,7 +98,5 @@ class TestUbla(testcase.GsUtilIntegrationTestCase):
     self.assertIn('command requires at least', stderr)
 
     # Neither arguments nor subcommand.
-    stderr = self.RunGsUtil(['ubla'],
-                            return_stderr=True,
-                            expected_status=1)
+    stderr = self.RunGsUtil(['ubla'], return_stderr=True, expected_status=1)
     self.assertIn('command requires at least', stderr)

--- a/gslib/tests/test_ubla.py
+++ b/gslib/tests/test_ubla.py
@@ -33,12 +33,9 @@ class TestUbla(testcase.GsUtilIntegrationTestCase):
   def _AssertEnabled(self, bucket_uri, value):
     stdout = self.RunGsUtil(self._get_ubla_cmd + [suri(bucket_uri)],
                             return_stdout=True)
-    uniform_bucket_level_access_re = re.compile(
-        r'^\s*Enabled:\s+(?P<enabled_val>.+)$', re.MULTILINE)
-    uniform_bucket_level_access_match = re.search(
-        uniform_bucket_level_access_re, stdout)
-    uniform_bucket_level_access_val = uniform_bucket_level_access_match.group(
-        'enabled_val')
+    uniform_bucket_level_access_re = re.compile(r'^\s*Enabled:\s+(?P<enabled_val>.+)$', re.MULTILINE)
+    uniform_bucket_level_access_match = re.search(uniform_bucket_level_access_re, stdout)
+    uniform_bucket_level_access_val = uniform_bucket_level_access_match.group('enabled_val')
     self.assertEqual(str(value), uniform_bucket_level_access_val)
 
   def test_off_on_default_buckets(self):
@@ -52,8 +49,7 @@ class TestUbla(testcase.GsUtilIntegrationTestCase):
     if self.test_api == ApiSelector.XML:
       return unittest.skip(
           'XML API has no concept of Uniform bucket-level access')
-    # TODO(mynameisrafe): Replace bucket_policy_only with uniform_bucket_level_access  when the property is live.
-    bucket_uri = self.CreateBucket(bucket_policy_only=True,
+    bucket_uri = self.CreateBucket(uniform_bucket_level_access=True,
                                    prefer_json_api=True)
     self._AssertEnabled(bucket_uri, True)
 
@@ -98,5 +94,7 @@ class TestUbla(testcase.GsUtilIntegrationTestCase):
     self.assertIn('command requires at least', stderr)
 
     # Neither arguments nor subcommand.
-    stderr = self.RunGsUtil(['ubla'], return_stderr=True, expected_status=1)
+    stderr = self.RunGsUtil(['ubla'],
+                            return_stderr=True,
+                            expected_status=1)
     self.assertIn('command requires at least', stderr)

--- a/gslib/tests/testcase/integration_testcase.py
+++ b/gslib/tests/testcase/integration_testcase.py
@@ -518,6 +518,7 @@ class GsUtilIntegrationTestCase(base.GsUtilTestCase):
                    prefer_json_api=False,
                    versioning_enabled=False,
                    bucket_policy_only=False,
+                   uniform_bucket_level_access=False,
                    bucket_name_prefix='',
                    bucket_name_suffix=''):
     """Creates a test bucket.
@@ -537,6 +538,8 @@ class GsUtilIntegrationTestCase(base.GsUtilTestCase):
           True.
       bucket_policy_only: If True, set the bucket's iamConfiguration's
           bucketPolicyOnly attribute to True.
+      uniform_bucket_level_access: If True, set the bucket's iamConfiguration's
+          uniformBucketLevelAccess attribute to True.
       bucket_name_prefix: Unicode string to be prepended to bucket_name
       bucket_name_suffix: Unicode string to be appended to bucket_name
 

--- a/gslib/third_party/storage_apitools/storage_v1_messages.py
+++ b/gslib/third_party/storage_apitools/storage_v1_messages.py
@@ -166,9 +166,12 @@ class Bucket(_messages.Message):
 
     Messages:
       BucketPolicyOnlyValue: The bucket's Bucket Policy Only configuration.
+      UniformBucketLevelAccessValue: The bucket's Bucket Policy Only
+      configuration.
 
     Fields:
       bucketPolicyOnly: The bucket's Bucket Policy Only configuration.
+      uniformBucketLevelAccess: The bucket's Bucket Policy Only configuration.
     """
 
     class BucketPolicyOnlyValue(_messages.Message):
@@ -188,6 +191,24 @@ class Bucket(_messages.Message):
       lockedTime = _message_types.DateTimeField(2)
 
     bucketPolicyOnly = _messages.MessageField('BucketPolicyOnlyValue', 1)
+
+    class UniformBucketLevelAccessValue(_messages.Message):
+      r"""The bucket's Uniform Bucket Level Access configuration.
+
+      Fields:
+        enabled: If set, access checks only use bucket-level IAM policies or
+          above.
+        lockedTime: The deadline time for changing
+          iamConfiguration.uniformbBucketLevelAccess.enabled from true to false
+          in RFC 3339 format. iamConfiguration.uniformbBucketLevelAccess.enabled
+          may be changed from true to false until the locked time, after which
+          the field is immutable.
+      """
+
+      enabled = _messages.BooleanField(1)
+      lockedTime = _message_types.DateTimeField(2)
+
+    uniformBucketLevelAccess = _messages.MessageField('UniformBucketLevelAccessValue', 2)
 
   @encoding.MapUnrecognizedFields('additionalProperties')
   class LabelsValue(_messages.Message):


### PR DESCRIPTION
- Adds the uniformBucketLevelAccess property to the bucket type
- Adds support for the uniformBucketLevelAccess property to existing commands that used bucket policy only
- Changes the ubla command to set and get from the uniformBucketLevelAccess property