### PR TITLE
Support service account impersonation for signurl in gsutil

### DIFF
--- a/gslib/cloud_api.py
+++ b/gslib/cloud_api.py
@@ -117,13 +117,7 @@ class CloudApi(object):
     """
     raise NotImplementedError('SetBucketIamPolicy must be overloaded')
 
-  def SignUrl(self,
-              method,
-              duration,
-              path,
-              logger,
-              region,
-              signed_headers,
+  def SignUrl(self, method, duration, path, logger, region, signed_headers,
               string_to_sign_debug):
     """Sign a url using service account's system managed private key.
 

--- a/gslib/cloud_api.py
+++ b/gslib/cloud_api.py
@@ -16,7 +16,6 @@
 
 from __future__ import absolute_import
 from __future__ import division
-from __future__ import print_function
 from __future__ import unicode_literals
 
 
@@ -124,7 +123,7 @@ class CloudApi(object):
     Args:
       method: The HTTP method to be used with the signed URL.
       duration: timedelta for which the constructed signed URL should be valid.
-      path: String path to the bucket of object for signing, in the form
+      path: String path to the bucket or object for signing, in the form
           'bucket' or 'bucket/object'.
       logger: logging.Logger for warning and debug output.
       region: Geographic region in which the requested resource resides.

--- a/gslib/cloud_api.py
+++ b/gslib/cloud_api.py
@@ -15,8 +15,8 @@
 """Gsutil API for interacting with cloud storage providers."""
 
 from __future__ import absolute_import
-from __future__ import print_function
 from __future__ import division
+from __future__ import print_function
 from __future__ import unicode_literals
 
 
@@ -118,13 +118,13 @@ class CloudApi(object):
     raise NotImplementedError('SetBucketIamPolicy must be overloaded')
 
   def SignUrl(self,
-      method,
-      duration,
-      path,
-      logger,
-      region,
-      signed_headers,
-      string_to_sign_debug):
+              method,
+              duration,
+              path,
+              logger,
+              region,
+              signed_headers,
+              string_to_sign_debug):
     """Sign a url using service account's system managed private key.
 
     Args:
@@ -134,8 +134,8 @@ class CloudApi(object):
           'bucket' or 'bucket/object'.
       logger: logging.Logger for warning and debug output.
       region: Geographic region in which the requested resource resides.
-      content_type: Optional Content-Type for the signed URL.
-          HTTP requests using the URL must match this Content-Type.
+      signed_headers: Dict containing the header  info like host
+          content-type etc.
       string_to_sign_debug: If true AND logger is enabled for debug level,
           print string to sign to debug. Used to differentiate user's
           signed URL from the probing permissions-check signed URL.

--- a/gslib/cloud_api.py
+++ b/gslib/cloud_api.py
@@ -148,7 +148,7 @@ class CloudApi(object):
     Returns:
       The signed url.
     """
-    raise NotImplementedError('GetBucket must be overloaded')
+    raise NotImplementedError('SignUrl must be overloaded')
 
   def ListBuckets(self, project_id=None, provider=None, fields=None):
     """Lists bucket metadata for the given project.

--- a/gslib/cloud_api.py
+++ b/gslib/cloud_api.py
@@ -117,6 +117,39 @@ class CloudApi(object):
     """
     raise NotImplementedError('SetBucketIamPolicy must be overloaded')
 
+  def SignUrl(self,
+      method,
+      duration,
+      path,
+      logger,
+      region,
+      signed_headers,
+      string_to_sign_debug):
+    """Sign a url using service account's system managed private key.
+
+    Args:
+      method: The HTTP method to be used with the signed URL.
+      duration: timedelta for which the constructed signed URL should be valid.
+      path: String path to the bucket of object for signing, in the form
+          'bucket' or 'bucket/object'.
+      logger: logging.Logger for warning and debug output.
+      region: Geographic region in which the requested resource resides.
+      content_type: Optional Content-Type for the signed URL.
+          HTTP requests using the URL must match this Content-Type.
+      string_to_sign_debug: If true AND logger is enabled for debug level,
+          print string to sign to debug. Used to differentiate user's
+          signed URL from the probing permissions-check signed URL.
+
+    Raises:
+      ArgumentException for errors during input validation.
+      ServiceException for errors interacting with cloud storage providers.
+      CommandException for errors because of invalid account used for signing.
+
+    Returns:
+      The signed url.
+    """
+    raise NotImplementedError('GetBucket must be overloaded')
+
   def ListBuckets(self, project_id=None, provider=None, fields=None):
     """Lists bucket metadata for the given project.
 

--- a/gslib/cloud_api_delegator.py
+++ b/gslib/cloud_api_delegator.py
@@ -536,15 +536,8 @@ class CloudApiDelegator(CloudApi):
                                                service_account_email,
                                                show_deleted_keys)
 
-  def SignUrl(self,
-              provider,
-              method,
-              duration,
-              path,
-              logger,
-              region,
-              signed_headers,
-              string_to_sign_debug):
+  def SignUrl(self, provider, method, duration, path, logger, region,
+              signed_headers, string_to_sign_debug):
     return self._GetApi(provider).SignUrl(
         method=method,
         duration=duration,
@@ -552,8 +545,7 @@ class CloudApiDelegator(CloudApi):
         logger=logger,
         region=region,
         signed_headers=signed_headers,
-        string_to_sign_debug=string_to_sign_debug
-    )
+        string_to_sign_debug=string_to_sign_debug)
 
   def UpdateHmacKey(self, project_id, access_id, state, etag, provider=None):
     return self._GetApi(provider).UpdateHmacKey(project_id, access_id, state,

--- a/gslib/cloud_api_delegator.py
+++ b/gslib/cloud_api_delegator.py
@@ -536,6 +536,25 @@ class CloudApiDelegator(CloudApi):
                                                service_account_email,
                                                show_deleted_keys)
 
+  def SignUrl(self,
+              provider,
+              method,
+              duration,
+              path,
+              logger,
+              region,
+              signed_headers,
+              string_to_sign_debug):
+    return self._GetApi(provider).SignUrl(
+        method=method,
+        duration=duration,
+        path=path,
+        logger=logger,
+        region=region,
+        signed_headers=signed_headers,
+        string_to_sign_debug=string_to_sign_debug
+    )
+
   def UpdateHmacKey(self, project_id, access_id, state, etag, provider=None):
     return self._GetApi(provider).UpdateHmacKey(project_id, access_id, state,
                                                 etag)

--- a/gslib/commands/signurl.py
+++ b/gslib/commands/signurl.py
@@ -105,8 +105,8 @@ _DETAILED_HELP_TEXT = ("""
   
   If you used `service account credentials
   <https://cloud.google.com/storage/docs/gsutil/addlhelp/CredentialTypesSupportingVariousUseCases#supported-credential-types_1>`_
-  for authentication, you can replace the  <private-key-file> argument
-  by -u or --use-service-account option to use the system-managed private key
+  for authentication, you can replace the  <private-key-file> argument with
+  the -u or --use-service-account option to use the system-managed private key
   directly. This avoids the need to download the private key file.
 
 <B>OPTIONS</B>

--- a/gslib/commands/signurl.py
+++ b/gslib/commands/signurl.py
@@ -91,9 +91,7 @@ _DETAILED_HELP_TEXT = ("""
   NOTE: Unlike the gsutil ls command, the signurl command does not support
   operations on sub-directories. For example, unless you have an object named
   `some-directory/` stored inside the bucket `some-bucket`, the following
-  command returns an error:
-
-    gsutil signurl <private-key-file> gs://some-bucket/some-directory/
+  command returns an error: `gsutil signurl <private-key-file> gs://some-bucket/some-directory/`
 
   The signurl command uses the private key for a service account (the
   '<private-key-file>' argument) to generate the cryptographic
@@ -107,7 +105,7 @@ _DETAILED_HELP_TEXT = ("""
   
   If you used `service account credentials
   <https://cloud.google.com/storage/docs/gsutil/addlhelp/CredentialTypesSupportingVariousUseCases#supported-credential-types_1>`_
-  for authentication then you can replace the  <private-key-file> argument
+  for authentication, you can replace the  <private-key-file> argument
   by -u or --use-service-account option to use the system-managed private key
   directly. This avoids the need to download the private key file.
 

--- a/gslib/commands/signurl.py
+++ b/gslib/commands/signurl.py
@@ -22,12 +22,10 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import unicode_literals
 
-import base64
 import calendar
 from datetime import datetime
 from datetime import timedelta
 import getpass
-# import hashlib
 import json
 import re
 import sys
@@ -40,12 +38,10 @@ from apitools.base.py.http_wrapper import Request
 
 from boto import config
 
-from gslib.cloud_api import AccessDeniedException
 from gslib.command import Command
 from gslib.command_argument import CommandArgument
 from gslib.cs_api_map import ApiSelector
 from gslib.exception import CommandException
-from gslib.impersonation_credentials import ImpersonationCredentials
 from gslib.storage_url import ContainsWildcard
 from gslib.storage_url import StorageUrlFromString
 from gslib.utils.boto_util import GetNewHttp
@@ -73,7 +69,7 @@ _MAX_EXPIRATION_TIME = timedelta(days=7)
 
 _SYNOPSIS = """
   gsutil signurl [-c <content_type>] [-d <duration>] [-m <http_method>] \\
-      [-p <password>] [-r <region>] [-s] keystore-file url...
+      [-p <password>] [-r <region>] [-u] keystore-file url...
 """
 
 _DETAILED_HELP_TEXT = ("""
@@ -241,6 +237,9 @@ def _GenSignedUrl(key,
 
   Args:
     key: The private key to use for signing the URL.
+    api: The CloudApiDelegator instance
+    use_service_account: If True, use the service account credentials
+        instead of using the key file to sign the url
     client_id: Client ID signing this URL.
     method: The HTTP method to be used with the signed URL.
     duration: timedelta for which the constructed signed URL should be valid.

--- a/gslib/commands/signurl.py
+++ b/gslib/commands/signurl.py
@@ -89,9 +89,11 @@ _DETAILED_HELP_TEXT = ("""
   for the specified HTTP method and valid for the given duration.
 
   NOTE: Unlike the gsutil ls command, the signurl command does not support
-  operations on sub-directories. For example, if you run the command:
+  operations on sub-directories. For example, unless you have an object named
+  `some-directory/` stored inside the bucket `some-bucket`, the following
+  command returns an error:
 
-    gsutil signurl <private-key-file> gs://some-bucket/some-object/
+    gsutil signurl <private-key-file> gs://some-bucket/some-directory/
 
   The signurl command uses the private key for a service account (the
   '<private-key-file>' argument) to generate the cryptographic
@@ -102,16 +104,12 @@ _DETAILED_HELP_TEXT = ("""
   key for use with the signurl command please see the `Authentication
   documentation.
   <https://cloud.google.com/storage/docs/authentication#generating-a-private-key>`_
-
-  gsutil will look up information about the object "some-object/" (with a
-  trailing slash) inside bucket "some-bucket", as opposed to operating on
-  objects nested under gs://some-bucket/some-object. Unless you actually
-  have an object with that name, the operation will fail.
   
-  If service account credentials were used for authentication then the 
-  <private-key-file> argument can be replaced by -u or --use-service-account
-  option to use the system-managed private key directly. This avoids the need
-  to download the private key file.
+  If you used `service account credentials
+  <https://cloud.google.com/storage/docs/gsutil/addlhelp/CredentialTypesSupportingVariousUseCases#supported-credential-types_1>`_
+  for authentication then you can replace the  <private-key-file> argument
+  by -u or --use-service-account option to use the system-managed private key
+  directly. This avoids the need to download the private key file.
 
 <B>OPTIONS</B>
   -m           Specifies the HTTP method to be authorized for use
@@ -152,7 +150,8 @@ _DETAILED_HELP_TEXT = ("""
                signed URL to create a bucket.
                
   -u --use-service-account
-               Use service account instead of a key file to sign the url.
+               Use service account credentials instead of a private key file
+               to sign the url.
 
 <B>USAGE</B>
   Create a signed url for downloading an object valid for 10 minutes:
@@ -160,14 +159,12 @@ _DETAILED_HELP_TEXT = ("""
     gsutil signurl -d 10m <private-key-file> gs://<bucket>/<object>
     
   
-  Create a signed url without a private-key:
-  
-    Only applicable if service account's credentials
-    were used to run the command
+  Create a signed url without a private key, using a service account's
+  credentials:
     
     gsutil signurl -d 10m -u gs://<bucket>/<object>
     
-    If impersonating a service account
+  Create a signed url by impersonating a service account:
     
     gsutil -i <service account email> signurl -d 10m -u gs://<bucket>/<object>  
 

--- a/gslib/commands/signurl.py
+++ b/gslib/commands/signurl.py
@@ -296,9 +296,7 @@ def _GenSignedUrl(key,
         signed_headers=signed_headers,
         string_to_sign_debug=string_to_sign_debug)
     raw_signature = sign(key, string_to_sign, digest)
-    final_url = GetFinalUrl(raw_signature,
-                            gs_host,
-                            gcs_path,
+    final_url = GetFinalUrl(raw_signature, gs_host, gcs_path,
                             canonical_query_string)
   return final_url
 
@@ -434,14 +432,8 @@ class UrlSignCommand(Command):
 
     return method, delta, content_type, passwd, region, use_service_account
 
-  def _ProbeObjectAccessWithClient(self,
-                                   key,
-                                   use_service_account,
-                                   provider,
-                                   client_email,
-                                   gcs_path,
-                                   logger,
-                                   region):
+  def _ProbeObjectAccessWithClient(self, key, use_service_account, provider,
+                                   client_email, gcs_path, logger, region):
     """Performs a head request against a signed url to check for read access."""
 
     # Choose a reasonable time in the future; if the user's system clock is
@@ -591,13 +583,9 @@ class UrlSignCommand(Command):
 
       print(url_info_str)
 
-      response_code = self._ProbeObjectAccessWithClient(key,
-                                                        use_service_account,
-                                                        url.scheme,
-                                                        client_email,
-                                                        gcs_path,
-                                                        self.logger,
-                                                        bucket_region)
+      response_code = self._ProbeObjectAccessWithClient(
+          key, use_service_account, url.scheme, client_email, gcs_path,
+          self.logger, bucket_region)
 
       if response_code == 404:
         if url.IsBucket() and method != 'PUT':

--- a/gslib/commands/signurl.py
+++ b/gslib/commands/signurl.py
@@ -108,7 +108,7 @@ _DETAILED_HELP_TEXT = ("""
   objects nested under gs://some-bucket/some-object. Unless you actually
   have an object with that name, the operation will fail.
   
-  If the service account credentials were used for authentication then the 
+  If service account credentials were used for authentication then the 
   <private-key-file> argument can be replaced by -u or --use-service-account
   option to use the system-managed private key directly. This avoids the need
   to download the private key file.
@@ -160,7 +160,7 @@ _DETAILED_HELP_TEXT = ("""
     gsutil signurl -d 10m <private-key-file> gs://<bucket>/<object>
     
   
-  Create a signed url without the private-key:
+  Create a signed url without a private-key:
   
     Only applicable if service account's credentials
     were used to run the command
@@ -240,6 +240,8 @@ def _GenSignedUrl(key,
     api: The CloudApiDelegator instance
     use_service_account: If True, use the service account credentials
         instead of using the key file to sign the url
+    provider: Cloud storage provider to connect to.  If not present,
+        class-wide default is used.
     client_id: Client ID signing this URL.
     method: The HTTP method to be used with the signed URL.
     duration: timedelta for which the constructed signed URL should be valid.

--- a/gslib/commands/signurl.py
+++ b/gslib/commands/signurl.py
@@ -90,8 +90,8 @@ _DETAILED_HELP_TEXT = ("""
 
   NOTE: Unlike the gsutil ls command, the signurl command does not support
   operations on sub-directories. For example, unless you have an object named
-  `some-directory/` stored inside the bucket `some-bucket`, the following
-  command returns an error: `gsutil signurl <private-key-file> gs://some-bucket/some-directory/`
+  ``some-directory/`` stored inside the bucket ``some-bucket``, the following
+  command returns an error: ``gsutil signurl <private-key-file> gs://some-bucket/some-directory/``
 
   The signurl command uses the private key for a service account (the
   '<private-key-file>' argument) to generate the cryptographic

--- a/gslib/gcs_json_api.py
+++ b/gslib/gcs_json_api.py
@@ -319,8 +319,8 @@ class GcsJsonApi(CloudApi):
       return self.credentials.service_account_email
     else:
       raise CommandException(
-          'signurl command can be performed only with a service account or '
-          'imperonsating a service account.')
+          'Cannot get service account email id for the given '
+          'credential type.')
 
   def _GetSignedContent(self, string_to_sign):
     """Returns the Signed Content."""
@@ -333,8 +333,8 @@ class GcsJsonApi(CloudApi):
       return self.credentials.sign_blob(string_to_sign)[1]
     else:
       raise CommandException(
-          'signurl command can be performed only with a service account or '
-          'imperonsating a service account.')
+          'Authentication using a service account is required for signing '
+          'the content.')
 
   def _FieldsContainsAclField(self, fields=None):
     """Checks Returns true if ACL related values are in fields set.

--- a/gslib/gcs_json_api.py
+++ b/gslib/gcs_json_api.py
@@ -65,7 +65,6 @@ from gslib.gcs_json_media import HttpWithNoRetries
 from gslib.gcs_json_media import UploadCallbackConnectionClassFactory
 from gslib.gcs_json_media import WrapDownloadHttpRequest
 from gslib.gcs_json_media import WrapUploadHttpRequest
-from gslib.iamcredentials_api import IamcredentailsApi
 from gslib.impersonation_credentials import ImpersonationCredentials
 from gslib.no_op_credentials import NoOpCredentials
 from gslib.progress_callback import ProgressCallbackWithTimeout

--- a/gslib/gcs_json_api.py
+++ b/gslib/gcs_json_api.py
@@ -433,13 +433,7 @@ class GcsJsonApi(CloudApi):
     except TRANSLATABLE_APITOOLS_EXCEPTIONS as e:
       self._TranslateExceptionAndRaise(e, bucket_name=bucket_name)
 
-  def SignUrl(self,
-              method,
-              duration,
-              path,
-              logger,
-              region,
-              signed_headers,
+  def SignUrl(self, method, duration, path, logger, region, signed_headers,
               string_to_sign_debug):
     """See CloudApi class for function doc strings."""
     service_account_id = self._GetServiceAccountId()
@@ -457,9 +451,7 @@ class GcsJsonApi(CloudApi):
       string_to_sign = string_to_sign.encode(UTF8)
 
     raw_signature = self._GetSignedContent(string_to_sign)
-    return GetFinalUrl(raw_signature,
-                       signed_headers['host'],
-                       path,
+    return GetFinalUrl(raw_signature, signed_headers['host'], path,
                        canonical_query_string)
 
   def GetBucket(self, bucket_name, provider=None, fields=None):

--- a/gslib/gcs_json_api.py
+++ b/gslib/gcs_json_api.py
@@ -56,6 +56,7 @@ from gslib.cloud_api import ResumableUploadAbortException
 from gslib.cloud_api import ResumableUploadException
 from gslib.cloud_api import ResumableUploadStartOverException
 from gslib.cloud_api import ServiceException
+from gslib.exception import CommandException
 from gslib.gcs_json_credentials import SetUpJsonCredentialsAndCache
 from gslib.gcs_json_media import BytesTransferredContainer
 from gslib.gcs_json_media import DownloadCallbackConnectionClassFactory
@@ -64,6 +65,8 @@ from gslib.gcs_json_media import HttpWithNoRetries
 from gslib.gcs_json_media import UploadCallbackConnectionClassFactory
 from gslib.gcs_json_media import WrapDownloadHttpRequest
 from gslib.gcs_json_media import WrapUploadHttpRequest
+from gslib.iamcredentials_api import IamcredentailsApi
+from gslib.impersonation_credentials import ImpersonationCredentials
 from gslib.no_op_credentials import NoOpCredentials
 from gslib.progress_callback import ProgressCallbackWithTimeout
 from gslib.project_id import PopulateProjectId
@@ -94,6 +97,7 @@ from gslib.utils.encryption_helper import CryptoKeyWrapperFromKey
 from gslib.utils.encryption_helper import FindMatchingCSEKInBotoConfig
 from gslib.utils.metadata_util import AddAcceptEncodingGzipIfNeeded
 from gslib.utils.retry_util import LogAndHandleRetries
+from gslib.utils.signurl_helper import CreatePayload, GetFinalUrl
 from gslib.utils.text_util import GetPrintableExceptionString
 from gslib.utils.translation_helper import CreateBucketNotFoundException
 from gslib.utils.translation_helper import CreateNotFoundExceptionForObjectWrite
@@ -101,6 +105,7 @@ from gslib.utils.translation_helper import CreateObjectNotFoundException
 from gslib.utils.translation_helper import DEFAULT_CONTENT_TYPE
 from gslib.utils.translation_helper import PRIVATE_DEFAULT_OBJ_ACL
 from gslib.utils.translation_helper import REMOVE_CORS_CONFIG
+from oauth2client.service_account import ServiceAccountCredentials
 
 if six.PY3:
   long = int
@@ -307,6 +312,31 @@ class GcsJsonApi(CloudApi):
     """Returns an upload-safe Http object (by disabling httplib2 retries)."""
     return GetNewHttp(http_class=HttpWithNoRetries)
 
+  def _GetServiceAccountId(self):
+    """Returns the service account email id."""
+    if isinstance(self.credentials, ImpersonationCredentials):
+      return self.credentials.service_account_id
+    elif isinstance(self.credentials, ServiceAccountCredentials):
+      return self.credentials.service_account_email
+    else:
+      raise CommandException(
+          'signurl command can be performed only with a service account or '
+          'imperonsating a service account.')
+
+  def _GetSignedContent(self, string_to_sign):
+    """Returns the Signed Content."""
+    if isinstance(self.credentials, ImpersonationCredentials):
+      iam_cred_api = self.credentials.api
+      service_account_id = self.credentials.service_account_id
+      response = iam_cred_api.SignBlob(service_account_id, string_to_sign)
+      return response.signedBlob
+    elif isinstance(self.credentials, ServiceAccountCredentials):
+      return self.credentials.sign_blob(string_to_sign)[1]
+    else:
+      raise CommandException(
+          'signurl command can be performed only with a service account or '
+          'imperonsating a service account.')
+
   def _FieldsContainsAclField(self, fields=None):
     """Checks Returns true if ACL related values are in fields set.
 
@@ -403,6 +433,35 @@ class GcsJsonApi(CloudApi):
                                                   global_params=global_params)
     except TRANSLATABLE_APITOOLS_EXCEPTIONS as e:
       self._TranslateExceptionAndRaise(e, bucket_name=bucket_name)
+
+  def SignUrl(self,
+              method,
+              duration,
+              path,
+              logger,
+              region,
+              signed_headers,
+              string_to_sign_debug):
+    """See CloudApi class for function doc strings."""
+    service_account_id = self._GetServiceAccountId()
+    string_to_sign, canonical_query_string = CreatePayload(
+        client_id=service_account_id,
+        method=method,
+        duration=duration,
+        path=path,
+        logger=logger,
+        region=region,
+        signed_headers=signed_headers,
+        string_to_sign_debug=string_to_sign_debug)
+
+    if six.PY3:
+      string_to_sign = string_to_sign.encode(UTF8)
+
+    raw_signature = self._GetSignedContent(string_to_sign)
+    return GetFinalUrl(raw_signature,
+                       signed_headers['host'],
+                       path,
+                       canonical_query_string)
 
   def GetBucket(self, bucket_name, provider=None, fields=None):
     """See CloudApi class for function doc strings."""

--- a/gslib/iamcredentials_api.py
+++ b/gslib/iamcredentials_api.py
@@ -19,7 +19,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import unicode_literals
 
-import datetime
 import json
 import logging
 import traceback
@@ -39,7 +38,6 @@ from gslib.utils.boto_util import GetCertsFile
 from gslib.utils.boto_util import GetMaxRetryDelay
 from gslib.utils.boto_util import GetNewHttp
 from gslib.utils.boto_util import GetNumRetries
-from oauth2client import client
 
 TRANSLATABLE_APITOOLS_EXCEPTIONS = (apitools_exceptions.HttpError)
 
@@ -102,12 +100,13 @@ class IamcredentailsApi(object):
           'key', u'AIzaSyDnacJHrKma0048b13sh8cgxNUwulubmJM')
 
   def SignBlob(self, service_account_id, message):
+    """Sign the blob using iamcredentials.SinbBlob API."""
     name = 'projects/-/serviceAccounts/%s' % service_account_id
     sign_blob_request = apitools_messages.SignBlobRequest(payload=message)
     request = (apitools_messages.
                IamcredentialsProjectsServiceAccountsSignBlobRequest(
-                  name=name,
-                  signBlobRequest=sign_blob_request))
+                   name=name,
+                   signBlobRequest=sign_blob_request))
     try:
       return self.api_client.projects_serviceAccounts.SignBlob(request)
     except TRANSLATABLE_APITOOLS_EXCEPTIONS as e:

--- a/gslib/iamcredentials_api.py
+++ b/gslib/iamcredentials_api.py
@@ -100,7 +100,7 @@ class IamcredentailsApi(object):
           'key', u'AIzaSyDnacJHrKma0048b13sh8cgxNUwulubmJM')
 
   def SignBlob(self, service_account_id, message):
-    """Sign the blob using iamcredentials.SinbBlob API."""
+    """Sign the blob using iamcredentials.SignBlob API."""
     name = 'projects/-/serviceAccounts/%s' % service_account_id
     sign_blob_request = apitools_messages.SignBlobRequest(payload=message)
     request = (

--- a/gslib/iamcredentials_api.py
+++ b/gslib/iamcredentials_api.py
@@ -103,10 +103,9 @@ class IamcredentailsApi(object):
     """Sign the blob using iamcredentials.SinbBlob API."""
     name = 'projects/-/serviceAccounts/%s' % service_account_id
     sign_blob_request = apitools_messages.SignBlobRequest(payload=message)
-    request = (apitools_messages.
-               IamcredentialsProjectsServiceAccountsSignBlobRequest(
-                   name=name,
-                   signBlobRequest=sign_blob_request))
+    request = (
+        apitools_messages.IamcredentialsProjectsServiceAccountsSignBlobRequest(
+            name=name, signBlobRequest=sign_blob_request))
     try:
       return self.api_client.projects_serviceAccounts.SignBlob(request)
     except TRANSLATABLE_APITOOLS_EXCEPTIONS as e:

--- a/gslib/iamcredentials_api.py
+++ b/gslib/iamcredentials_api.py
@@ -101,6 +101,18 @@ class IamcredentailsApi(object):
       self.api_client.AddGlobalParam(
           'key', u'AIzaSyDnacJHrKma0048b13sh8cgxNUwulubmJM')
 
+  def SignBlob(self, service_account_id, message):
+    name = 'projects/-/serviceAccounts/%s' % service_account_id
+    sign_blob_request = apitools_messages.SignBlobRequest(payload=message)
+    request = (apitools_messages.
+               IamcredentialsProjectsServiceAccountsSignBlobRequest(
+                  name=name,
+                  signBlobRequest=sign_blob_request))
+    try:
+      return self.api_client.projects_serviceAccounts.SignBlob(request)
+    except TRANSLATABLE_APITOOLS_EXCEPTIONS as e:
+      raise self._TranslateExceptionAndRaise(e, service_account_id)
+
   def GenerateAccessToken(self, service_account_id, scopes):
     """Generates an access token for the given service account."""
     name = 'projects/-/serviceAccounts/%s' % service_account_id

--- a/gslib/impersonation_credentials.py
+++ b/gslib/impersonation_credentials.py
@@ -46,6 +46,10 @@ class ImpersonationCredentials(client.OAuth2Credentials):
                                                    None,
                                                    scopes=scopes)
 
+  @property
+  def service_account_id(self):
+    return self._service_account_id
+
   def _refresh(self, http):
     # client.Oauth2Credentials converts scopes into a set, so we need to convert
     # back to a list before making the API request.

--- a/gslib/tests/signurl_signatures.py
+++ b/gslib/tests/signurl_signatures.py
@@ -72,3 +72,10 @@ TEST_SIGN_URL_GET_WITH_JSON_KEY = (
     'ential=test%40developer.gserviceaccount.com%2F19000101%2Fasia%'
     '2Fstorage%2Fgoog4_request&x-goog-date=19000101T000555Z&x-goog-'
     'expires=0&x-goog-signedheaders=host')
+
+TEST_SIGN_URL_PUT_WITH_SERVICE_ACCOUNT = (
+    'https://storage.googleapis.com/test/test.txt?x-goog-signature='
+    '66616b655f7369676e6174757265&x-goog-algorithm=GOOG4-RSA-SHA256'
+    '&x-goog-credential=fake_service_account_email%2F19000101%2Fus-'
+    'east1%2Fstorage%2Fgoog4_request&x-goog-date=19000101T000555Z&x'
+    '-goog-expires=3600&x-goog-signedheaders=host')

--- a/gslib/tests/test_signurl.py
+++ b/gslib/tests/test_signurl.py
@@ -23,15 +23,31 @@ from datetime import datetime
 from datetime import timedelta
 import pkgutil
 
+import boto
+
 import gslib.commands.signurl
 from gslib.commands.signurl import HAVE_OPENSSL
 from gslib.exception import CommandException
+from gslib.gcs_json_api import GcsJsonApi
+from gslib.iamcredentials_api import IamcredentailsApi
+from gslib.impersonation_credentials import ImpersonationCredentials
 import gslib.tests.testcase as testcase
-from gslib.tests.testcase.integration_testcase import SkipForS3
+from gslib.tests.testcase.integration_testcase import (
+  SkipForS3, SkipForXML)
 from gslib.tests.util import ObjectToURI as suri
 from gslib.tests.util import SetBotoConfigForTest
 from gslib.tests.util import unittest
 import gslib.tests.signurl_signatures as sigs
+from oauth2client import client
+from oauth2client.service_account import ServiceAccountCredentials
+
+from six import add_move, MovedModule
+add_move(MovedModule('mock', 'mock', 'unittest.mock'))
+from six.moves import mock
+
+
+SERVICE_ACCOUNT = boto.config.get_value('GSUtil',
+                                        'test_impersonate_service_account')
 
 
 # pylint: disable=protected-access
@@ -160,6 +176,25 @@ class TestSignUrl(testcase.GsUtilIntegrationTestCase):
     for obj_url in obj_urls:
       self.assertIn(suri(obj_url), stdout)
 
+  @unittest.skipUnless(SERVICE_ACCOUNT,
+                       'Test requires test_impersonate_service_account.')
+  @SkipForS3('Tests only uses gs credentials.')
+  @SkipForXML('Tests only run on JSON API.')
+  def testSignUrlWithServiceAccount(self):
+    with SetBotoConfigForTest([('Credentials', 'gs_impersonate_service_account',
+                                SERVICE_ACCOUNT)]):
+      stdout, stderr = self.RunGsUtil(
+          ['signurl', '-r', 'us-east1', '-u', 'gs://pub'],
+          return_stdout=True,
+          return_stderr=True)
+    # The signed url returned in stdout relies on current time.
+    # We are not able to mock the datetime here because RunGsUtil creates
+    # a separate process and runs the command.
+    self.assertIn('https://storage.googleapis.com/pub', stdout)
+    self.assertIn(
+        'All API calls will be executed as [%s]' % SERVICE_ACCOUNT,
+        stderr)
+
   def testSignUrlOfNonObjectUrl(self):
     """Tests the signurl output of a non-existent file."""
     self.RunGsUtil(['signurl', self._GetKsFile(), 'gs://'],
@@ -186,6 +221,16 @@ class UnitTestSignUrl(testcase.GsUtilUnitTestCase):
       return datetime(1900, 1, 1, 0, 5, 55)
 
     gslib.utils.signurl_helper._NowUTC = fake_now
+
+  def _get_mock_api_delegator(self):
+    mock_api_delegator = self.MakeGsUtilApi()
+
+    # The MAkeGsUtilAPi maps apiclass.gs.JSON to BotoTranslation
+    # instead of GcsJsonApi
+    # Issue https://github.com/GoogleCloudPlatform/gsutil/issues/970
+    # SignUrl relies on the GcsJsonApi so we are replacing the mapping here.
+    mock_api_delegator.api_map['apiclass']['gs']['JSON'] = GcsJsonApi
+    return mock_api_delegator
 
   def testDurationSpec(self):
     tests = [
@@ -228,6 +273,128 @@ class UnitTestSignUrl(testcase.GsUtilUnitTestCase):
           region='us-east',
           content_type='')
     self.assertEquals(expected, signed_url)
+
+  @SkipForS3('Tests only uses gs credentials.')
+  @SkipForXML('Tests only run on JSON API.')
+  def testSignPutUsingServiceAccount(self):
+    """Tests the _GenSignedUrl function PUT method with service account."""
+    expected = sigs.TEST_SIGN_URL_PUT_WITH_SERVICE_ACCOUNT
+    duration = timedelta(seconds=3600)
+
+    mock_api_delegator = self._get_mock_api_delegator()
+    json_api = mock_api_delegator._GetApi('gs')
+    # patch a service account credentials
+    mock_credentials = mock.Mock(spec=ServiceAccountCredentials)
+    mock_credentials.service_account_email = 'fake_service_account_email'
+    mock_credentials.sign_blob.return_value = ('fake_key', b'fake_signature')
+    json_api.credentials = mock_credentials
+    with SetBotoConfigForTest([('Credentials', 'gs_host',
+                                'storage.googleapis.com')]):
+      signed_url = gslib.commands.signurl._GenSignedUrl(
+          None,
+          api=mock_api_delegator,
+          use_service_account=True,
+          provider='gs',
+          client_id=self.client_email,
+          method='PUT',
+          gcs_path='test/test.txt',
+          duration=duration,
+          logger=self.logger,
+          region='us-east1',
+          content_type='')
+    self.assertEqual(expected, signed_url)
+    mock_credentials.sign_blob.assert_called_once_with(
+        b'GOOG4-RSA-SHA256\n19000101T000555Z\n19000101/us-east1/storage/'
+        b'goog4_request\n7f110b30eeca7fdd8846e876bceee85384d8e4c7388b359'
+        b'6544b1b503f9e2320')
+
+  @SkipForS3('Tests only uses gs credentials.')
+  @SkipForXML('Tests only run on JSON API.')
+  def testSignUrlWithIncorrectAccountType(self):
+    """Tests the _GenSignedUrl with incorrect account type.
+
+    Test that GenSignedUrl function with 'use_service_account' set to True
+    and a service account not used for credentials raises an error.
+    """
+    expected = sigs.TEST_SIGN_URL_PUT_WITH_SERVICE_ACCOUNT
+    duration = timedelta(seconds=3600)
+
+    mock_api_delegator = self._get_mock_api_delegator()
+    json_api = mock_api_delegator._GetApi('gs')
+    # patch a service account credentials
+    mock_credentials = mock.Mock(spec=client.OAuth2Credentials)
+    mock_credentials.service_account_email = 'fake_service_account_email'
+    json_api.credentials = mock_credentials
+    with SetBotoConfigForTest([('Credentials', 'gs_host',
+                                'storage.googleapis.com')]):
+      self.assertRaises(CommandException,
+                        gslib.commands.signurl._GenSignedUrl,
+                        None,
+                        api=mock_api_delegator,
+                        use_service_account=True,
+                        provider='gs',
+                        client_id=self.client_email,
+                        method='PUT',
+                        gcs_path='test/test.txt',
+                        duration=duration,
+                        logger=self.logger,
+                        region='us-east1',
+                        content_type='')
+
+  @SkipForS3('Tests only uses gs credentials.')
+  @SkipForXML('Tests only run on JSON API.')
+  @mock.patch('gslib.iamcredentials_api.apitools_client')
+  @mock.patch('gslib.iamcredentials_api.apitools_messages')
+  def testSignPutUsingImersonatedServiceAccount(self,
+                                                mock_api_messages,
+                                                mock_apiclient):
+    """Tests the _GenSignedUrl function PUT method with impersonation.
+
+    Test _GenSignedUrl function using an impersonated service account.
+    """
+    expected = sigs.TEST_SIGN_URL_PUT_WITH_SERVICE_ACCOUNT
+    duration = timedelta(seconds=3600)
+
+    mock_api_delegator = self._get_mock_api_delegator()
+    json_api = mock_api_delegator._GetApi('gs')
+
+    # A mock object of type ImpersonationCredentials.
+    mock_credentials = mock.Mock(spec=ImpersonationCredentials)
+
+    api_client_obj = mock.Mock()
+    mock_apiclient.IamcredentialsV1.return_value = api_client_obj
+
+    # The api_client.IamcredntialsV1 get's in IamCredentialsApi's init
+    mock_iam_cred_api = IamcredentailsApi(credentials=mock.Mock())
+    mock_credentials.api = mock_iam_cred_api
+    mock_credentials.service_account_id = 'fake_service_account_email'
+
+    # Mock the response and assign it as a  return value for the SignBlob func.
+    mock_resp = mock.Mock()
+    mock_resp.signedBlob = b'fake_signature'
+    api_client_obj.projects_serviceAccounts.SignBlob.return_value = mock_resp
+
+    json_api.credentials = mock_credentials
+
+    with SetBotoConfigForTest([('Credentials', 'gs_host',
+                                'storage.googleapis.com')]):
+      signed_url = gslib.commands.signurl._GenSignedUrl(
+          None,
+          api=mock_api_delegator,
+          use_service_account=True,
+          provider='gs',
+          client_id=self.client_email,
+          method='PUT',
+          gcs_path='test/test.txt',
+          duration=duration,
+          logger=self.logger,
+          region='us-east1',
+          content_type='')
+    self.assertEqual(expected, signed_url)
+    mock_api_messages.SignBlobRequest.assert_called_once_with(
+        payload=b'GOOG4-RSA-SHA256\n19000101T000555Z\n19000101/us-east1'
+                b'/storage/goog4_request\n7f110b30eeca7fdd8846e876bceee'
+                b'85384d8e4c7388b3596544b1b503f9e2320')
 
   def testSignResumableWithKeyFile(self):
     """Tests _GenSignedUrl using key file with a RESUMABLE method."""

--- a/gslib/tests/test_signurl.py
+++ b/gslib/tests/test_signurl.py
@@ -185,7 +185,7 @@ class UnitTestSignUrl(testcase.GsUtilUnitTestCase):
     def fake_now():
       return datetime(1900, 1, 1, 0, 5, 55)
 
-    gslib.commands.signurl._NowUTC = fake_now
+    gslib.utils.signurl_helper._NowUTC = fake_now
 
   def testDurationSpec(self):
     tests = [
@@ -208,8 +208,8 @@ class UnitTestSignUrl(testcase.GsUtilUnitTestCase):
         if expected is not None:
           self.fail('{0} failed to parse')
 
-  def testSignPut(self):
-    """Tests the _GenSignedUrl function with a PUT method."""
+  def testSignPutUsingKeyFile(self):
+    """Tests the _GenSignedUrl function with a PUT method using Key file."""
     expected = sigs.TEST_SIGN_PUT_SIG
 
     duration = timedelta(seconds=3600)
@@ -217,6 +217,9 @@ class UnitTestSignUrl(testcase.GsUtilUnitTestCase):
                                 'storage.googleapis.com')]):
       signed_url = gslib.commands.signurl._GenSignedUrl(
           self.key,
+          api=None,
+          use_service_account=False,
+          provider='gs',
           client_id=self.client_email,
           method='RESUMABLE',
           gcs_path='test/test.txt',
@@ -226,8 +229,8 @@ class UnitTestSignUrl(testcase.GsUtilUnitTestCase):
           content_type='')
     self.assertEquals(expected, signed_url)
 
-  def testSignResumable(self):
-    """Tests the _GenSignedUrl function with a RESUMABLE method."""
+  def testSignResumableWithKeyFile(self):
+    """Tests _GenSignedUrl using key file with a RESUMABLE method."""
     expected = sigs.TEST_SIGN_RESUMABLE
 
     class MockLogger(object):
@@ -244,6 +247,9 @@ class UnitTestSignUrl(testcase.GsUtilUnitTestCase):
                                 'storage.googleapis.com')]):
       signed_url = gslib.commands.signurl._GenSignedUrl(
           self.key,
+          api=None,
+          use_service_account=False,
+          provider='gs',
           client_id=self.client_email,
           method='RESUMABLE',
           gcs_path='test/test.txt',
@@ -260,6 +266,9 @@ class UnitTestSignUrl(testcase.GsUtilUnitTestCase):
                                 'storage.googleapis.com')]):
       signed_url = gslib.commands.signurl._GenSignedUrl(
           self.key,
+          api=None,
+          use_service_account=False,
+          provider='gs',
           client_id=self.client_email,
           method='RESUMABLE',
           gcs_path='test/test.txt',
@@ -270,8 +279,8 @@ class UnitTestSignUrl(testcase.GsUtilUnitTestCase):
     # No warning, since content type was included.
     self.assertFalse(mock_logger2.warning_issued)
 
-  def testSignurlPutContentype(self):
-    """Tests the _GenSignedUrl function a PUT method and content type."""
+  def testSignurlPutContentypeUsingKeyFile(self):
+    """Tests _GenSignedUrl using key file with a PUT method and content type."""
     expected = sigs.TEST_SIGN_URL_PUT_CONTENT
 
     duration = timedelta(seconds=3600)
@@ -279,6 +288,9 @@ class UnitTestSignUrl(testcase.GsUtilUnitTestCase):
                                 'storage.googleapis.com')]):
       signed_url = gslib.commands.signurl._GenSignedUrl(
           self.key,
+          api=None,
+          use_service_account=False,
+          provider='gs',
           client_id=self.client_email,
           method='PUT',
           gcs_path='test/test.txt',
@@ -288,8 +300,8 @@ class UnitTestSignUrl(testcase.GsUtilUnitTestCase):
           content_type='text/plain')
     self.assertEquals(expected, signed_url)
 
-  def testSignurlGet(self):
-    """Tests the _GenSignedUrl function with a GET method."""
+  def testSignurlGetUsingKeyFile(self):
+    """Tests the _GenSignedUrl function using key file with a GET method."""
     expected = sigs.TEST_SIGN_URL_GET
 
     duration = timedelta(seconds=0)
@@ -297,6 +309,9 @@ class UnitTestSignUrl(testcase.GsUtilUnitTestCase):
                                 'storage.googleapis.com')]):
       signed_url = gslib.commands.signurl._GenSignedUrl(
           self.key,
+          api=None,
+          use_service_account=False,
+          provider='gs',
           client_id=self.client_email,
           method='GET',
           gcs_path='test/test.txt',
@@ -306,7 +321,7 @@ class UnitTestSignUrl(testcase.GsUtilUnitTestCase):
           content_type='')
     self.assertEquals(expected, signed_url)
 
-  def testSignurlGetWithJSONKey(self):
+  def testSignurlGetWithJSONKeyUsingKeyFile(self):
     """Tests _GenSignedUrl with a GET method and the test JSON private key."""
     expected = sigs.TEST_SIGN_URL_GET_WITH_JSON_KEY
 
@@ -319,6 +334,9 @@ class UnitTestSignUrl(testcase.GsUtilUnitTestCase):
                                 'storage.googleapis.com')]):
       signed_url = gslib.commands.signurl._GenSignedUrl(
           key,
+          api=None,
+          use_service_account=False,
+          provider='gs',
           client_id=client_email,
           method='GET',
           gcs_path='test/test.txt',

--- a/gslib/tests/test_signurl.py
+++ b/gslib/tests/test_signurl.py
@@ -32,8 +32,7 @@ from gslib.gcs_json_api import GcsJsonApi
 from gslib.iamcredentials_api import IamcredentailsApi
 from gslib.impersonation_credentials import ImpersonationCredentials
 import gslib.tests.testcase as testcase
-from gslib.tests.testcase.integration_testcase import (
-  SkipForS3, SkipForXML)
+from gslib.tests.testcase.integration_testcase import (SkipForS3, SkipForXML)
 from gslib.tests.util import ObjectToURI as suri
 from gslib.tests.util import SetBotoConfigForTest
 from gslib.tests.util import unittest
@@ -44,7 +43,6 @@ from oauth2client.service_account import ServiceAccountCredentials
 from six import add_move, MovedModule
 add_move(MovedModule('mock', 'mock', 'unittest.mock'))
 from six.moves import mock
-
 
 SERVICE_ACCOUNT = boto.config.get_value('GSUtil',
                                         'test_impersonate_service_account')
@@ -191,9 +189,8 @@ class TestSignUrl(testcase.GsUtilIntegrationTestCase):
     # We are not able to mock the datetime here because RunGsUtil creates
     # a separate process and runs the command.
     self.assertIn('https://storage.googleapis.com/pub', stdout)
-    self.assertIn(
-        'All API calls will be executed as [%s]' % SERVICE_ACCOUNT,
-        stderr)
+    self.assertIn('All API calls will be executed as [%s]' % SERVICE_ACCOUNT,
+                  stderr)
 
   def testSignUrlOfNonObjectUrl(self):
     """Tests the signurl output of a non-existent file."""
@@ -345,8 +342,7 @@ class UnitTestSignUrl(testcase.GsUtilUnitTestCase):
   @SkipForXML('Tests only run on JSON API.')
   @mock.patch('gslib.iamcredentials_api.apitools_client')
   @mock.patch('gslib.iamcredentials_api.apitools_messages')
-  def testSignPutUsingImersonatedServiceAccount(self,
-                                                mock_api_messages,
+  def testSignPutUsingImersonatedServiceAccount(self, mock_api_messages,
                                                 mock_apiclient):
     """Tests the _GenSignedUrl function PUT method with impersonation.
 
@@ -393,8 +389,8 @@ class UnitTestSignUrl(testcase.GsUtilUnitTestCase):
     self.assertEqual(expected, signed_url)
     mock_api_messages.SignBlobRequest.assert_called_once_with(
         payload=b'GOOG4-RSA-SHA256\n19000101T000555Z\n19000101/us-east1'
-                b'/storage/goog4_request\n7f110b30eeca7fdd8846e876bceee'
-                b'85384d8e4c7388b3596544b1b503f9e2320')
+        b'/storage/goog4_request\n7f110b30eeca7fdd8846e876bceee'
+        b'85384d8e4c7388b3596544b1b503f9e2320')
 
   def testSignResumableWithKeyFile(self):
     """Tests _GenSignedUrl using key file with a RESUMABLE method."""

--- a/gslib/tests/testcase/unit_testcase.py
+++ b/gslib/tests/testcase/unit_testcase.py
@@ -36,6 +36,7 @@ from gslib.command_runner import CommandRunner
 from gslib.cs_api_map import ApiMapConstants
 from gslib.cs_api_map import ApiSelector
 from gslib.discard_messages_queue import DiscardMessagesQueue
+from gslib.gcs_json_api import GcsJsonApi
 from gslib.tests.mock_logging_handler import MockLoggingHandler
 from gslib.tests.testcase import base
 import gslib.tests.util as util
@@ -73,6 +74,7 @@ class GsutilApiUnitTestClassMapFactory(object):
     gs_class_map = {
         ApiSelector.XML: BotoTranslation,
         ApiSelector.JSON: BotoTranslation
+        #ApiSelector.JSON: GcsJsonApi
     }
     s3_class_map = {ApiSelector.XML: BotoTranslation}
     class_map = {'gs': gs_class_map, 's3': s3_class_map}

--- a/gslib/tests/testcase/unit_testcase.py
+++ b/gslib/tests/testcase/unit_testcase.py
@@ -72,9 +72,12 @@ class GsutilApiUnitTestClassMapFactory(object):
   def GetClassMap(cls):
     """Returns a class map for use in unit tests."""
     gs_class_map = {
-        ApiSelector.XML: BotoTranslation,
-        ApiSelector.JSON: BotoTranslation
-        #ApiSelector.JSON: GcsJsonApi
+        ApiSelector.XML:
+            BotoTranslation,
+        # TODO: This should be replaced with 'ApiSelector.JSON: GcsJsonApi'.
+        # Refer Issue https://github.com/GoogleCloudPlatform/gsutil/issues/970
+        ApiSelector.JSON:
+            BotoTranslation
     }
     s3_class_map = {ApiSelector.XML: BotoTranslation}
     class_map = {'gs': gs_class_map, 's3': s3_class_map}

--- a/gslib/utils/signurl_helper.py
+++ b/gslib/utils/signurl_helper.py
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*-
+# Copyright 2014 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Utility functions for signurl command."""
+
+import base64
+from datetime import datetime
+import hashlib
+import six
+from six.moves import urllib
+
+from boto import config
+
+from gslib.utils.constants import UTF8
+
+_CANONICAL_REQUEST_FORMAT = ('{method}\n{resource}\n{query_string}\n{headers}'                             
+                             '\n{signed_headers}\n{hashed_payload}')
+_SIGNING_ALGO = 'GOOG4-RSA-SHA256'
+_STRING_TO_SIGN_FORMAT = ('{signing_algo}\n{request_time}\n{credential_scope}'
+                          '\n{hashed_request}')
+_SIGNED_URL_FORMAT = ('https://{host}/{path}?x-goog-signature={sig}&'
+                      '{query_string}')
+_UNSIGNED_PAYLOAD = 'UNSIGNED-PAYLOAD'
+
+
+def CreatePayload(client_id,
+                   method,
+                   duration,
+                   path,
+                   logger,
+                   region,
+                   signed_headers,
+                   string_to_sign_debug=False):
+  """TODO: Add function description."""
+  signing_time = datetime.utcnow()
+
+  canonical_day = signing_time.strftime('%Y%m%d')
+  canonical_time = signing_time.strftime('%Y%m%dT%H%M%SZ')
+  canonical_scope = '{date}/{region}/storage/goog4_request'.format(
+      date=canonical_day, region=region)
+
+  signed_query_params = {
+      'x-goog-algorithm': _SIGNING_ALGO,
+      'x-goog-credential': client_id + '/' + canonical_scope,
+      'x-goog-date': canonical_time,
+      'x-goog-signedheaders': ';'.join(sorted(signed_headers.keys())),
+      'x-goog-expires': '%d' % duration.total_seconds()
+  }
+
+  canonical_resource = '/{}'.format(path)
+  canonical_query_string = '&'.join([
+      '{}={}'.format(param, urllib.parse.quote_plus(signed_query_params[param]))
+      for param in sorted(signed_query_params.keys())
+  ])
+  canonical_headers = '\n'.join([
+      '{}:{}'.format(header.lower(), signed_headers[header])
+      for header in sorted(signed_headers.keys())
+  ]) + '\n'
+  canonical_signed_headers = ';'.join(sorted(signed_headers.keys()))
+
+  canonical_request = _CANONICAL_REQUEST_FORMAT.format(
+      method=method,
+      resource=canonical_resource,
+      query_string=canonical_query_string,
+      headers=canonical_headers,
+      signed_headers=canonical_signed_headers,
+      hashed_payload=_UNSIGNED_PAYLOAD)
+
+  if six.PY3:
+    canonical_request = canonical_request.encode(UTF8)
+
+  canonical_request_hasher = hashlib.sha256()
+  canonical_request_hasher.update(canonical_request)
+  hashed_canonical_request = base64.b16encode(
+      canonical_request_hasher.digest()).lower().decode(UTF8)
+
+  string_to_sign = _STRING_TO_SIGN_FORMAT.format(
+      signing_algo=_SIGNING_ALGO,
+      request_time=canonical_time,
+      credential_scope=canonical_scope,
+      hashed_request=hashed_canonical_request)
+
+  if string_to_sign_debug and logger:
+    logger.debug(
+        'Canonical request (ignore opening/closing brackets): [[[%s]]]' %
+        canonical_request)
+    logger.debug('String to sign (ignore opening/closing brackets): [[[%s]]]' %
+                 string_to_sign)
+
+  return string_to_sign, canonical_query_string
+
+
+def GetFinalUrl(raw_signature, host, path, canonical_query_string):
+  signature = (
+      base64.b16encode(raw_signature)
+        .lower()
+        .decode()
+  )  # yapf: disable
+
+  return _SIGNED_URL_FORMAT.format(host=host,
+                                   path=path,
+                                   sig=signature,
+                                   query_string=canonical_query_string)

--- a/gslib/utils/signurl_helper.py
+++ b/gslib/utils/signurl_helper.py
@@ -17,14 +17,12 @@
 import base64
 from datetime import datetime
 import hashlib
+
+from gslib.utils.constants import UTF8
 import six
 from six.moves import urllib
 
-from boto import config
-
-from gslib.utils.constants import UTF8
-
-_CANONICAL_REQUEST_FORMAT = ('{method}\n{resource}\n{query_string}\n{headers}'                             
+_CANONICAL_REQUEST_FORMAT = ('{method}\n{resource}\n{query_string}\n{headers}'
                              '\n{signed_headers}\n{hashed_payload}')
 _SIGNING_ALGO = 'GOOG4-RSA-SHA256'
 _STRING_TO_SIGN_FORMAT = ('{signing_algo}\n{request_time}\n{credential_scope}'
@@ -35,13 +33,13 @@ _UNSIGNED_PAYLOAD = 'UNSIGNED-PAYLOAD'
 
 
 def CreatePayload(client_id,
-                   method,
-                   duration,
-                   path,
-                   logger,
-                   region,
-                   signed_headers,
-                   string_to_sign_debug=False):
+                  method,
+                  duration,
+                  path,
+                  logger,
+                  region,
+                  signed_headers,
+                  string_to_sign_debug=False):
   """TODO: Add function description."""
   signing_time = datetime.utcnow()
 
@@ -102,12 +100,7 @@ def CreatePayload(client_id,
 
 
 def GetFinalUrl(raw_signature, host, path, canonical_query_string):
-  signature = (
-      base64.b16encode(raw_signature)
-        .lower()
-        .decode()
-  )  # yapf: disable
-
+  signature = base64.b16encode(raw_signature).lower().decode()
   return _SIGNED_URL_FORMAT.format(host=host,
                                    path=path,
                                    sig=signature,

--- a/gslib/utils/signurl_helper.py
+++ b/gslib/utils/signurl_helper.py
@@ -32,6 +32,10 @@ _SIGNED_URL_FORMAT = ('https://{host}/{path}?x-goog-signature={sig}&'
 _UNSIGNED_PAYLOAD = 'UNSIGNED-PAYLOAD'
 
 
+def _NowUTC():
+  return datetime.utcnow()
+
+
 def CreatePayload(client_id,
                   method,
                   duration,
@@ -40,8 +44,27 @@ def CreatePayload(client_id,
                   region,
                   signed_headers,
                   string_to_sign_debug=False):
-  """TODO: Add function description."""
-  signing_time = datetime.utcnow()
+  """Create a string that needs to be signed.
+
+  Args:
+    client_id: Client ID signing this URL.
+    method: The HTTP method to be used with the signed URL.
+    duration: timedelta for which the constructed signed URL should be valid.
+    path: String path to the bucket of object for signing, in the form
+        'bucket' or 'bucket/object'.
+    logger: logging.Logger for warning and debug output.
+    region: Geographic region in which the requested resource resides.
+    signed_headers: Dict containing the header  info like host
+          content-type etc.
+    string_to_sign_debug: If true AND logger is enabled for debug level,
+        print string to sign to debug. Used to differentiate user's
+        signed URL from the probing permissions-check signed URL.
+
+  Returns:
+    A tuple where the 1st element is the string to sign.
+    The second element is the query string.
+  """
+  signing_time = _NowUTC()
 
   canonical_day = signing_time.strftime('%Y%m%d')
   canonical_time = signing_time.strftime('%Y%m%dT%H%M%SZ')
@@ -100,6 +123,7 @@ def CreatePayload(client_id,
 
 
 def GetFinalUrl(raw_signature, host, path, canonical_query_string):
+  """Get the final signed url."""
   signature = base64.b16encode(raw_signature).lower().decode()
   return _SIGNED_URL_FORMAT.format(host=host,
                                    path=path,

--- a/gslib/utils/update_util.py
+++ b/gslib/utils/update_util.py
@@ -75,6 +75,7 @@ def DisallowUpdateIfDataInGsutilDir(directory=gslib.GSUTIL_DIR):
   # MANFFEST.in, and most users who drop data into gsutil dir do so at the top
   # level directory.
   addl_excludes = (
+      '.coverage',
       '.DS_Store',
       '.style.yapf',
       '.travis.yml',


### PR DESCRIPTION
The `gsutil signurl` command uses the private key for a service account (the  '<key-file>' argument) to generate the cryptographic  signature for the generated URL. 

However, impersonated credential flow does not involve local credentials/certificates. The aim is to run `signurl` command without using a key-file. To support this,[ iamcredentials.signBlob()](https://cloud.google.com/iam/docs/reference/credentials/rest/v1/projects.serviceAccounts/signBlob) can be used. This method Signs a blob using a service account's system-managed private key and does not require a key-file.

A flag `--use-service-account` or '-u' will be used to let gsutil know that the key file has not been provided. If a service account was impersonated, gsutil will use that account’s credentials to sign the url. If a service account was already used as the default credentials, then those credentials will be used to sign the url.
A typical signurl command looks like this
```
gsutil  signurl -d <duration> -r <region> <keyfile> <url1> <url2>
```
With a service account impersonated, the command would look something like this:
```
gsutil  --impersonate-service-account <service account email id> signurl -d <duration> -r <region> --use-service-account <url1> <url2>
```
A positive side-effect of this feature is that if the command is called using the appropriate service account credentials (say using the boto.config) then we no longer have to explicitly provide the key file.
```
gsutil signurl -d <duration> -r <region> --use-service-account <url1> <url2>
```