### PR TITLE
Fix streaming upload in Python 3

### DIFF
--- a/gslib/utils/system_util.py
+++ b/gslib/utils/system_util.py
@@ -195,7 +195,7 @@ def GetGsutilClientIdAndSecret():
 
 def GetStreamFromFileUrl(storage_url, mode='rb'):
   if storage_url.IsStream():
-    return sys.stdin
+    return sys.stdin if six.PY2 else sys.stdin.buffer
   else:
     return open(storage_url.object_name, mode)
 


### PR DESCRIPTION
When trying a streaming upload through stdin, in a gsutil 4.43 installed through pypi in a python 3.7 environment, with the command

```
a_program | gsutil cp - gs://bucket/path
```

I'm getting the following error

```
...
   File "/usr/local/lib/python3.7/site-packages/gslib/utils/hashing_helper.py", line 427, in read
    data = self._orig_fp.read(size)
  File "/usr/local/lib/python3.7/site-packages/gslib/resumable_streaming_upload.py", line 146, in read
    data = b''.join(buffered_data)
TypeError: sequence item 0: expected a bytes-like object, str found
```

Trying to locate the cause of the error, I found that the stream is read through `sys.stdin.read()`, which in python 3 returns string objects instead of bytes. With this fix I no longer get an error and the upload finishes successfully.