### PR TITLE
Fixed an issue with listing files w/ folders & folders the same name

### DIFF
--- a/gslib/commands/config.py
+++ b/gslib/commands/config.py
@@ -1145,7 +1145,8 @@ class ConfigCommand(Command):
 # version to use. If not set below gsutil defaults to API version 1.
 """)
     api_version = 2
-    if cred_type == CredTypes.HMAC: api_version = 1
+    if cred_type == CredTypes.HMAC:
+      api_version = 1
 
     config_file.write('default_api_version = %d\n' % api_version)
 

--- a/gslib/storage_url.py
+++ b/gslib/storage_url.py
@@ -261,6 +261,10 @@ class _CloudUrl(StorageUrl):
       prefix = '%s/%s' % (prefix, wildcard_suffix)
     return prefix
 
+  def AsPrefixedUrl(self, wildcard_suffix=None):
+    url_string = self.CreatePrefixUrl(wildcard_suffix)
+    return _CloudUrl(url_string)
+
   @property
   def bucket_url_string(self):
     return '%s://%s/' % (self.scheme, self.bucket_name)

--- a/gslib/tests/test_cp.py
+++ b/gslib/tests/test_cp.py
@@ -544,7 +544,10 @@ class _DeleteBucketThenStartOverCopyCallbackHandler(object):
 class _ResumableUploadRetryHandler(object):
   """Test callback handler for causing retries during a resumable transfer."""
 
-  def __init__(self, retry_at_byte, exception_to_raise, exc_args,
+  def __init__(self,
+               retry_at_byte,
+               exception_to_raise,
+               exc_args,
                num_retries=1):
     self._retry_at_byte = retry_at_byte
     self._exception_to_raise = exception_to_raise

--- a/gslib/tests/test_ls.py
+++ b/gslib/tests/test_ls.py
@@ -369,6 +369,27 @@ class TestLs(testcase.GsUtilIntegrationTestCase):
 
     _Check1()
 
+  def test_subdir_with_same_name_as_object_running_without_trailing_slash_lists_just_file(
+      self):
+    """Tests listing a bucket contents when there is an object with the same name
+    minus the prefix in the same directory as the subdir prefix"""
+    bucket_uri = self.CreateBucket()
+
+    # Two objects;
+    obj_uri = self.CreateObject(bucket_uri=bucket_uri,
+                                object_name='foo',
+                                contents=b'something')
+    prefix_uri = self.CreateObject(bucket_uri=bucket_uri, object_name='foo/')
+
+    # Use @Retry as hedge against bucket listing eventual consistency.
+    @Retry(AssertionError, tries=3, timeout_secs=1)
+    def _Check1():
+      stdout = self.RunGsUtil(['ls', '%s/foo' % suri(bucket_uri)],
+                              return_stdout=True)
+      self.assertEqual('%s\n' % (obj_uri), stdout)
+
+    _Check1()
+
   def test_subdir_nocontents(self):
     """Tests listing a bucket subdirectory using -d.
 

--- a/gslib/tests/test_metrics.py
+++ b/gslib/tests/test_metrics.py
@@ -591,7 +591,10 @@ class _JSONForceHTTPErrorCopyCallbackHandler(object):
 class _ResumableUploadRetryHandler(object):
   """Test callback handler for causing retries during a resumable transfer."""
 
-  def __init__(self, retry_at_byte, exception_to_raise, exc_args,
+  def __init__(self,
+               retry_at_byte,
+               exception_to_raise,
+               exc_args,
                num_retries=1):
     self._retry_at_byte = retry_at_byte
     self._exception_to_raise = exception_to_raise

--- a/gslib/tests/test_util.py
+++ b/gslib/tests/test_util.py
@@ -274,7 +274,8 @@ class TestUtil(testcase.GsUtilUnitTestCase):
                     443 if env_var.lower().startswith('https') else 80))
             # Shouldn't populate info for other variables
             for other_env_var in valid_variables:
-              if other_env_var == env_var: continue
+              if other_env_var == env_var:
+                continue
               self._AssertProxyInfosEqual(
                   boto_util.ProxyInfoFromEnvironmentVar(other_env_var),
                   httplib2.ProxyInfo(httplib2.socks.PROXY_TYPE_HTTP, None, 0))

--- a/gslib/tests/util.py
+++ b/gslib/tests/util.py
@@ -279,7 +279,8 @@ def GenerationFromURI(uri):
     Generation string for the URI.
   """
   if not (uri.generation or uri.version_id):
-    if uri.scheme == 's3': return 'null'
+    if uri.scheme == 's3':
+      return 'null'
   return uri.generation or uri.version_id
 
 

--- a/gslib/utils/copy_helper.py
+++ b/gslib/utils/copy_helper.py
@@ -697,8 +697,8 @@ def ConstructDstUrl(src_url,
     # src_subdir/obj.
     src_url_path_sans_final_dir = GetPathBeforeFinalDir(src_url, exp_src_url)
 
-    dst_key_name = exp_src_url.versionless_url_string[len(
-        src_url_path_sans_final_dir):].lstrip(src_url.delim)
+    dst_key_name = exp_src_url.versionless_url_string[
+        len(src_url_path_sans_final_dir):].lstrip(src_url.delim)
     # Handle case where dst_url is a non-existent subdir.
     if not have_existing_dest_subdir:
       dst_key_name = dst_key_name.partition(src_url.delim)[-1]

--- a/gslib/utils/ls_helper.py
+++ b/gslib/utils/ls_helper.py
@@ -371,11 +371,9 @@ class LsHelper(object):
       # User provided a prefix or object URL, but it's impossible to tell
       # which until we do a listing and see what matches.
       top_level_iterator = PluralityCheckableIterator(
-          self._iterator_func(
-              url.CreatePrefixUrl(wildcard_suffix=None),
-              all_versions=self.all_versions).IterAll(
-                  expand_top_level_buckets=True,
-                  bucket_listing_fields=self.bucket_listing_fields))
+          self._iterator_func(str(url), all_versions=self.all_versions).IterAll(
+              expand_top_level_buckets=True,
+              bucket_listing_fields=self.bucket_listing_fields))
       plurality = top_level_iterator.HasPlurality()
 
       try:
@@ -386,8 +384,7 @@ class LsHelper(object):
         # Re-iterate without requesting encrypted fields.
         top_level_iterator = PluralityCheckableIterator(
             self._iterator_func(
-                url.CreatePrefixUrl(wildcard_suffix=None),
-                all_versions=self.all_versions).IterAll(
+                str(url), all_versions=self.all_versions).IterAll(
                     expand_top_level_buckets=True,
                     bucket_listing_fields=UNENCRYPTED_FULL_LISTING_FIELDS))
         plurality = top_level_iterator.HasPlurality()

--- a/gslib/utils/ls_helper.py
+++ b/gslib/utils/ls_helper.py
@@ -371,9 +371,10 @@ class LsHelper(object):
       # User provided a prefix or object URL, but it's impossible to tell
       # which until we do a listing and see what matches.
       top_level_iterator = PluralityCheckableIterator(
-          self._iterator_func(url.url_string, all_versions=self.all_versions).IterAll(
-              expand_top_level_buckets=True,
-              bucket_listing_fields=self.bucket_listing_fields))
+          self._iterator_func(
+              url.url_string, all_versions=self.all_versions).IterAll(
+                  expand_top_level_buckets=True,
+                  bucket_listing_fields=self.bucket_listing_fields))
       plurality = top_level_iterator.HasPlurality()
 
       try:

--- a/gslib/utils/ls_helper.py
+++ b/gslib/utils/ls_helper.py
@@ -371,7 +371,7 @@ class LsHelper(object):
       # User provided a prefix or object URL, but it's impossible to tell
       # which until we do a listing and see what matches.
       top_level_iterator = PluralityCheckableIterator(
-          self._iterator_func(str(url), all_versions=self.all_versions).IterAll(
+          self._iterator_func(url.url_string, all_versions=self.all_versions).IterAll(
               expand_top_level_buckets=True,
               bucket_listing_fields=self.bucket_listing_fields))
       plurality = top_level_iterator.HasPlurality()
@@ -384,7 +384,7 @@ class LsHelper(object):
         # Re-iterate without requesting encrypted fields.
         top_level_iterator = PluralityCheckableIterator(
             self._iterator_func(
-                str(url), all_versions=self.all_versions).IterAll(
+                url.url_string, all_versions=self.all_versions).IterAll(
                     expand_top_level_buckets=True,
                     bucket_listing_fields=UNENCRYPTED_FULL_LISTING_FIELDS))
         plurality = top_level_iterator.HasPlurality()

--- a/gslib/wildcard_iterator.py
+++ b/gslib/wildcard_iterator.py
@@ -112,7 +112,8 @@ class CloudWildcardIterator(WildcardIterator):
     self.project_id = project_id
     self.logger = logger or logging.getLogger()
 
-  def __iter__(self, bucket_listing_fields=None,
+  def __iter__(self,
+               bucket_listing_fields=None,
                expand_top_level_buckets=False):
     """Iterator that gets called when iterating over the cloud wildcard.
 

--- a/gslib/wildcard_iterator.py
+++ b/gslib/wildcard_iterator.py
@@ -190,7 +190,7 @@ class CloudWildcardIterator(WildcardIterator):
         # Checking object(s) first prevents unnecessary listings (which are slower,
         # more expensive, and also subject to eventual consistency).
         contains_wildcard = ContainsWildcard(self.wildcard_url.url_string)
-        is_prefix = IsCloudSubdirPlaceholder(self.wildcard_url_raw)
+        is_prefix = self.wildcard_url_raw.endswith('/')
         if ((not contains_wildcard) and (not is_prefix) and
             self.wildcard_url.IsObject() and not self.all_versions):
           try:

--- a/gslib/wildcard_iterator.py
+++ b/gslib/wildcard_iterator.py
@@ -190,7 +190,7 @@ class CloudWildcardIterator(WildcardIterator):
         # Checking object(s) first prevents unnecessary listings (which are slower,
         # more expensive, and also subject to eventual consistency).
         contains_wildcard = ContainsWildcard(self.wildcard_url.url_string)
-        is_prefix = self.wildcard_url_raw.endswith('/')
+        is_prefix = self.wildcard_url_raw.url_string.endswith('/')
         if ((not contains_wildcard) and (not is_prefix) and
             self.wildcard_url.IsObject() and not self.all_versions):
           try:


### PR DESCRIPTION
Take for example:

* foo
* foo/
* foo/bar

If you ran on `master`, you would get:

```
touma@setsuna:repos/gsutil ‹master›$ ./gsutil ls -l "gs://nasomi-testing-bucket/foo/"
         0  2019-11-16T19:07:23Z  gs://nasomi-testing-bucket/foo
TOTAL: 1 objects, 0 bytes (0 B)
```

.. though you probably wanted to list the entire directory. This is because we check if something is an object first -- and strip trailing slashes to do this inside of `WildcardIterator`, therefore it always returns the file instance. 

This change will let you list the contents. 

Taking suggestions for a cleaner approach -- since I am new to the codebase. 