### PR TITLE
Update wildcard_iterator.py

### DIFF
--- a/gslib/wildcard_iterator.py
+++ b/gslib/wildcard_iterator.py
@@ -643,10 +643,10 @@ class FileWildcardIterator(WildcardIterator):
     # originated on Windows) os.walk() will not attempt to decode and then die
     # with a "codec can't decode byte" error, and instead we can catch the error
     # at yield time and print a more informative error message.
-    for dirpath, dirnames, filenames in os.walk(directory.encode(UTF8)):
-      dirpath = dirpath.decode(UTF8)
-      dirnames = [dn.decode(UTF8) for dn in dirnames]
-      filenames = [fn.decode(UTF8) for fn in filenames]
+    for dirpath, dirnames, filenames in os.walk(directory.decode(UTF8)):
+      # dirpath = dirpath.decode(UTF8)
+      # dirnames = [dn.decode(UTF8) for dn in dirnames]
+      # filenames = [fn.decode(UTF8) for fn in filenames]
       if self.logger:
         for dirname in dirnames:
           full_dir_path = os.path.join(dirpath, dirname)

--- a/gslib/wildcard_iterator.py
+++ b/gslib/wildcard_iterator.py
@@ -643,10 +643,7 @@ class FileWildcardIterator(WildcardIterator):
     # originated on Windows) os.walk() will not attempt to decode and then die
     # with a "codec can't decode byte" error, and instead we can catch the error
     # at yield time and print a more informative error message.
-    for dirpath, dirnames, filenames in os.walk(directory.decode(UTF8)):
-      # dirpath = dirpath.decode(UTF8)
-      # dirnames = [dn.decode(UTF8) for dn in dirnames]
-      # filenames = [fn.decode(UTF8) for fn in filenames]
+    for dirpath, dirnames, filenames in os.walk(six.ensure_text(directory)):
       if self.logger:
         for dirname in dirnames:
           full_dir_path = os.path.join(dirpath, dirname)


### PR DESCRIPTION
With these changes I was able to upload utf-8 filenames to a bucket using Windows.

> os.walk() will not attempt to decode
I guess this assumption is wrong. os.walk() works well once you provide Unicode string as an argument.

This is not a solution / completed pull request, just wanted to share results of my research