### PR TITLE
Add the -d flag to the options for `gsutil iam ch`

### DIFF
--- a/gslib/commands/iam.py
+++ b/gslib/commands/iam.py
@@ -198,6 +198,8 @@ _CH_DESCRIPTION = """
 <B>CH OPTIONS</B>
   The ``ch`` sub-command has the following options
 
+  -d          Removes roles granted to the specified member.
+
   -R, -r      Performs ``iam ch`` recursively to all objects under the
               specified bucket.
 


### PR DESCRIPTION
This addresses b/147214920, which noted the omission.