### PR TITLE
Fix incorrect rendered number of objects when using perfdiag -i

### DIFF
--- a/gslib/cloud_api_delegator.py
+++ b/gslib/cloud_api_delegator.py
@@ -159,8 +159,8 @@ class CloudApiDelegator(CloudApi):
       raise ArgumentException('No provider selected for CloudApi')
 
     if (selected_provider not in self.api_map[ApiMapConstants.DEFAULT_MAP] or
-        self.api_map[ApiMapConstants.DEFAULT_MAP][selected_provider] not in
-        self.api_map[ApiMapConstants.API_MAP][selected_provider]):
+        self.api_map[ApiMapConstants.DEFAULT_MAP][selected_provider]
+        not in self.api_map[ApiMapConstants.API_MAP][selected_provider]):
       raise ArgumentException('No default api available for provider %s' %
                               selected_provider)
 

--- a/gslib/commands/perfdiag.py
+++ b/gslib/commands/perfdiag.py
@@ -1037,7 +1037,8 @@ class PerfDiagCommand(Command):
         'file_size': self.thru_filesize,
         'processes': self.processes,
         'threads': self.threads,
-        'parallelism': self.parallel_strategy
+        'parallelism': self.parallel_strategy,
+        'num_objects': self.num_objects
     }
 
     # Copy the file(s) to the test bucket, and also get the serialization data
@@ -1127,7 +1128,8 @@ class PerfDiagCommand(Command):
         'threads': self.threads,
         'parallelism': self.parallel_strategy,
         'gzip_encoded_writes': self.gzip_encoded_writes,
-        'gzip_compression_ratio': self.gzip_compression_ratio
+        'gzip_compression_ratio': self.gzip_compression_ratio,
+        'num_objects': self.num_objects
     }
 
     # Warmup the TCP connection.
@@ -1819,7 +1821,8 @@ class PerfDiagCommand(Command):
       write_thru = self.results['write_throughput']
       text_util.print_to_fd(
           'Copied %s %s file(s) for a total transfer size of %s.' %
-          (self.num_objects, MakeHumanReadable(write_thru['file_size']),
+          (write_thru.get('num_objects', self.num_objects),
+           MakeHumanReadable(write_thru['file_size']),
            MakeHumanReadable(write_thru['total_bytes_copied'])))
       text_util.print_to_fd(
           'Write throughput: %s/s.' %
@@ -1836,7 +1839,8 @@ class PerfDiagCommand(Command):
       write_thru_file = self.results['write_throughput_file']
       text_util.print_to_fd(
           'Copied %s %s file(s) for a total transfer size of %s.' %
-          (self.num_objects, MakeHumanReadable(write_thru_file['file_size']),
+          (write_thru_file.get('num_objects', self.num_objects),
+           MakeHumanReadable(write_thru_file['file_size']),
            MakeHumanReadable(write_thru_file['total_bytes_copied'])))
       text_util.print_to_fd(
           'Write throughput: %s/s.' %
@@ -1853,7 +1857,8 @@ class PerfDiagCommand(Command):
       read_thru = self.results['read_throughput']
       text_util.print_to_fd(
           'Copied %s %s file(s) for a total transfer size of %s.' %
-          (self.num_objects, MakeHumanReadable(read_thru['file_size']),
+          (read_thru.get('num_objects', self.num_objects),
+           MakeHumanReadable(read_thru['file_size']),
            MakeHumanReadable(read_thru['total_bytes_copied'])))
       text_util.print_to_fd(
           'Read throughput: %s/s.' %
@@ -1870,7 +1875,8 @@ class PerfDiagCommand(Command):
       read_thru_file = self.results['read_throughput_file']
       text_util.print_to_fd(
           'Copied %s %s file(s) for a total transfer size of %s.' %
-          (self.num_objects, MakeHumanReadable(read_thru_file['file_size']),
+          (read_thru_file.get('num_objects', self.num_objects),
+           MakeHumanReadable(read_thru_file['file_size']),
            MakeHumanReadable(read_thru_file['total_bytes_copied'])))
       text_util.print_to_fd(
           'Read throughput: %s/s.' %

--- a/gslib/wildcard_iterator.py
+++ b/gslib/wildcard_iterator.py
@@ -238,8 +238,8 @@ class CloudWildcardIterator(WildcardIterator):
             if obj_or_prefix.datatype == CloudApi.CsObjectOrPrefixType.OBJECT:
               gcs_object = obj_or_prefix.data
               if prog.match(gcs_object.name):
-                if not suffix_wildcard or (StripOneSlash(
-                    gcs_object.name) == suffix_wildcard):
+                if not suffix_wildcard or (StripOneSlash(gcs_object.name)
+                                           == suffix_wildcard):
                   if not single_version_request or (self._SingleVersionMatches(
                       gcs_object.generation)):
                     yield self._GetObjectRef(


### PR DESCRIPTION
Because the value passed to -n wasn't stored in the output file (when
-o is provided), running `perfdiag -i` with that file would
render inconsistent data for throughput tests.

Like in the example below, where 5 is default value for -n.

```
Copied 5 20 MiB file(s) for a total transfer size of 1.95 GiB.
```

For the record, when provided both -n and -i, perfdiag would render
something like in the example below, where 999 is value passed to -n.

```
Copied 999 20 MiB file(s) for a total transfer size of 1.95 GiB.
```

Now the number passed to -n is stored in the results, and used to
render the proper output. The previous behavior is preserved for
backward compatibility reasons, in case of running perfdiag -i with an
old file.