### PR TITLE
Updating rsync to separate copy and mirror uses

### DIFF
--- a/gslib/commands/rsync.py
+++ b/gslib/commands/rsync.py
@@ -116,17 +116,12 @@ _DETAILED_HELP_TEXT = ("""
   contents under src_url, by copying any missing files/objects (or those whose
   data has changed), and (if the -d option is specified) deleting any extra
   files/objects. src_url must specify a directory, bucket, or bucket
-  subdirectory. For example, to make gs://mybucket/data match the contents of
-  the local directory "data" you could do:
+  subdirectory. For example, to sync the contents of the local directory "data"
+  to the bucket gs://mybucket/data, you could do:
 
-    gsutil rsync -d data gs://mybucket/data
+    gsutil rsync data gs://mybucket/data
 
   To recurse into directories use the -r option:
-
-    gsutil rsync -d -r data gs://mybucket/data
-
-  To copy only new/changed files without deleting extra files from
-  gs://mybucket/data leave off the -d option:
 
     gsutil rsync -r data gs://mybucket/data
 
@@ -134,29 +129,12 @@ _DETAILED_HELP_TEXT = ("""
   gsutil -m option, to perform parallel (multi-threaded/multi-processing)
   synchronization:
 
-    gsutil -m rsync -d -r data gs://mybucket/data
+    gsutil -m rsync -r data gs://mybucket/data
 
   The -m option typically will provide a large performance boost if either the
   source or destination (or both) is a cloud URL. If both source and
   destination are file URLs the -m option will typically thrash the disk and
   slow synchronization down.
-
-  To make the local directory "data" the same as the contents of
-  gs://mybucket/data:
-
-    gsutil rsync -d -r gs://mybucket/data data
-
-  To make the contents of gs://mybucket2 the same as gs://mybucket1:
-
-    gsutil rsync -d -r gs://mybucket1 gs://mybucket2
-
-  You can also mirror data across local directories:
-
-    gsutil rsync -d -r dir1 dir2
-
-  To mirror your content across clouds:
-
-    gsutil rsync -d -r gs://my-gs-bucket s3://my-s3-bucket
 
   Note 1: Shells (like bash, zsh) sometimes attempt to expand wildcards in ways
   that can be surprising. Also, attempting to copy files whose names contain
@@ -173,15 +151,39 @@ _DETAILED_HELP_TEXT = ("""
   workstation.
 
 
-<B>BE CAREFUL WHEN USING -d OPTION!</B>
+<B>Using -d Option (with caution!) to mirror source and destination.</B>
   The rsync -d option is very useful and commonly used, because it provides a
   means of making the contents of a destination bucket or directory match those
-  of a source bucket or directory. However, please exercise caution when you
+  of a source bucket or directory. This is done by copying all data from the
+  source to the destination and deleting all other data in the destination that
+  is not in the source. Please exercise caution when you
   use this option: It's possible to delete large amounts of data accidentally
-  if, for example, you erroneously reverse source and destination. For example,
-  if you meant to synchronize a local directory from a bucket in the cloud but
-  instead run the command:
+  if, for example, you erroneously reverse source and destination. 
+  
+  To make the local directory "data" the same as the contents of
+  gs://mybucket/data, meaning DELETE all other data in the remote bucket that
+  is not found in the local directory:
 
+    gsutil rsync -d -r gs://mybucket/data data
+
+  To make the contents of gs://mybucket2 the same as gs://mybucket1 and deleting
+  objects that aren't in the source bucket:
+
+    gsutil rsync -d -r gs://mybucket1 gs://mybucket2
+
+  You can also mirror data across local directories. This example will copy all
+  objects from dir1 into dir2 and delete all objects in dir2 which are not in dir1:
+
+    gsutil rsync -d -r dir1 dir2
+
+  To mirror your content across clouds:
+
+    gsutil rsync -d -r gs://my-gs-bucket s3://my-s3-bucket
+
+  As mentioned above, using -d can be dangerous because of how quickly data can
+  be deleted. For example, if you meant to synchronize a local directory from
+  a bucket in the cloud but instead run the command:
+  
     gsutil -m rsync -r -d ./your-dir gs://your-bucket
 
   and your-dir is currently empty, you will quickly delete all of the objects in


### PR DESCRIPTION
Removing the -d delete from the top section and moving it to it's own mirroring section.  The goal is to reduce confusion when people want to sync from source without deleting files and avoid accidental deletion. Internal CL approved: 284841364