### PR TITLE
[Fix-Issue-935]: fix error while transferring binary from S3 with Python3

### DIFF
--- a/gslib/command_runner.py
+++ b/gslib/command_runner.py
@@ -501,7 +501,7 @@ class CommandRunner(object):
       cur_ver = gslib.VERSION
       try:
         cur_ver = LookUpGsutilVersion(gsutil_api, GSUTIL_PUB_TARBALL)
-      except:
+      except Exception:
         return False
 
       with open(last_checked_for_gsutil_update_timestamp_file, 'w') as f:

--- a/gslib/commands/config.py
+++ b/gslib/commands/config.py
@@ -1145,7 +1145,8 @@ class ConfigCommand(Command):
 # version to use. If not set below gsutil defaults to API version 1.
 """)
     api_version = 2
-    if cred_type == CredTypes.HMAC: api_version = 1
+    if cred_type == CredTypes.HMAC: 
+      api_version = 1
 
     config_file.write('default_api_version = %d\n' % api_version)
 

--- a/gslib/commands/config.py
+++ b/gslib/commands/config.py
@@ -1145,7 +1145,7 @@ class ConfigCommand(Command):
 # version to use. If not set below gsutil defaults to API version 1.
 """)
     api_version = 2
-    if cred_type == CredTypes.HMAC: 
+    if cred_type == CredTypes.HMAC:
       api_version = 1
 
     config_file.write('default_api_version = %d\n' % api_version)

--- a/gslib/daisy_chain_wrapper.py
+++ b/gslib/daisy_chain_wrapper.py
@@ -41,7 +41,7 @@ _DEFAULT_DOWNLOAD_CHUNK_SIZE = 1024 * 1024 * 100
 class BufferWrapper(object):
   """Wraps the download file pointer to use our in-memory buffer."""
 
-  def __init__(self, daisy_chain_wrapper):
+  def __init__(self, daisy_chain_wrapper, mode='b'):
     """Provides a buffered write interface for a file download.
 
     Args:
@@ -49,6 +49,10 @@ class BufferWrapper(object):
                            locking.
     """
     self.daisy_chain_wrapper = daisy_chain_wrapper
+    if hasattr(daisy_chain_wrapper, 'mode'):
+      self.mode = daisy_chain_wrapper.mode
+    else:
+      self.mode = mode
 
   def write(self, data):  # pylint: disable=invalid-name
     """Waits for space in the buffer, then writes data to the buffer."""

--- a/gslib/tests/test_cp.py
+++ b/gslib/tests/test_cp.py
@@ -544,9 +544,9 @@ class _DeleteBucketThenStartOverCopyCallbackHandler(object):
 class _ResumableUploadRetryHandler(object):
   """Test callback handler for causing retries during a resumable transfer."""
 
-  def __init__(self, 
-               retry_at_byte, 
-               exception_to_raise, 
+  def __init__(self,
+               retry_at_byte,
+               exception_to_raise,
                exc_args,
                num_retries=1):
     self._retry_at_byte = retry_at_byte

--- a/gslib/tests/test_cp.py
+++ b/gslib/tests/test_cp.py
@@ -544,7 +544,10 @@ class _DeleteBucketThenStartOverCopyCallbackHandler(object):
 class _ResumableUploadRetryHandler(object):
   """Test callback handler for causing retries during a resumable transfer."""
 
-  def __init__(self, retry_at_byte, exception_to_raise, exc_args,
+  def __init__(self, 
+               retry_at_byte, 
+               exception_to_raise, 
+               exc_args,
                num_retries=1):
     self._retry_at_byte = retry_at_byte
     self._exception_to_raise = exception_to_raise

--- a/gslib/tests/test_metrics.py
+++ b/gslib/tests/test_metrics.py
@@ -591,9 +591,9 @@ class _JSONForceHTTPErrorCopyCallbackHandler(object):
 class _ResumableUploadRetryHandler(object):
   """Test callback handler for causing retries during a resumable transfer."""
 
-  def __init__(self, 
-               retry_at_byte, 
-               exception_to_raise, 
+  def __init__(self,
+               retry_at_byte,
+               exception_to_raise,
                exc_args,
                num_retries=1):
     self._retry_at_byte = retry_at_byte

--- a/gslib/tests/test_metrics.py
+++ b/gslib/tests/test_metrics.py
@@ -591,7 +591,10 @@ class _JSONForceHTTPErrorCopyCallbackHandler(object):
 class _ResumableUploadRetryHandler(object):
   """Test callback handler for causing retries during a resumable transfer."""
 
-  def __init__(self, retry_at_byte, exception_to_raise, exc_args,
+  def __init__(self, 
+               retry_at_byte, 
+               exception_to_raise, 
+               exc_args,
                num_retries=1):
     self._retry_at_byte = retry_at_byte
     self._exception_to_raise = exception_to_raise

--- a/gslib/tests/test_util.py
+++ b/gslib/tests/test_util.py
@@ -274,7 +274,7 @@ class TestUtil(testcase.GsUtilUnitTestCase):
                     443 if env_var.lower().startswith('https') else 80))
             # Shouldn't populate info for other variables
             for other_env_var in valid_variables:
-              if other_env_var == env_var: 
+              if other_env_var == env_var:
                 continue
               self._AssertProxyInfosEqual(
                   boto_util.ProxyInfoFromEnvironmentVar(other_env_var),

--- a/gslib/tests/test_util.py
+++ b/gslib/tests/test_util.py
@@ -274,7 +274,8 @@ class TestUtil(testcase.GsUtilUnitTestCase):
                     443 if env_var.lower().startswith('https') else 80))
             # Shouldn't populate info for other variables
             for other_env_var in valid_variables:
-              if other_env_var == env_var: continue
+              if other_env_var == env_var: 
+                continue
               self._AssertProxyInfosEqual(
                   boto_util.ProxyInfoFromEnvironmentVar(other_env_var),
                   httplib2.ProxyInfo(httplib2.socks.PROXY_TYPE_HTTP, None, 0))

--- a/gslib/tests/util.py
+++ b/gslib/tests/util.py
@@ -279,7 +279,8 @@ def GenerationFromURI(uri):
     Generation string for the URI.
   """
   if not (uri.generation or uri.version_id):
-    if uri.scheme == 's3': return 'null'
+    if uri.scheme == 's3': 
+      return 'null'
   return uri.generation or uri.version_id
 
 

--- a/gslib/tests/util.py
+++ b/gslib/tests/util.py
@@ -279,7 +279,7 @@ def GenerationFromURI(uri):
     Generation string for the URI.
   """
   if not (uri.generation or uri.version_id):
-    if uri.scheme == 's3': 
+    if uri.scheme == 's3':
       return 'null'
   return uri.generation or uri.version_id
 

--- a/gslib/utils/copy_helper.py
+++ b/gslib/utils/copy_helper.py
@@ -697,8 +697,8 @@ def ConstructDstUrl(src_url,
     # src_subdir/obj.
     src_url_path_sans_final_dir = GetPathBeforeFinalDir(src_url, exp_src_url)
 
-    dst_key_name = exp_src_url.versionless_url_string[len(
-        src_url_path_sans_final_dir):].lstrip(src_url.delim)
+    dst_key_name = exp_src_url.versionless_url_string[
+        len(src_url_path_sans_final_dir):].lstrip(src_url.delim)
     # Handle case where dst_url is a non-existent subdir.
     if not have_existing_dest_subdir:
       dst_key_name = dst_key_name.partition(src_url.delim)[-1]

--- a/gslib/wildcard_iterator.py
+++ b/gslib/wildcard_iterator.py
@@ -110,7 +110,8 @@ class CloudWildcardIterator(WildcardIterator):
     self.project_id = project_id
     self.logger = logger or logging.getLogger()
 
-  def __iter__(self, bucket_listing_fields=None,
+  def __iter__(self, 
+               bucket_listing_fields=None,
                expand_top_level_buckets=False):
     """Iterator that gets called when iterating over the cloud wildcard.
 

--- a/gslib/wildcard_iterator.py
+++ b/gslib/wildcard_iterator.py
@@ -110,7 +110,7 @@ class CloudWildcardIterator(WildcardIterator):
     self.project_id = project_id
     self.logger = logger or logging.getLogger()
 
-  def __iter__(self, 
+  def __iter__(self,
                bucket_listing_fields=None,
                expand_top_level_buckets=False):
     """Iterator that gets called when iterating over the cloud wildcard.


### PR DESCRIPTION
Hi

I would like to contribute this patch to fix #935. 

This patch modified the initializer of `BufferWrapper` class in `gslib/daisy_chain_wrapper.py`, making it respect the wrapped class mode field or mode from input parameter. The input has a default value 'b' for mode.

With this change, the boto3 could correctly check buffer mode and do the things right under Python3 interpreter.

Please kindly review the patch.

Thanks