### PR TITLE
Log GCS service-account key used to sign urls.

### DIFF
--- a/gslib/gcs_json_api.py
+++ b/gslib/gcs_json_api.py
@@ -328,6 +328,9 @@ class GcsJsonApi(CloudApi):
       iam_cred_api = self.credentials.api
       service_account_id = self.credentials.service_account_id
       response = iam_cred_api.SignBlob(service_account_id, string_to_sign)
+      self.logger.debug(
+        'Key ID used to sign blob for service account "%s": "%s"' % (
+          service_account_id, response.keyId))
       return response.signedBlob
     elif isinstance(self.credentials, ServiceAccountCredentials):
       return self.credentials.sign_blob(string_to_sign)[1]

--- a/gslib/gcs_json_api.py
+++ b/gslib/gcs_json_api.py
@@ -329,8 +329,8 @@ class GcsJsonApi(CloudApi):
       service_account_id = self.credentials.service_account_id
       response = iam_cred_api.SignBlob(service_account_id, string_to_sign)
       self.logger.debug(
-        'Key ID used to sign blob for service account "%s": "%s"' % (
-          service_account_id, response.keyId))
+          'Key ID used to sign blob for service account "%s": "%s"' %
+          (service_account_id, response.keyId))
       return response.signedBlob
     elif isinstance(self.credentials, ServiceAccountCredentials):
       return self.credentials.sign_blob(string_to_sign)[1]


### PR DESCRIPTION
When --use-service-account (-u) is used to sign URLs, allow debug
logging to record the Key ID used. This can then be looked up with
'gcloud iam service-accounts keys list' to find its expiration date.

b/154569245