### PR TITLE
 Use print instead of text_util.print_to_fd in kms set encryption

### DIFF
--- a/gslib/commands/kms.py
+++ b/gslib/commands/kms.py
@@ -316,8 +316,8 @@ class KmsCommand(Command):
 
     bucket_metadata.encryption = apitools_messages.Bucket.EncryptionValue(
         defaultKmsKeyName=self.kms_key)
-    text_util.print_to_fd('Setting default KMS key for bucket %s...' %
-                          str(bucket_url).rstrip('/'))
+    print('Setting default KMS key for bucket %s...' %
+          str(bucket_url).rstrip('/'))
     self.gsutil_api.PatchBucket(bucket_url.bucket_name,
                                 bucket_metadata,
                                 fields=['encryption'],

--- a/gslib/tests/test_kms.py
+++ b/gslib/tests/test_kms.py
@@ -157,7 +157,7 @@ class TestKmsSubcommandsFailWhenXmlForced(testcase.GsUtilIntegrationTestCase):
       ('Credentials', 'gs_access_key_id', 'dummykey'),
       ('Credentials', 'gs_secret_access_key', 'dummysecret'),
   ]
-  dummy_keyname = ('projects/my-project/locations/global/'
+  dummy_keyname = ('projects/my-project/locations/us-central1/'
                    'keyRings/my-keyring/cryptoKeys/my-key')
 
   def DoTestSubcommandFailsWhenXmlForcedFromHmacInBotoConfig(self, subcommand):
@@ -189,11 +189,12 @@ class TestKmsSubcommandsFailWhenXmlForced(testcase.GsUtilIntegrationTestCase):
 class TestKmsUnitTests(testcase.GsUtilUnitTestCase):
   """Unit tests for gsutil kms."""
 
-  dummy_keyname = ('projects/my-project/locations/global/'
+  dummy_keyname = ('projects/my-project/locations/us-central1/'
                    'keyRings/my-keyring/cryptoKeys/my-key')
 
-  @mock.patch('gslib.boto_translation.CloudApi.GetProjectServiceAccount')
-  @mock.patch('gslib.boto_translation.CloudApi.PatchBucket')
+  @mock.patch(
+      'gslib.cloud_api_delegator.CloudApiDelegator.GetProjectServiceAccount')
+  @mock.patch('gslib.cloud_api_delegator.CloudApiDelegator.PatchBucket')
   @mock.patch('gslib.kms_api.KmsApi.GetKeyIamPolicy')
   @mock.patch('gslib.kms_api.KmsApi.SetKeyIamPolicy')
   def testEncryptionSetKeySucceedsWhenUpdateKeyPolicySucceeds(
@@ -208,9 +209,11 @@ class TestKmsUnitTests(testcase.GsUtilUnitTestCase):
                 suri(bucket_uri)],
         return_stdout=True)
     self.assertIn('Setting default KMS key for bucket', stdout)
+    mock_patch_bucket.assert_called()
 
-  @mock.patch('gslib.boto_translation.CloudApi.GetProjectServiceAccount')
-  @mock.patch('gslib.boto_translation.CloudApi.PatchBucket')
+  @mock.patch(
+      'gslib.cloud_api_delegator.CloudApiDelegator.GetProjectServiceAccount')
+  @mock.patch('gslib.cloud_api_delegator.CloudApiDelegator.PatchBucket')
   @mock.patch('gslib.kms_api.KmsApi.GetKeyIamPolicy')
   @mock.patch('gslib.kms_api.KmsApi.SetKeyIamPolicy')
   def testEncryptionSetKeySucceedsWhenUpdateKeyPolicyFailsWithWarningFlag(
@@ -226,9 +229,11 @@ class TestKmsUnitTests(testcase.GsUtilUnitTestCase):
                 suri(bucket_uri)],
         return_stdout=True)
     self.assertIn('Setting default KMS key for bucket', stdout)
+    mock_patch_bucket.assert_called()
 
-  @mock.patch('gslib.boto_translation.CloudApi.GetProjectServiceAccount')
-  @mock.patch('gslib.boto_translation.CloudApi.PatchBucket')
+  @mock.patch(
+      'gslib.cloud_api_delegator.CloudApiDelegator.GetProjectServiceAccount')
+  @mock.patch('gslib.cloud_api_delegator.CloudApiDelegator.PatchBucket')
   @mock.patch('gslib.kms_api.KmsApi.GetKeyIamPolicy')
   @mock.patch('gslib.kms_api.KmsApi.SetKeyIamPolicy')
   def testEncryptionSetKeyFailsWhenUpdateKeyPolicyFailsWithoutWarningFlag(


### PR DESCRIPTION
This addresses the ordering of the printed messages when the PatchBucket api call fails, since `text_util.print_to_fd` buffers in `stdout` until after the exception is raised to the user, which is printed to `stderr`.

This change depends on https://github.com/GoogleCloudPlatform/gsutil/pull/979