### PR TITLE
Fix regression in cp caused by change #889.

### DIFF
--- a/gslib/tests/test_copy_helper_funcs.py
+++ b/gslib/tests/test_copy_helper_funcs.py
@@ -709,11 +709,10 @@ class TestExpandUrlToSingleBlr(GsUtilUnitTestCase):
 
   @mock.patch('gslib.cloud_api.CloudApi')
   def testWithSlashNoMatch(self, mock_gsutil_api):
-    """Tests use case that was removed"""
     mock_gsutil_api.ListObjects.return_value = iter([])
     (exp_url, have_existing_dst_container) = ExpandUrlToSingleBlr(
         'gs://test/folder/', mock_gsutil_api, 'project_id', False,
         CreateOrGetGsutilLogger('copy_test'))
 
-    self.assertFalse(have_existing_dst_container)
+    self.assertTrue(have_existing_dst_container)
     self.assertEqual(exp_url, StorageUrlFromString('gs://test/folder/'))

--- a/gslib/tests/test_naming.py
+++ b/gslib/tests/test_naming.py
@@ -319,7 +319,7 @@ class GsutilNamingTests(testcase.GsUtilUnitTestCase):
     actual = set(
         str(u) for u in self._test_wildcard_iterator(suri(
             dst_bucket_uri, '**')).IterAll(expand_top_level_buckets=True))
-    expected = set([suri(dst_bucket_uri, 'abc', 'f1')])
+    expected = set([suri(dst_bucket_uri, 'abc', 'dir1', 'f1')])
     self.assertEqual(expected, actual)
 
   # @SequentialAndParallelTransfer
@@ -637,6 +637,20 @@ class GsutilNamingTests(testcase.GsUtilUnitTestCase):
     src_file = self.CreateTempFile(file_name='foo')
     dst_bucket_uri = self.CreateBucket()
     self.RunCommand('cp', ['-R', src_file, suri(dst_bucket_uri, 'dir/foo')])
+    actual = set(
+        str(u) for u in self._test_wildcard_iterator(suri(
+            dst_bucket_uri, '**')).IterAll(expand_top_level_buckets=True))
+    expected = set([suri(dst_bucket_uri, 'dir/foo')])
+    self.assertEqual(expected, actual)
+
+  def testCopyingFileToNonExistentDir(self):
+    """Tests copying a file to a non-existent directory.
+
+    Should create the directory and add the file to it
+    """
+    src_file = self.CreateTempFile(file_name='foo')
+    dst_bucket_uri = self.CreateBucket()
+    self.RunCommand('cp', [src_file, suri(dst_bucket_uri, 'dir') + '/'])
     actual = set(
         str(u) for u in self._test_wildcard_iterator(suri(
             dst_bucket_uri, '**')).IterAll(expand_top_level_buckets=True))


### PR DESCRIPTION
The previously committed change caused a problem where running:

cp myFile gs://mybucket/nonExistentDir/

would create a file named "nonExistentDir" under "mybucket" instead of
creating "nonExistentDir/myFile".  Rather than try to special case this
I've just reverted part of the previous PR since expected behavior gets
gets ambiguous when providing multiple source files/directories.