### PR TITLE
Small formatting fixes to the docs

### DIFF
--- a/gslib/commands/bucketpolicyonly.py
+++ b/gslib/commands/bucketpolicyonly.py
@@ -71,7 +71,8 @@ _DESCRIPTION = """
   The Bucket Policy Only feature is now known as `uniform bucket-level access
   <https://cloud.google.com/storage/docs/uniform-bucket-level-access>`_.
   The ``bucketpolicyonly`` command is still supported, but we recommend using
-  the equivalent ``ubla`` `command<https://cloud.google.com/storage/docs/gsutil/commands/ubla>`_.
+  the equivalent ``ubla`` `command
+  <https://cloud.google.com/storage/docs/gsutil/commands/ubla>`_.
 
   The ``bucketpolicyonly`` command is used to retrieve or configure the
   uniform bucket-level access setting of Cloud Storage buckets. This command has

--- a/gslib/commands/rsync.py
+++ b/gslib/commands/rsync.py
@@ -151,7 +151,7 @@ _DETAILED_HELP_TEXT = ("""
   workstation.
 
 
-<B>Using ``-d`` Option (with caution!) to mirror source and destination.</B>
+<B>Using -d Option (with caution!) to mirror source and destination.</B>
   The rsync -d option is very useful and commonly used, because it provides a
   means of making the contents of a destination bucket or directory match those
   of a source bucket or directory. This is done by copying all data from the


### PR DESCRIPTION
* Remove `` tags around "-d" in the section header of rsync: the tags were added to force the text to remain lowercase, but the docs generator still capitalizes it, so we'll rely on post processing to take care of this issue.

* Fix the URL tagging in ubla: the docs generator had trouble with the existing syntax. I think there needs to be a space after "command"