### PR TITLE
KMS tests now create KMS keys in the same region as buckets

### DIFF
--- a/gslib/command_runner.py
+++ b/gslib/command_runner.py
@@ -501,7 +501,7 @@ class CommandRunner(object):
       cur_ver = gslib.VERSION
       try:
         cur_ver = LookUpGsutilVersion(gsutil_api, GSUTIL_PUB_TARBALL)
-      except:
+      except Exception:
         return False
 
       with open(last_checked_for_gsutil_update_timestamp_file, 'w') as f:

--- a/gslib/commands/config.py
+++ b/gslib/commands/config.py
@@ -1145,7 +1145,8 @@ class ConfigCommand(Command):
 # version to use. If not set below gsutil defaults to API version 1.
 """)
     api_version = 2
-    if cred_type == CredTypes.HMAC: api_version = 1
+    if cred_type == CredTypes.HMAC:
+      api_version = 1
 
     config_file.write('default_api_version = %d\n' % api_version)
 

--- a/gslib/tests/test_cp.py
+++ b/gslib/tests/test_cp.py
@@ -544,7 +544,10 @@ class _DeleteBucketThenStartOverCopyCallbackHandler(object):
 class _ResumableUploadRetryHandler(object):
   """Test callback handler for causing retries during a resumable transfer."""
 
-  def __init__(self, retry_at_byte, exception_to_raise, exc_args,
+  def __init__(self,
+               retry_at_byte,
+               exception_to_raise,
+               exc_args,
                num_retries=1):
     self._retry_at_byte = retry_at_byte
     self._exception_to_raise = exception_to_raise

--- a/gslib/tests/test_metrics.py
+++ b/gslib/tests/test_metrics.py
@@ -591,7 +591,10 @@ class _JSONForceHTTPErrorCopyCallbackHandler(object):
 class _ResumableUploadRetryHandler(object):
   """Test callback handler for causing retries during a resumable transfer."""
 
-  def __init__(self, retry_at_byte, exception_to_raise, exc_args,
+  def __init__(self,
+               retry_at_byte,
+               exception_to_raise,
+               exc_args,
                num_retries=1):
     self._retry_at_byte = retry_at_byte
     self._exception_to_raise = exception_to_raise

--- a/gslib/tests/test_util.py
+++ b/gslib/tests/test_util.py
@@ -274,7 +274,8 @@ class TestUtil(testcase.GsUtilUnitTestCase):
                     443 if env_var.lower().startswith('https') else 80))
             # Shouldn't populate info for other variables
             for other_env_var in valid_variables:
-              if other_env_var == env_var: continue
+              if other_env_var == env_var:
+                continue
               self._AssertProxyInfosEqual(
                   boto_util.ProxyInfoFromEnvironmentVar(other_env_var),
                   httplib2.ProxyInfo(httplib2.socks.PROXY_TYPE_HTTP, None, 0))

--- a/gslib/tests/testcase/integration_testcase.py
+++ b/gslib/tests/testcase/integration_testcase.py
@@ -1219,7 +1219,7 @@ class GsUtilIntegrationTestCase(base.GsUtilTestCase):
 
 class KmsTestingResources(object):
   """Constants for KMS resource names to be used in integration testing."""
-  KEYRING_LOCATION = 'global'
+  KEYRING_LOCATION = 'us-central1'
   # Since KeyRings and their child resources cannot be deleted, we minimize the
   # number of resources created by using a hard-coded keyRing name.
   KEYRING_NAME = 'keyring-for-gsutil-integration-tests'

--- a/gslib/tests/util.py
+++ b/gslib/tests/util.py
@@ -279,7 +279,8 @@ def GenerationFromURI(uri):
     Generation string for the URI.
   """
   if not (uri.generation or uri.version_id):
-    if uri.scheme == 's3': return 'null'
+    if uri.scheme == 's3':
+      return 'null'
   return uri.generation or uri.version_id
 
 

--- a/gslib/utils/copy_helper.py
+++ b/gslib/utils/copy_helper.py
@@ -697,8 +697,8 @@ def ConstructDstUrl(src_url,
     # src_subdir/obj.
     src_url_path_sans_final_dir = GetPathBeforeFinalDir(src_url, exp_src_url)
 
-    dst_key_name = exp_src_url.versionless_url_string[len(
-        src_url_path_sans_final_dir):].lstrip(src_url.delim)
+    dst_key_name = exp_src_url.versionless_url_string[
+        len(src_url_path_sans_final_dir):].lstrip(src_url.delim)
     # Handle case where dst_url is a non-existent subdir.
     if not have_existing_dest_subdir:
       dst_key_name = dst_key_name.partition(src_url.delim)[-1]

--- a/gslib/wildcard_iterator.py
+++ b/gslib/wildcard_iterator.py
@@ -110,7 +110,8 @@ class CloudWildcardIterator(WildcardIterator):
     self.project_id = project_id
     self.logger = logger or logging.getLogger()
 
-  def __iter__(self, bucket_listing_fields=None,
+  def __iter__(self,
+               bucket_listing_fields=None,
                expand_top_level_buckets=False):
     """Iterator that gets called when iterating over the cloud wildcard.
 


### PR DESCRIPTION
Previously keys were created in 'global', but global doesn't actually mean these keys can be used in any region. Switched the same default region for buckets.
