### PR TITLE
Use V4 signature as default for S3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ matrix:
     # Xenial Tests
     - os: linux
       dist: xenial
+      python: "pypy"
+    - os: linux
+      dist: xenial
       python: "2.7"
     - os: linux
       dist: xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,6 @@ language: python
 
 matrix:
   include:
-    # Trusty Tests
-    - os: linux
-      dist: trusty
-      python: "pypy"
     # Xenial Tests
     - os: linux
       dist: xenial

--- a/gslib/boto_translation.py
+++ b/gslib/boto_translation.py
@@ -685,6 +685,8 @@ class BotoTranslation(CloudApi):
       try:
         cb_handler = DownloadProxyCallbackHandler(start_byte, callback)
         headers = headers.copy()
+        if 'range' in headers:
+          headers.pop('range')
         headers['Range'] = 'bytes=%d-%d' % (start_byte, end_byte)
 
         # Disable AWSAuthConnection-level retry behavior, since that would

--- a/gslib/no_op_auth_plugin.py
+++ b/gslib/no_op_auth_plugin.py
@@ -29,7 +29,7 @@ from boto.auth_handler import AuthHandler
 class NoOpAuth(AuthHandler):
   """No-op authorization plugin class."""
 
-  capability = ['s3']
+  capability = ['hmac-v4-s3', 's3']
 
   def __init__(self, path, config, provider):
     pass

--- a/gslib/tests/test_cp.py
+++ b/gslib/tests/test_cp.py
@@ -1685,7 +1685,7 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
     Regions like us-east2 accept only V4 signature, hence we will create
     the bucket in us-east2 region to enforce testing with V4 signature.
     """
-    src_bucket_uri = self.CreateBucket(provider='s3')
+    src_bucket_uri = self.CreateBucket(provider='s3', location='us-east-2')
     dst_dir = self.CreateTempDir()
     self.CreateObject(bucket_uri=src_bucket_uri,
                       object_name='obj0',
@@ -1714,8 +1714,8 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
 
     _CopyAndCheck()
 
-  @SkipForS3('Boto lib required for S3 does not handle paths '
-             'starting with slash.')
+  @SkipForS3('The boto lib used for S3 does not handle objects '
+             'starting with slashes if we use V4 signature')
   def test_recursive_download_with_leftover_slash_only_dir_placeholder(self):
     """Tests that we correctly handle leftover dir placeholders."""
     src_bucket_uri = self.CreateBucket()

--- a/gslib/tests/test_ls.py
+++ b/gslib/tests/test_ls.py
@@ -732,7 +732,8 @@ class TestLs(testcase.GsUtilIntegrationTestCase):
   def test_recursive_list_trailing_slash(self):
     """Tests listing an object with a trailing slash."""
     bucket_uri = self.CreateBucket()
-    self.CreateObject(bucket_uri=bucket_uri, object_name='foo/',
+    self.CreateObject(bucket_uri=bucket_uri,
+                      object_name='foo/',
                       contents=b'foo')
     self.AssertNObjectsInBucket(bucket_uri, 1)
     stdout = self.RunGsUtil(['ls', '-R', suri(bucket_uri)], return_stdout=True)

--- a/gslib/tests/test_ls.py
+++ b/gslib/tests/test_ls.py
@@ -717,7 +717,9 @@ class TestLs(testcase.GsUtilIntegrationTestCase):
     # Make sure it still exited cleanly.
     self.assertEqual(p.returncode, 0)
 
-  def test_recursive_list_trailing_slash(self):
+  @SkipForS3('Boto lib required for S3 does not handle paths '
+             'starting with slash.')
+  def test_recursive_list_slash_only(self):
     """Tests listing an object with a trailing slash."""
     bucket_uri = self.CreateBucket()
     self.CreateObject(bucket_uri=bucket_uri, object_name='/', contents=b'foo')
@@ -727,6 +729,19 @@ class TestLs(testcase.GsUtilIntegrationTestCase):
     # removed.
     self.assertIn(suri(bucket_uri) + '/', stdout)
 
+  def test_recursive_list_trailing_slash(self):
+    """Tests listing an object with a trailing slash."""
+    bucket_uri = self.CreateBucket()
+    self.CreateObject(bucket_uri=bucket_uri, object_name='foo/',
+                      contents=b'foo')
+    self.AssertNObjectsInBucket(bucket_uri, 1)
+    stdout = self.RunGsUtil(['ls', '-R', suri(bucket_uri)], return_stdout=True)
+    # Note: The suri function normalizes the URI, so the double slash gets
+    # removed.
+    self.assertIn(suri(bucket_uri) + '/foo/', stdout)
+
+  @SkipForS3('Boto lib required for S3 does not handle paths '
+             'starting with slash.')
   def test_recursive_list_trailing_two_slash(self):
     """Tests listing an object with two trailing slashes."""
     bucket_uri = self.CreateBucket()

--- a/gslib/tests/test_parallel_cp.py
+++ b/gslib/tests/test_parallel_cp.py
@@ -40,6 +40,7 @@ from __future__ import unicode_literals
 import os
 
 import gslib.tests.testcase as testcase
+from gslib.tests.testcase.integration_testcase import SkipForS3
 from gslib.tests.util import ObjectToURI as suri
 from gslib.tests.util import SequentialAndParallelTransfer
 from gslib.utils.retry_util import Retry
@@ -124,6 +125,8 @@ class TestParallelCp(testcase.GsUtilIntegrationTestCase):
     lines = self.AssertNObjectsInBucket(dst_bucket_uri, 1)
     self.assertEqual(suri(dst_bucket_uri, 'dir1', 'foo'), lines[0])
 
+  @SkipForS3('Boto lib required for S3 does not handle paths '
+             'starting with slash.')
   @SequentialAndParallelTransfer
   def testCopyingFileToObjectWithConsecutiveSlashes(self):
     """Tests copying a file to an object containing consecutive slashes."""

--- a/gslib/tests/test_parallel_cp.py
+++ b/gslib/tests/test_parallel_cp.py
@@ -125,8 +125,8 @@ class TestParallelCp(testcase.GsUtilIntegrationTestCase):
     lines = self.AssertNObjectsInBucket(dst_bucket_uri, 1)
     self.assertEqual(suri(dst_bucket_uri, 'dir1', 'foo'), lines[0])
 
-  @SkipForS3('Boto lib required for S3 does not handle paths '
-             'starting with slash.')
+  @SkipForS3('The boto lib used for S3 does not handle objects '
+            'starting with slashes if we use V4 signature')
   @SequentialAndParallelTransfer
   def testCopyingFileToObjectWithConsecutiveSlashes(self):
     """Tests copying a file to an object containing consecutive slashes."""

--- a/gslib/tests/test_rm.py
+++ b/gslib/tests/test_rm.py
@@ -508,11 +508,10 @@ class TestRm(testcase.GsUtilIntegrationTestCase):
     if self.multiregional_buckets:
       self.AssertNObjectsInBucket(bucket_uri, 1, versioned=True)
 
-    self._RunRemoveCommandAndCheck(['rm', '-r', suri(bucket_uri)],
-                                   objects_to_remove=[
-                                       '%s#%s' % (suri(ouri1), urigen(ouri1))
-                                   ],
-                                   buckets_to_remove=[suri(bucket_uri)])
+    self._RunRemoveCommandAndCheck(
+        ['rm', '-r', suri(bucket_uri)],
+        objects_to_remove=['%s#%s' % (suri(ouri1), urigen(ouri1))],
+        buckets_to_remove=[suri(bucket_uri)])
 
   def test_rm_object_with_slashes(self):
     """Tests removing a bucket that has objects with slashes."""

--- a/gslib/tests/test_rm.py
+++ b/gslib/tests/test_rm.py
@@ -492,8 +492,8 @@ class TestRm(testcase.GsUtilIntegrationTestCase):
     self._RunRemoveCommandAndCheck(['-q', 'rm', suri(key_uri)], [])
     self.AssertNObjectsInBucket(bucket_uri, 0)
 
-  @SkipForS3('Boto lib required for S3 does not handle paths '
-             'starting with slash.')
+  @SkipForS3('The boto lib used for S3 does not handle objects '
+             'starting with slashes if we use V4 signature')
   def test_rm_object_with_prefix_slash(self):
     """Tests removing a bucket that has an object starting with slash.
 
@@ -536,8 +536,8 @@ class TestRm(testcase.GsUtilIntegrationTestCase):
                                    ],
                                    buckets_to_remove=[suri(bucket_uri)])
 
-  @SkipForS3('Boto lib required for S3 does not handle paths '
-             'starting with slash.')
+  @SkipForS3('The boto lib used for S3 does not handle objects '
+             'starting with slashes if we use V4 signature')
   def test_slasher_horror_film(self):
     """Tests removing a bucket with objects that are filled with slashes."""
     bucket_uri = self.CreateVersionedBucket()

--- a/gslib/tests/test_rm.py
+++ b/gslib/tests/test_rm.py
@@ -492,11 +492,33 @@ class TestRm(testcase.GsUtilIntegrationTestCase):
     self._RunRemoveCommandAndCheck(['-q', 'rm', suri(key_uri)], [])
     self.AssertNObjectsInBucket(bucket_uri, 0)
 
-  def test_rm_object_with_slash(self):
-    """Tests removing a bucket that has an object with a slash in it."""
+  @SkipForS3('Boto lib required for S3 does not handle paths '
+             'starting with slash.')
+  def test_rm_object_with_prefix_slash(self):
+    """Tests removing a bucket that has an object starting with slash.
+
+    The boto lib used for S3 does not handle objects starting with slashes
+    if we use V4 signature. Hence we are testing objects with prefix
+    slashes separately.
+    """
     bucket_uri = self.CreateVersionedBucket()
     ouri1 = self.CreateObject(bucket_uri=bucket_uri,
                               object_name='/dirwithslash/foo',
+                              contents=b'z')
+    if self.multiregional_buckets:
+      self.AssertNObjectsInBucket(bucket_uri, 1, versioned=True)
+
+    self._RunRemoveCommandAndCheck(['rm', '-r', suri(bucket_uri)],
+                                   objects_to_remove=[
+                                       '%s#%s' % (suri(ouri1), urigen(ouri1))
+                                   ],
+                                   buckets_to_remove=[suri(bucket_uri)])
+
+  def test_rm_object_with_slashes(self):
+    """Tests removing a bucket that has objects with slashes."""
+    bucket_uri = self.CreateVersionedBucket()
+    ouri1 = self.CreateObject(bucket_uri=bucket_uri,
+                              object_name='h/e/l//lo',
                               contents=b'z')
     ouri2 = self.CreateObject(bucket_uri=bucket_uri,
                               object_name='dirnoslash/foo',
@@ -515,6 +537,8 @@ class TestRm(testcase.GsUtilIntegrationTestCase):
                                    ],
                                    buckets_to_remove=[suri(bucket_uri)])
 
+  @SkipForS3('Boto lib required for S3 does not handle paths '
+             'starting with slash.')
   def test_slasher_horror_film(self):
     """Tests removing a bucket with objects that are filled with slashes."""
     bucket_uri = self.CreateVersionedBucket()

--- a/gslib/tests/testcase/integration_testcase.py
+++ b/gslib/tests/testcase/integration_testcase.py
@@ -519,7 +519,8 @@ class GsUtilIntegrationTestCase(base.GsUtilTestCase):
                    versioning_enabled=False,
                    bucket_policy_only=False,
                    bucket_name_prefix='',
-                   bucket_name_suffix=''):
+                   bucket_name_suffix='',
+                   location=None):
     """Creates a test bucket.
 
     The bucket and all of its contents will be deleted after the test.
@@ -539,6 +540,7 @@ class GsUtilIntegrationTestCase(base.GsUtilTestCase):
           bucketPolicyOnly attribute to True.
       bucket_name_prefix: Unicode string to be prepended to bucket_name
       bucket_name_suffix: Unicode string to be appended to bucket_name
+      location: The location/region in which the bucket should be created.
 
     Returns:
       StorageUri for the created bucket.
@@ -547,13 +549,15 @@ class GsUtilIntegrationTestCase(base.GsUtilTestCase):
       provider = self.default_provider
 
     # Location is controlled by the -b test flag.
-    if self.multiregional_buckets or provider == 's3':
-      location = None
-    else:
-      # We default to the "us-central1" location for regional buckets, but allow
-      # overriding this value in the Boto config.
-      location = boto.config.get('GSUtil', 'test_cmd_regional_bucket_location',
-                                 'us-central1')
+    if location is None:
+      if self.multiregional_buckets or provider == 's3':
+        location = None
+      else:
+        # We default to the "us-central1" location for regional buckets,
+        # but allow overriding this value in the Boto config.
+        location = boto.config.get('GSUtil',
+                                   'test_cmd_regional_bucket_location',
+                                   'us-central1')
 
     bucket_name_prefix = six.ensure_text(bucket_name_prefix)
     bucket_name_suffix = six.ensure_text(bucket_name_suffix)


### PR DESCRIPTION
Amazon S3 recommends using V4 signature for all the requests. The current implementation of our fork of [boto](https://github.com/gsutil-mirrors/boto) lib uses V2 signature by default for regions which support both V2 and V4 signature.

We have made changes to our boto fork to use V4 signature by default for all regions https://github.com/gsutil-mirrors/boto/pull/11

Using V4 signature makes some of the Integration tests in gsutil to break for S3, because boto lib does not play well with objects starting with slashes, among other things. Hence changes have been made in test cases to skip certain tests for S3 specifically.  The boto lib itself does not support objects starting with slashes, so it is safe to skip these tests for S3.