### PR TITLE
Add userproject support to signurl

### DIFF
--- a/gslib/tests/signurl_signatures.py
+++ b/gslib/tests/signurl_signatures.py
@@ -72,3 +72,18 @@ TEST_SIGN_URL_GET_WITH_JSON_KEY = (
     'ential=test%40developer.gserviceaccount.com%2F19000101%2Fasia%'
     '2Fstorage%2Fgoog4_request&x-goog-date=19000101T000555Z&x-goog-'
     'expires=0&x-goog-signedheaders=host')
+
+TEST_SIGN_URL_GET_USERPROJECT = (
+    'https://storage.googleapis.com/test/test.txt?x-goog-signature='
+    '8d31c53203d1ad0e94b17d9327f3a93cd44f41c440bb3fae12a04c0f9acbd9'
+    '9e0f9aa6876f1f53920bd9be2cfd5228adeb09045d2c59d903bb77b4de44cc'
+    '5587a01d55d1d3e1a76442e32a7c3227b859aa469d20b10081249880e38fcb'
+    '9335032243933eb339f05bfdd5c351ca72acce6258442c9e6bde4fbc3c97de'
+    'b412776934c020b450a9e6758ae170db1479167c14bcedec219ec33073ba0b'
+    '1c8ad46517da198159847fa0ba384b5c4a0f31969303dcfc99a3ee18c13f71'
+    '99d0ac2a3d239c01b2b25c829815d3ecae9a778cdb7c70182cc821720068d4'
+    '59aa1a5ad1c59ee9a747710a990e0bc24d533a036cbc9938af02cd70c252c4'
+    'abdd92c29913afd2&userProject=myproject&x-goog-algorithm=GOOG4-'
+    'RSA-SHA256&x-goog-credential=test%40developer.gserviceaccount.'
+    'com%2F19000101%2Fasia%2Fstorage%2Fgoog4_request&x-goog-date=19'
+    '000101T000555Z&x-goog-expires=0&x-goog-signedheaders=host')

--- a/gslib/tests/test_signurl.py
+++ b/gslib/tests/test_signurl.py
@@ -327,3 +327,22 @@ class UnitTestSignUrl(testcase.GsUtilUnitTestCase):
           region='asia',
           content_type='')
     self.assertEquals(expected, signed_url)
+
+  def testSignurlGetWithUserProject(self):
+    """Tests the _GenSignedUrl function with a userproject."""
+    expected = sigs.TEST_SIGN_URL_GET_USERPROJECT
+
+    duration = timedelta(seconds=0)
+    with SetBotoConfigForTest([('Credentials', 'gs_host',
+                                'storage.googleapis.com')]):
+      signed_url = gslib.commands.signurl._GenSignedUrl(
+          self.key,
+          client_id=self.client_email,
+          method='GET',
+          gcs_path='test/test.txt',
+          duration=duration,
+          logger=self.logger,
+          region='asia',
+          content_type='',
+          userproject='myproject')
+    self.assertEquals(expected, signed_url)


### PR DESCRIPTION
Add support to signurl to provide an optional projectname that will be billed, useful for generating presigned links for buckets that are set to requester pays.