### PR TITLE
All-caps note, caution, and warning callouts.

### DIFF
--- a/gslib/addlhelp/crc32c.py
+++ b/gslib/addlhelp/crc32c.py
@@ -147,7 +147,7 @@ _DETAILED_HELP_TEXT = ("""
   Python it won't work with 32-bit crcmod, and instead you'll need to install
   32-bit Python in order to use crcmod.
 
-  Note: If you have installed crcmod and gsutil hasn't detected it, it may have
+  NOTE: If you have installed crcmod and gsutil hasn't detected it, it may have
   been installed to the wrong directory. It should be located at
   <python_dir>\\files\\Lib\\site-packages\\crcmod\\
 

--- a/gslib/addlhelp/encryption.py
+++ b/gslib/addlhelp/encryption.py
@@ -75,6 +75,7 @@ _DETAILED_HELP_TEXT = ("""
   copies instead uses the destination bucket's default encryption type - if the
   bucket has a default KMS key set, that CMEK is used for encryption; if not,
   Google-managed encryption is used.
+  
   WARNING: This means that when overwriting or rewriting a CSEK- or
   CMEK-encrypted object, if encryption_key is not specified, gsutil will replace
   customer-supplied or customer-managed encryption with Google-managed

--- a/gslib/commands/acl.py
+++ b/gslib/commands/acl.py
@@ -150,8 +150,9 @@ _CH_DESCRIPTION = """
   Cache-Control header of "Cache-Control:private, max-age=0, no-transform" on
   such objects. For help doing this, see "gsutil help setmeta".
 
-  Grant anyone on the internet WRITE access to the bucket example-bucket
-  (WARNING: this is not recommended as you will be responsible for the content):
+  Grant anyone on the internet WRITE access to the bucket example-bucket:
+  
+  WARNING: this is not recommended as you will be responsible for the content
 
     gsutil acl ch -u AllUsers:W gs://example-bucket
 

--- a/gslib/commands/cat.py
+++ b/gslib/commands/cat.py
@@ -52,12 +52,10 @@ _DETAILED_HELP_TEXT = ("""
 
   (The final '-' causes gsutil to stream the output to stdout.)
 
-
-<B>WARNING: DATA INTEGRITY CHECKING NOT DONE</B>
-  The gsutil cat command does not compute a checksum of the downloaded data.
-  Therefore, we recommend that users either perform their own validation of the
-  output of gsutil cat or use gsutil cp or rsync (both of which perform
-  integrity checking automatically).
+  WARNING: The gsutil cat command does not compute a checksum of the
+  downloaded data. Therefore, we recommend that users either perform
+  their own validation of the output of gsutil cat or use gsutil cp
+  or rsync (both of which perform integrity checking automatically).
 
 
 <B>OPTIONS</B>

--- a/gslib/commands/cp.py
+++ b/gslib/commands/cp.py
@@ -442,11 +442,11 @@ _PARALLEL_COMPOSITE_UPLOADS_TEXT = """
   distributions to get crcmod included with the stock distribution. Once that is
   done we will re-enable parallel composite uploads by default in gsutil.
 
-  Warning: Parallel composite uploads should not be used with NEARLINE,
+  WARNING: Parallel composite uploads should not be used with NEARLINE,
   COLDLINE, or ARCHIVE storage class buckets, because doing so incurs an early
   deletion charge for each component object.
   
-  Warning: Parallel composite uploads should not be used in buckets that have a
+  WARNING: Parallel composite uploads should not be used in buckets that have a
   `retention policy <https://cloud.google.com/storage/docs/bucket-lock>`_,
   because the component pieces cannot be deleted until each has met the
   bucket's minimum retention period.
@@ -617,7 +617,7 @@ _OPTIONS_TEXT = """
                  works like the -j option described above, but it applies to
                  all uploaded files, regardless of extension.
 
-                 Warning: If you use this option and some of the source files
+                 CAUTION: If you use this option and some of the source files
                  don't compress well (e.g., that's often true of binary data),
                  this option may result in longer uploads.
 
@@ -764,7 +764,7 @@ _OPTIONS_TEXT = """
                  works like the -z option described above, but it applies to
                  all uploaded files, regardless of extension.
 
-                 Warning: If you use this option and some of the source files
+                 CAUTION: If you use this option and some of the source files
                  don't compress well (e.g., that's often true of binary data),
                  this option may result in files taking up more space in the
                  cloud than they would if left uncompressed.

--- a/gslib/commands/cp.py
+++ b/gslib/commands/cp.py
@@ -117,7 +117,7 @@ _DESCRIPTION_TEXT = """
   The contents of stdin can name files, cloud URLs, and wildcards of files
   and cloud URLs.
 
-  Note: Shells (like bash, zsh) sometimes attempt to expand wildcards in ways
+  NOTE: Shells (like bash, zsh) sometimes attempt to expand wildcards in ways
   that can be surprising. Also, attempting to copy files whose names contain
   wildcard characters can result in problems. For more details about these
   issues see the section "POTENTIALLY SURPRISING BEHAVIOR WHEN USING WILDCARDS"
@@ -167,7 +167,7 @@ _NAME_CONSTRUCTION_TEXT = """
   gs://my-bucket/subdir does not exist, this same gsutil cp command will create
   the object gs://my-bucket/subdir/a/b/c.
 
-  Note: If you use the
+  NOTE: If you use the
   `Google Cloud Platform Console <https://console.cloud.google.com>`_
   to create folders, it does so by creating a "placeholder" object that ends
   with a "/" character. gsutil skips these objects when downloading from the
@@ -314,7 +314,7 @@ _CHECKSUM_VALIDATION_TEXT = """
      by your content pipeline and the time it was uploaded to Google Cloud
      Storage).
 
-  Note: The Content-MD5 header is ignored for composite objects, because such
+  NOTE: The Content-MD5 header is ignored for composite objects, because such
   objects only have a CRC32C checksum.
 """
 
@@ -383,7 +383,7 @@ _STREAMING_TRANSFERS_TEXT = """
   validation, use a non-streaming transfer, which performs integrity checking
   automatically.
 
-  Note: Streaming transfers are not allowed when the top-level gsutil -m flag
+  NOTE: Streaming transfers are not allowed when the top-level gsutil -m flag
   is used.
 """
 
@@ -404,7 +404,7 @@ _SLICED_OBJECT_DOWNLOADS_TEXT = """
   the machine performing the download. If compiled crcmod is not available,
   a non-sliced object download will instead be performed.
 
-  Note: since sliced object downloads cause multiple writes to occur at various
+  NOTE: since sliced object downloads cause multiple writes to occur at various
   locations on disk, this mechanism can degrade performance for disks with slow
   seek times, especially for large numbers of slices. While the default number
   of slices is set small to avoid this problem, you can disable sliced object
@@ -552,17 +552,20 @@ _OPTIONS_TEXT = """
 
   -A             Copy all source versions from a source buckets/folders.
                  If not set, only the live version of each source object is
-                 copied. Note: this option is only useful when the destination
+                 copied.
+                 
+                 NOTE: this option is only useful when the destination
                  bucket has versioning enabled.
 
   -c             If an error occurs, continue to attempt to copy the remaining
                  files. If any copies were unsuccessful, gsutil's exit status
                  will be non-zero even if this flag is set. This option is
-                 implicitly set when running "gsutil -m cp...". Note: -c only
-                 applies to the actual copying operation. If an error occurs
-                 while iterating over the files in the local directory (e.g.,
-                 invalid Unicode file name) gsutil will print an error message
-                 and abort.
+                 implicitly set when running "gsutil -m cp...".
+                 
+                 NOTE: -c only applies to the actual copying operation. If an
+                 error occurs while iterating over the files in the local
+                 directory (e.g., invalid Unicode file name) gsutil will print
+                 an error message and abort.
 
   -D             Copy in "daisy chain" mode, i.e., copying between two buckets
                  by hooking a download to an upload, via the machine where
@@ -578,7 +581,7 @@ _OPTIONS_TEXT = """
                      gsutil cp -D -p gs://bucket/obj gs://bucket/obj_tmp
                      gsutil mv -p gs://bucket/obj_tmp gs://bucket/obj
 
-                 Note: Daisy chain mode is automatically used when copying
+                 NOTE: Daisy chain mode is automatically used when copying
                  between providers (e.g., to copy data from Google Cloud Storage
                  to another provider).
 
@@ -657,7 +660,7 @@ _OPTIONS_TEXT = """
                  status indicates there was at least one failure during the
                  gsutil run).
 
-                 Note: If you're trying to synchronize the contents of a
+                 NOTE: If you're trying to synchronize the contents of a
                  directory and a bucket (or two buckets), see
                  "gsutil help rsync".
 

--- a/gslib/commands/iam.py
+++ b/gslib/commands/iam.py
@@ -76,12 +76,12 @@ _CH_SYNOPSIS = """
       -d ("user"|"serviceAccount"|"domain"|"group"):id
       -d ("allUsers"|"allAuthenticatedUsers")
 
-  Note: The "iam ch" command does not support changing IAM policies with
+  NOTE: The "iam ch" command does not support changing IAM policies with
   bindings that contain conditions. As such, "iam ch" cannot be used to add
   conditions to a policy or to change the policy of a resource that already
   contains conditions. See additional details below.
 
-  Note: The "gsutil iam" command disallows using project convenience groups
+  NOTE: The "gsutil iam" command disallows using project convenience groups
   (projectOwner, projectEditor, projectViewer) as the first segment of a binding
   because these groups go against the principle of least privilege.
 
@@ -154,7 +154,7 @@ _CH_DESCRIPTION = """
   The gsutil -m option may be set to handle object-level operations more
   efficiently.
 
-  Note: The ``iam ch`` command may NOT be used to change the IAM policy of a
+  NOTE: The ``iam ch`` command may NOT be used to change the IAM policy of a
   resource that contains conditions in its policy bindings. Attempts to do so
   will result in an error. To change the IAM policy of such a resource, you can
   perform a read-modify-write operation by using ``gsutil iam get`` to save the

--- a/gslib/commands/ls.py
+++ b/gslib/commands/ls.py
@@ -241,11 +241,12 @@ _DETAILED_HELP_TEXT = ("""
 <B>OPTIONS</B>
   -l          Prints long listing (owner, length).
 
-  -L          Prints even more detail than -l.  Note: If you use this option
-              with the (non-default) XML API it will generate an additional
-              request per object being listed, which makes the -L option run
-              much more slowly (and cost more) using the XML API than the
-              default JSON API.
+  -L          Prints even more detail than -l.
+  
+              Note: If you use this option with the (non-default) XML API it
+              will generate an additional request per object being listed,
+              which makes the -L option run much more slowly (and cost more)
+              using the XML API than the default JSON API.
 
   -d          List matching subdirectory names instead of contents, and do not
               recurse into matching subdirectories even if the -R option is

--- a/gslib/commands/perfdiag.py
+++ b/gslib/commands/perfdiag.py
@@ -124,7 +124,7 @@ _DETAILED_HELP_TEXT = ("""
               throughput experiments. Each process will receive an equal number
               of threads. The default value is 1.
 
-              Note: All specified threads and processes will be created, but may
+              NOTE: All specified threads and processes will be created, but may
               not by saturated with work if too few objects (specified with -n)
               and too few components (specified with -y) are specified.
 
@@ -156,9 +156,11 @@ _DETAILED_HELP_TEXT = ("""
   -s          Sets the size (in bytes) for each of the N (set with -n) objects
               used in the read and write throughput tests. The default is 1 MiB.
               This can also be specified using byte suffixes such as 500K or 1M.
-              Note: these values are interpreted as multiples of 1024 (K=1024,
+              
+              NOTE: these values are interpreted as multiples of 1024 (K=1024,
               M=1024*1024, etc.)
-              Note: If rthru_file or wthru_file are performed, N (set with -n)
+              
+              NOTE: If rthru_file or wthru_file are performed, N (set with -n)
               times as much disk space as specified will be required for the
               operation.
 

--- a/gslib/commands/rsync.py
+++ b/gslib/commands/rsync.py
@@ -392,17 +392,19 @@ _DETAILED_HELP_TEXT = ("""
   -C             If an error occurs, continue to attempt to copy the remaining
                  files. If errors occurred, gsutil's exit status will be
                  non-zero even if this flag is set. This option is implicitly
-                 set when running "gsutil -m rsync...".  Note: -C only applies
-                 to the actual copying operation. If an error occurs while
-                 iterating over the files in the local directory (e.g., invalid
-                 Unicode file name) gsutil will print an error message and
-                 abort.
+                 set when running "gsutil -m rsync...".
+                 
+                 NOTE: -C only applies to the actual copying operation. If an
+                 error occurs while iterating over the files in the local
+                 directory (e.g., invalid Unicode file name) gsutil will print
+                 an error message and abort.
 
   -d             Delete extra files under dst_url not found under src_url. By
-                 default extra files are not deleted. Note: this option can
-                 delete data quickly if you specify the wrong source/destination
-                 combination. See the help section above,
-                 "BE CAREFUL WHEN USING -d OPTION!".
+                 default extra files are not deleted.
+                 
+                 NOTE: this option can delete data quickly if you specify the
+                 wrong source/destination combination. See the help section
+                 above, "BE CAREFUL WHEN USING -d OPTION!".
 
   -e             Exclude symlinks. When specified, symbolic links will be
                  ignored. Note that gsutil does not follow directory symlinks,

--- a/gslib/commands/rsync.py
+++ b/gslib/commands/rsync.py
@@ -436,7 +436,7 @@ _DETAILED_HELP_TEXT = ("""
                  works like the -j option described above, but it applies to
                  all uploaded files, regardless of extension.
 
-                 Warning: If you use this option and some of the source files
+                 CAUTION: If you use this option and some of the source files
                  don't compress well (e.g., that's often true of binary data),
                  this option may result in longer uploads.
 

--- a/gslib/commands/signurl.py
+++ b/gslib/commands/signurl.py
@@ -98,7 +98,7 @@ _DETAILED_HELP_TEXT = ("""
   will be produced for each provided url, authorized
   for the specified HTTP method and valid for the given duration.
 
-  Note: Unlike the gsutil ls command, the signurl command does not support
+  NOTE: Unlike the gsutil ls command, the signurl command does not support
   operations on sub-directories. For example, if you run the command:
 
     gsutil signurl <private-key-file> gs://some-bucket/some-object/

--- a/gslib/commands/stat.py
+++ b/gslib/commands/stat.py
@@ -71,7 +71,7 @@ _DETAILED_HELP_TEXT = ("""
   printed from the command, it still has an exit status of 0 for an existing
   object and 1 for a non-existent object.
 
-  Note: Unlike the gsutil ls command, the stat command does not support
+  NOTE: Unlike the gsutil ls command, the stat command does not support
   operations on sub-directories. For example, if you run the command:
 
     gsutil -q stat gs://some-bucket/some-subdir/

--- a/gslib/commands/update.py
+++ b/gslib/commands/update.py
@@ -74,7 +74,7 @@ _DETAILED_HELP_TEXT = ("""
   instead. This is primarily used for distributing pre-release versions of
   the code to a small group of early test users.
 
-  Note: gsutil periodically checks whether a more recent software update is
+  NOTE: gsutil periodically checks whether a more recent software update is
   available. By default this check is performed every 30 days; you can change
   (or disable) this check by editing the software_update_check_period variable
   in the .boto config file. Note also that gsutil will only check for software

--- a/gslib/commands/web.py
+++ b/gslib/commands/web.py
@@ -99,10 +99,11 @@ _DESCRIPTION = """
      c.storage.googleapis.com (ask your DNS administrator for help with this).
 
   Now if you open a browser and navigate to http://www.example.com, it will
-  display the main page instead of the default bucket listing. Note: It can
-  take time for DNS updates to propagate because of caching used by the DNS,
-  so it may take up to a day for the domain-named bucket website to work after
-  you create the CNAME DNS record.
+  display the main page instead of the default bucket listing.
+  
+  NOTE: It can take time for DNS updates to propagate because of caching used
+  by the DNS, so it may take up to a day for the domain-named bucket website to
+  work after you create the CNAME DNS record.
 
   Additional notes:
 


### PR DESCRIPTION
Additionally, place such callouts on their own lines in places where they're buried in a paragraph.

This formatting provides consistency in callouts and asides, and it should pave the way to addressing b/112876931.