### PR TITLE
Prevent trailing spaces in json output of iam get

### DIFF
--- a/gslib/commands/iam.py
+++ b/gslib/commands/iam.py
@@ -347,6 +347,7 @@ class IamCommand(Command):
     policy_str = json.dumps(
         policy_json,
         sort_keys=True,
+        separators=(',',': '),
         indent=2,
     )
     print(policy_str)


### PR DESCRIPTION
`json.dumps` will output trailing spaces after commas, if an indent is
specified. Explicity defining the separators, i.e., comma without a
space, fixes this.

Closes: https://github.com/GoogleCloudPlatform/gsutil/issues/975

Signed-off-by: Bart Smykla <bsmykla@vmware.com>