### PR TITLE
Change object versioning terminology

### DIFF
--- a/gslib/addlhelp/versions.py
+++ b/gslib/addlhelp/versions.py
@@ -23,13 +23,12 @@ from gslib.help_provider import HelpProvider
 
 _DETAILED_HELP_TEXT = ("""
 <B>OVERVIEW</B>
-  Versioning-enabled buckets maintain an archive of objects, providing a way to
-  un-delete data that you accidentally deleted, or to retrieve older versions of
-  your data. You can turn versioning on or off for a bucket at any time. Turning
-  versioning off leaves existing object versions in place, and simply causes the
-  bucket to stop accumulating new object versions. In this case, if you upload
-  to an existing object the current version is overwritten instead of creating
-  a new version.
+  Versioning-enabled buckets maintain noncurrent versions of objects, providing
+  a way to un-delete data that you accidentally deleted, or to retrieve older
+  versions of your data. You can turn versioning on or off for a bucket at any
+  time. Turning versioning off leaves existing object versions in place and
+  simply causes the bucket to overwrite the live version of the object whenever
+  a new version is uploaded.
 
   Regardless of whether you have enabled versioning on a bucket, every object
   has two associated positive integer fields:
@@ -101,9 +100,8 @@ _DETAILED_HELP_TEXT = ("""
     gsutil rm gs://bucket/object
 
   The same is true when using wildcards like * and **. These will operate only
-  on the live version of matching objects. For example, this
-  command will remove the live version and create an archived version for each
-  object in a bucket:
+  on the live version of matching objects. For example, this command will remove
+  the live version and create a noncurrent version for each object in a bucket:
 
     gsutil rm gs://bucket/**
 
@@ -147,7 +145,7 @@ _DETAILED_HELP_TEXT = ("""
     gsutil mv gs://bucket/object#1360101007329000 gs://bucket/object
 
   If you remove the live version of an object in a versioning-enabled bucket,
-  an archived version will be preserved:
+  a noncurrent version will be preserved:
 
     gsutil rm gs://bucket/object
 

--- a/gslib/commands/cp.py
+++ b/gslib/commands/cp.py
@@ -248,8 +248,8 @@ _COPY_IN_CLOUD_TEXT = """
     gsutil cp gs://bucket1/obj gs://bucket2
 
   will cause only the single live version of gs://bucket1/obj to be copied to
-  gs://bucket2, even if there are archived versions of gs://bucket1/obj. To also
-  copy archived versions, use the -A flag:
+  gs://bucket2, even if there are noncurrent versions of gs://bucket1/obj. To
+  also copy noncurrent versions, use the -A flag:
 
     gsutil cp -A gs://bucket1/obj gs://bucket2
 

--- a/gslib/commands/notification.py
+++ b/gslib/commands/notification.py
@@ -206,7 +206,8 @@ _CREATE_DESCRIPTION = """
               OBJECT_FINALIZE - An object has been created.
               OBJECT_METADATA_UPDATE - The metadata of an object has changed.
               OBJECT_DELETE - An object has been permanently deleted.
-              OBJECT_ARCHIVE - A live Cloud Storage object has been archived.
+              OBJECT_ARCHIVE - A live version of an object has become a
+                noncurrent version.
 
   -f        Specifies the payload format of notification messages. Must be
             either "json" for a payload matches the object metadata for the

--- a/gslib/commands/rewrite.py
+++ b/gslib/commands/rewrite.py
@@ -86,8 +86,8 @@ _DETAILED_HELP_TEXT = ("""
     gsutil rewrite -k -r gs://bucket/subdir
 
   The rewrite command acts only on live object versions, so specifying a
-  URL with a generation will fail. If you want to rewrite an archived
-  generation, first copy it to the live version, then rewrite it, for example:
+  URL with a generation number fails. If you want to rewrite a noncurrent
+  version, first copy it to the live version, then rewrite it, for example:
 
     gsutil cp gs://bucket/object#123 gs://bucket/object
     gsutil rewrite -k gs://bucket/object

--- a/gslib/commands/rsync.py
+++ b/gslib/commands/rsync.py
@@ -352,11 +352,11 @@ _DETAILED_HELP_TEXT = ("""
      times to be used in its comparisons. This means gsutil rsync will resort to
      using checksums for any file with a timestamp before 1970-01-01 UTC.
 
-  2. The gsutil rsync command considers only the current object generations in
+  2. The gsutil rsync command considers only the live object version in
      the source and destination buckets when deciding what to copy / delete. If
      versioning is enabled in the destination bucket then gsutil rsync's
      overwriting or deleting objects will end up creating versions, but the
-     command doesn't try to make the archived generations match in the source
+     command doesn't try to make any noncurrent versions match in the source
      and destination buckets.
 
   3. The gsutil rsync command does not support copying special file types


### PR DESCRIPTION
Instead of "archived" versions, refer to them as "noncurrent" versions. This will avoid terminology overload and matches equivalent changes being made to the documentation found in cloud.google.com/storage/docs

b/140083251 tracks the request to make this change.