### PR TITLE
Remove binary output assumption of stdout in tests

### DIFF
--- a/gslib/tests/test_hash.py
+++ b/gslib/tests/test_hash.py
@@ -42,11 +42,9 @@ class TestHashUnit(testcase.GsUtilUnitTestCase):
   def testHashContents(self):
     tmp_file = self.CreateTempFile(contents=_TEST_FILE_CONTENTS)
     stdout = self.RunCommand('hash', args=[tmp_file], return_stdout=True)
-    self.assertIn(b'Hashes [base64]', stdout)
-    self.assertIn(
-        ('\tHash (crc32c):\t\t%s' % _TEST_FILE_B64_CRC).encode('ascii'), stdout)
-    self.assertIn(('\tHash (md5):\t\t%s' % _TEST_FILE_B64_MD5).encode('ascii'),
-                  stdout)
+    self.assertIn('Hashes [base64]', stdout)
+    self.assertIn(('\tHash (crc32c):\t\t%s' % _TEST_FILE_B64_CRC), stdout)
+    self.assertIn(('\tHash (md5):\t\t%s' % _TEST_FILE_B64_MD5), stdout)
 
   def testHashNoMatch(self):
     try:
@@ -58,11 +56,9 @@ class TestHashUnit(testcase.GsUtilUnitTestCase):
   def testHashHexFormat(self):
     tmp_file = self.CreateTempFile(contents=_TEST_FILE_CONTENTS)
     stdout = self.RunCommand('hash', args=['-h', tmp_file], return_stdout=True)
-    self.assertIn(b'Hashes [hex]', stdout)
-    self.assertIn(
-        ('\tHash (crc32c):\t\t%s' % _TEST_FILE_HEX_CRC).encode('ascii'), stdout)
-    self.assertIn(('\tHash (md5):\t\t%s' % _TEST_FILE_HEX_MD5).encode('ascii'),
-                  stdout)
+    self.assertIn('Hashes [hex]', stdout)
+    self.assertIn(('\tHash (crc32c):\t\t%s' % _TEST_FILE_HEX_CRC), stdout)
+    self.assertIn(('\tHash (md5):\t\t%s' % _TEST_FILE_HEX_MD5), stdout)
 
   def testHashWildcard(self):
     num_test_files = 2
@@ -86,14 +82,11 @@ class TestHashUnit(testcase.GsUtilUnitTestCase):
                                   args=['-c', '-m', tmp_file],
                                   return_stdout=True)
     for stdout in (stdout_crc, stdout_both):
-      self.assertIn(
-          ('\tHash (crc32c):\t\t%s' % _TEST_FILE_B64_CRC).encode('ascii'),
-          stdout)
+      self.assertIn(('\tHash (crc32c):\t\t%s' % _TEST_FILE_B64_CRC), stdout)
     for stdout in (stdout_md5, stdout_both):
-      self.assertIn(
-          ('\tHash (md5):\t\t%s' % _TEST_FILE_B64_MD5).encode('ascii'), stdout)
-    self.assertNotIn(b'md5', stdout_crc)
-    self.assertNotIn(b'crc32c', stdout_md5)
+      self.assertIn(('\tHash (md5):\t\t%s' % _TEST_FILE_B64_MD5), stdout)
+    self.assertNotIn('md5', stdout_crc)
+    self.assertNotIn('crc32c', stdout_md5)
 
 
 class TestHash(testcase.GsUtilIntegrationTestCase):

--- a/gslib/tests/test_help.py
+++ b/gslib/tests/test_help.py
@@ -35,37 +35,37 @@ class HelpUnitTests(testcase.GsUtilUnitTestCase):
 
   def test_help_noargs(self):
     stdout = self.RunCommand('help', return_stdout=True)
-    self.assertIn(b'Available commands', stdout)
+    self.assertIn('Available commands', stdout)
 
   def test_help_subcommand_arg(self):
     stdout = self.RunCommand('help', ['web', 'set'], return_stdout=True)
-    self.assertIn(b'gsutil web set', stdout)
-    self.assertNotIn(b'gsutil web get', stdout)
+    self.assertIn('gsutil web set', stdout)
+    self.assertNotIn('gsutil web get', stdout)
 
   def test_help_invalid_subcommand_arg(self):
     stdout = self.RunCommand('help', ['web', 'asdf'], return_stdout=True)
-    self.assertIn(b'help about one of the subcommands', stdout)
+    self.assertIn('help about one of the subcommands', stdout)
 
   def test_help_with_subcommand_for_command_without_subcommands(self):
     stdout = self.RunCommand('help', ['ls', 'asdf'], return_stdout=True)
-    self.assertIn(b'has no subcommands', stdout)
+    self.assertIn('has no subcommands', stdout)
 
   def test_help_command_arg(self):
     stdout = self.RunCommand('help', ['ls'], return_stdout=True)
-    self.assertIn(b'ls - List providers, buckets', stdout)
+    self.assertIn('ls - List providers, buckets', stdout)
 
   def test_command_help_arg(self):
     stdout = self.RunCommand('ls', ['--help'], return_stdout=True)
-    self.assertIn(b'ls - List providers, buckets', stdout)
+    self.assertIn('ls - List providers, buckets', stdout)
 
   def test_subcommand_help_arg(self):
     stdout = self.RunCommand('web', ['set', '--help'], return_stdout=True)
-    self.assertIn(b'gsutil web set', stdout)
-    self.assertNotIn(b'gsutil web get', stdout)
+    self.assertIn('gsutil web set', stdout)
+    self.assertNotIn('gsutil web get', stdout)
 
   def test_command_args_with_help(self):
     stdout = self.RunCommand('cp', ['foo', 'bar', '--help'], return_stdout=True)
-    self.assertIn(b'cp - Copy files and objects', stdout)
+    self.assertIn('cp - Copy files and objects', stdout)
 
 
 class HelpIntegrationTests(testcase.GsUtilIntegrationTestCase):

--- a/gslib/tests/test_kms.py
+++ b/gslib/tests/test_kms.py
@@ -207,7 +207,7 @@ class TestKmsUnitTests(testcase.GsUtilUnitTestCase):
         'kms', ['encryption', '-k', self.dummy_keyname,
                 suri(bucket_uri)],
         return_stdout=True)
-    self.assertIn(b'Setting default KMS key for bucket', stdout)
+    self.assertIn('Setting default KMS key for bucket', stdout)
 
   @mock.patch('gslib.boto_translation.CloudApi.GetProjectServiceAccount')
   @mock.patch('gslib.boto_translation.CloudApi.PatchBucket')
@@ -225,7 +225,7 @@ class TestKmsUnitTests(testcase.GsUtilUnitTestCase):
         'kms', ['encryption', '-k', self.dummy_keyname, '-w',
                 suri(bucket_uri)],
         return_stdout=True)
-    self.assertIn(b'Setting default KMS key for bucket', stdout)
+    self.assertIn('Setting default KMS key for bucket', stdout)
 
   @mock.patch('gslib.boto_translation.CloudApi.GetProjectServiceAccount')
   @mock.patch('gslib.boto_translation.CloudApi.PatchBucket')

--- a/gslib/tests/test_naming.py
+++ b/gslib/tests/test_naming.py
@@ -523,7 +523,7 @@ class GsutilNamingTests(testcase.GsUtilUnitTestCase):
     stdout = self.RunCommand('cat', [suri(dst_bucket_uri, 'f2.txt')],
                              return_stdout=True)
 
-    f = gzip.GzipFile(fileobj=six.BytesIO(stdout), mode='rb')
+    f = gzip.GzipFile(fileobj=six.BytesIO(six.ensure_binary(stdout)), mode='rb')
     try:
       self.assertEqual(f.read(), b'plaintext')
     finally:
@@ -797,16 +797,15 @@ class GsutilNamingTests(testcase.GsUtilUnitTestCase):
         test_objects=['foo1', 'd0/foo2', 'd1/d2/foo3'])
     output = self.RunCommand('ls', [suri(src_bucket_uri, '*')],
                              return_stdout=True)
-    expected = set(
-        uri.encode(UTF8) for uri in [
-            suri(src_bucket_uri, 'foo1'),
-            suri(src_bucket_uri, 'd1', ':'),
-            suri(src_bucket_uri, 'd1', 'd2') + src_bucket_uri.delim,
-            suri(src_bucket_uri, 'd0', ':'),
-            suri(src_bucket_uri, 'd0', 'foo2')
-        ])
-    expected.add(b'')  # Blank line between subdir listings.
-    actual = set([line.strip() for line in output.split(b'\n')])
+    expected = set([
+        suri(src_bucket_uri, 'foo1'),
+        suri(src_bucket_uri, 'd1', ':'),
+        suri(src_bucket_uri, 'd1', 'd2') + src_bucket_uri.delim,
+        suri(src_bucket_uri, 'd0', ':'),
+        suri(src_bucket_uri, 'd0', 'foo2')
+    ])
+    expected.add('')  # Blank line between subdir listings.
+    actual = set([line.strip() for line in output.split('\n')])
     self.assertEqual(expected, actual)
 
   def testLsBucketRecursive(self):
@@ -815,17 +814,16 @@ class GsutilNamingTests(testcase.GsUtilUnitTestCase):
         test_objects=['foo1', 'd0/foo2', 'd1/d2/foo3'])
     output = self.RunCommand('ls', ['-R', suri(src_bucket_uri, '*')],
                              return_stdout=True)
-    expected = set(
-        uri.encode(UTF8) for uri in [
-            suri(src_bucket_uri, 'foo1'),
-            suri(src_bucket_uri, 'd1', ':'),
-            suri(src_bucket_uri, 'd1', 'd2', ':'),
-            suri(src_bucket_uri, 'd1', 'd2', 'foo3'),
-            suri(src_bucket_uri, 'd0', ':'),
-            suri(src_bucket_uri, 'd0', 'foo2')
-        ])
-    expected.add(b'')  # Blank line between subdir listings.
-    actual = set([line.strip() for line in output.split(b'\n')])
+    expected = set([
+        suri(src_bucket_uri, 'foo1'),
+        suri(src_bucket_uri, 'd1', ':'),
+        suri(src_bucket_uri, 'd1', 'd2', ':'),
+        suri(src_bucket_uri, 'd1', 'd2', 'foo3'),
+        suri(src_bucket_uri, 'd0', ':'),
+        suri(src_bucket_uri, 'd0', 'foo2')
+    ])
+    expected.add('')  # Blank line between subdir listings.
+    actual = set([line.strip() for line in output.split('\n')])
     self.assertEqual(expected, actual)
 
   def testLsBucketRecursiveWithLeadingSlashObjectName(self):
@@ -833,9 +831,9 @@ class GsutilNamingTests(testcase.GsUtilUnitTestCase):
     dst_bucket_uri = self.CreateBucket(test_objects=['f0'])
     output = self.RunCommand('ls', ['-R', suri(dst_bucket_uri, '*')],
                              return_stdout=True)
-    expected = set([suri(dst_bucket_uri, 'f0').encode(UTF8)])
-    expected.add(b'')  # Blank line between subdir listings.
-    actual = set([line.strip() for line in output.split(b'\n')])
+    expected = set([suri(dst_bucket_uri, 'f0')])
+    expected.add('')  # Blank line between subdir listings.
+    actual = set([line.strip() for line in output.split('\n')])
     self.assertEqual(expected, actual)
 
   def testLsBucketSubdirNonRecursive(self):
@@ -845,12 +843,11 @@ class GsutilNamingTests(testcase.GsUtilUnitTestCase):
     output = self.RunCommand('ls', [suri(src_bucket_uri, 'src_subdir')],
                              return_stdout=True)
     expected = set([
-        suri(src_bucket_uri, 'src_subdir', 'foo').encode(UTF8),
-        (suri(src_bucket_uri, 'src_subdir', 'nested') +
-         src_bucket_uri.delim).encode(UTF8)
+        suri(src_bucket_uri, 'src_subdir', 'foo'),
+        (suri(src_bucket_uri, 'src_subdir', 'nested') + src_bucket_uri.delim)
     ])
-    expected.add(b'')  # Blank line between subdir listings.
-    actual = set([line.strip() for line in output.split(b'\n')])
+    expected.add('')  # Blank line between subdir listings.
+    actual = set([line.strip() for line in output.split('\n')])
     self.assertEqual(expected, actual)
 
   def testLsBucketSubdirRecursive(self):
@@ -862,13 +859,13 @@ class GsutilNamingTests(testcase.GsUtilUnitTestCase):
           'ls', ['-R', suri(src_bucket_uri, 'src_subdir') + final_char],
           return_stdout=True)
       expected = set([
-          suri(src_bucket_uri, 'src_subdir', ':').encode(UTF8),
-          suri(src_bucket_uri, 'src_subdir', 'foo').encode(UTF8),
-          suri(src_bucket_uri, 'src_subdir', 'nested', ':').encode(UTF8),
-          suri(src_bucket_uri, 'src_subdir', 'nested', 'foo2').encode(UTF8)
+          suri(src_bucket_uri, 'src_subdir', ':'),
+          suri(src_bucket_uri, 'src_subdir', 'foo'),
+          suri(src_bucket_uri, 'src_subdir', 'nested', ':'),
+          suri(src_bucket_uri, 'src_subdir', 'nested', 'foo2')
       ])
-      expected.add(b'')  # Blank line between subdir listings.
-      actual = set([line.strip() for line in output.split(b'\n')])
+      expected.add('')  # Blank line between subdir listings.
+      actual = set([line.strip() for line in output.split('\n')])
       self.assertEqual(expected, actual)
 
   def testSetAclOnBucketRuns(self):
@@ -1356,7 +1353,7 @@ class GsutilNamingTests(testcase.GsUtilUnitTestCase):
                       contents=b'foo')
     stdout = self.RunCommand('ls', [suri(bucket_uri, object_name)],
                              return_stdout=True)
-    self.assertIn(object_name.encode(UTF8), stdout)
+    self.assertIn(six.ensure_text(object_name), six.ensure_text(stdout))
 
   def testRecursiveListTrailingSlash(self):
     bucket_uri = self.CreateBucket()
@@ -1366,8 +1363,8 @@ class GsutilNamingTests(testcase.GsUtilUnitTestCase):
     stdout = self.RunCommand('ls', ['-R', suri(bucket_uri)], return_stdout=True)
     # Note: The suri function normalizes the URI, so the double slash gets
     # removed.
-    self.assertEqual(stdout.splitlines(), [(suri(obj_uri) + '/:').encode(UTF8),
-                                           (suri(obj_uri) + '/').encode(UTF8)])
+    self.assertEqual(stdout.splitlines(), [(suri(obj_uri) + '/:'),
+                                           (suri(obj_uri) + '/')])
 
   def FinalObjNameComponent(self, uri):
     """For gs://bucket/abc/def/ghi returns ghi."""
@@ -1408,7 +1405,7 @@ class GsUtilCommandTests(testcase.GsUtilUnitTestCase):
     """Test that the cat command basically runs."""
     src_uri = self.CreateObject(contents='foo')
     stdout = self.RunCommand('cat', [suri(src_uri)], return_stdout=True)
-    self.assertEqual(stdout, b'foo')
+    self.assertEqual(stdout, 'foo')
 
   def testGetLoggingCommandRuns(self):
     """Test that the 'logging get' command basically runs."""

--- a/gslib/tests/test_parallel_cp.py
+++ b/gslib/tests/test_parallel_cp.py
@@ -126,7 +126,7 @@ class TestParallelCp(testcase.GsUtilIntegrationTestCase):
     self.assertEqual(suri(dst_bucket_uri, 'dir1', 'foo'), lines[0])
 
   @SkipForS3('The boto lib used for S3 does not handle objects '
-            'starting with slashes if we use V4 signature')
+             'starting with slashes if we use V4 signature')
   @SequentialAndParallelTransfer
   def testCopyingFileToObjectWithConsecutiveSlashes(self):
     """Tests copying a file to an object containing consecutive slashes."""

--- a/gslib/tests/testcase/unit_testcase.py
+++ b/gslib/tests/testcase/unit_testcase.py
@@ -107,10 +107,18 @@ class GsUtilUnitTestCase(base.GsUtilTestCase):
     self.stdout_save = sys.stdout
     self.stderr_save = sys.stderr
     fd, self.stdout_file = tempfile.mkstemp()
-    sys.stdout = os.fdopen(fd, 'wb+')
+    # Specify the encoding explicitly to ensure Windows uses 'utf-8' instead of
+    # the default of 'cp1252'.
+    if six.PY2:
+      sys.stdout = os.fdopen(fd, 'w+')
+    else:
+      sys.stdout = os.fdopen(fd, 'w+', encoding='utf-8')
     fd, self.stderr_file = tempfile.mkstemp()
     # do not set sys.stderr to be 'wb+' - it will blow up the logger
-    sys.stderr = os.fdopen(fd, 'w+')
+    if six.PY2:
+      sys.stderr = os.fdopen(fd, 'w+')
+    else:
+      sys.stderr = os.fdopen(fd, 'w+', encoding='utf-8')
     self.accumulated_stdout = []
     self.accumulated_stderr = []
 
@@ -209,7 +217,7 @@ class GsUtilUnitTestCase(base.GsUtilTestCase):
       One or a tuple of requested return values, depending on whether
       return_stdout, return_stderr, and/or return_log_handler were specified.
       Return Types:
-        stdout - binary
+        stdout - str (binary in Py2, text in Py3)
         stderr - str (binary in Py2, text in Py3)
         log_handler - MockLoggingHandler
     """
@@ -262,8 +270,8 @@ class GsUtilUnitTestCase(base.GsUtilTestCase):
         except UnicodeDecodeError:
           sys.stdout.seek(0)
           sys.stderr.seek(0)
-          stdout = sys.stdout.buffer.read().decode(UTF8)
-          stderr = sys.stderr.buffer.read().decode(UTF8)
+          stdout = sys.stdout.buffer.read()
+          stderr = sys.stderr.buffer.read()
       logging.getLogger(command_name).removeHandler(mock_log_handler)
       mock_log_handler.close()
 


### PR DESCRIPTION
I changed the unit test base class to open stdout in `w+` mode instead of `wb+` mode. In doing so, we bring the fake stdout in line with that provided by `sys.stdout`, and cleans up our test cases since we don't need to explicitly convert all strings to bytes for comparison. 

This is compatible for both python 2 and 3 (note that the file descriptors have the same mode and system-dependent encoding)

```python
Python 2.7.17 (default, Dec 23 2019, 21:25:33)
[GCC 4.2.1 Compatible Apple LLVM 11.0.0 (clang-1100.0.33.16)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import sys
>>> sys.stdout
<open file '<stdout>', mode 'w' at 0x10e0511e0>
>>> open('/tmp/fakefile', 'w+')
<open file '/tmp/fakefile', mode 'w+' at 0x10e17b9c0>
```

```python
Python 3.7.7 (default, Mar 10 2020, 15:43:33)
[Clang 11.0.0 (clang-1100.0.33.17)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import sys
>>> sys.stdout
<_io.TextIOWrapper name='<stdout>' mode='w' encoding='UTF-8'>
>>> open('/tmp/fakefile', 'w+')
<_io.TextIOWrapper name='/tmp/fakefile' mode='w+' encoding='UTF-8'>
```

To support Windows, I needed to specify the `encoding=utf-8` explicitly when opening the file descriptor for writing. Otherwise, by default in Python 3, Windows opens files using the system encoding of `cp1252`. 

```python
Python 3.8.2 (tags/v3.8.2:7b3ab59, Feb 25 2020, 23:03:10) [MSC v.1916 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import sys
>>> sys.stdout
<_io.TextIOWrapper name='<stdout>' mode='w' encoding='utf-8'>
>>> open('fakefile', 'w+')
<_io.TextIOWrapper name='fakefile' mode='w+' encoding='cp1252'>
>>> open('fakefile', 'w+', encoding='utf-8')
<_io.TextIOWrapper name='fakefile' mode='w+' encoding='utf-8'>
```

This PR depends on https://github.com/gsutil-mirrors/boto/pull/10