### PR TITLE
Signurl: Restrict duration to 12 hours when -u flag is used

### DIFF
--- a/gslib/commands/signurl.py
+++ b/gslib/commands/signurl.py
@@ -157,8 +157,8 @@ _DETAILED_HELP_TEXT = ("""
   -u           Use service account credentials instead of a private key file
                to sign the url.
 
-               You can also use the --use-service-account option,
-               which is equivalent to -u.
+               You can also use the ``--use-service-account`` option,
+               which is equivalent to ``-u``.
                Note that both options have a maximum allowed duration of
                12 hours for a valid link.
 

--- a/gslib/commands/signurl.py
+++ b/gslib/commands/signurl.py
@@ -129,12 +129,12 @@ _DETAILED_HELP_TEXT = ("""
                the duration the link remains valid is the sum of all the
                duration options.
 
-               The max duration allowed is 7d when private-key-file is used.
+               The max duration allowed is 7 days when ``private-key-file``
+               is used.
 
                The max duration allowed is 12 hours when -u option is used.
-               This limitation exists because the system managed key used for
-               signing the url is guaranteed to remain valid for
-               at least 12 hours.
+               This limitation exists because the system managed key used to
+               sign the url is guaranteed to remain valid for at least 12 hours.
 
   -c           Specifies the content type for which the signed url is
                valid for.
@@ -158,8 +158,8 @@ _DETAILED_HELP_TEXT = ("""
                to sign the url.
 
                You can equivalently use --use-service-account instead of -u.
-               Note that the max alloweod duration is 12 hours if this option
-               is used.
+               The max alloweod duration for the valid link is 12 hours
+               if you use --use-service-account or -u option.
 
 <B>USAGE</B>
   Create a signed url for downloading an object valid for 10 minutes:

--- a/gslib/commands/signurl.py
+++ b/gslib/commands/signurl.py
@@ -134,7 +134,7 @@ _DETAILED_HELP_TEXT = ("""
 
                The max duration allowed is 12 hours when -u option is used.
                This limitation exists because the system-managed key used to
-               sign the url is guaranteed to remain valid for at least 12 hours.
+               sign the url may not remain valid after 12 hours.
 
   -c           Specifies the content type for which the signed url is
                valid for.

--- a/gslib/commands/signurl.py
+++ b/gslib/commands/signurl.py
@@ -157,9 +157,10 @@ _DETAILED_HELP_TEXT = ("""
   -u           Use service account credentials instead of a private key file
                to sign the url.
 
-               You can equivalently use --use-service-account instead of -u.
-               The max alloweod duration for the valid link is 12 hours
-               if you use --use-service-account or -u option.
+               You can also use the --use-service-account option,
+               which is equivalent to -u.
+               Note that both options have a maximum allowed duration of
+               12 hours for a valid link.
 
 <B>USAGE</B>
   Create a signed url for downloading an object valid for 10 minutes:

--- a/gslib/commands/signurl.py
+++ b/gslib/commands/signurl.py
@@ -66,6 +66,7 @@ except ImportError:
 
 _AUTO_DETECT_REGION = 'auto'
 _MAX_EXPIRATION_TIME = timedelta(days=7)
+_MAX_EXPIRATION_TIME_WITH_MINUS_U = timedelta(hours=12)
 
 _SYNOPSIS = """
   gsutil signurl [-c <content_type>] [-d <duration>] [-m <http_method>] \\
@@ -128,7 +129,12 @@ _DETAILED_HELP_TEXT = ("""
                the duration the link remains valid is the sum of all the
                duration options.
 
-               The max duration allowed is 7d.
+               The max duration allowed is 7d when private-key-file is used.
+
+               The max duration allowed is 12 hours when -u option is used.
+               This limitation exists because the system managed key used for
+               signing the url is guaranteed to remain valid for
+               at least 12 hours.
 
   -c           Specifies the content type for which the signed url is
                valid for.
@@ -151,7 +157,9 @@ _DETAILED_HELP_TEXT = ("""
   -u           Use service account credentials instead of a private key file
                to sign the url.
 
-               You can equivalently use --use-service-account instead of -u
+               You can equivalently use --use-service-account instead of -u.
+               Note that the max alloweod duration is 12 hours if this option
+               is used.
 
 <B>USAGE</B>
   Create a signed url for downloading an object valid for 10 minutes:
@@ -414,7 +422,15 @@ class UrlSignCommand(Command):
     if delta is None:
       delta = timedelta(hours=1)
     else:
-      if delta > _MAX_EXPIRATION_TIME:
+      if use_service_account and delta > _MAX_EXPIRATION_TIME_WITH_MINUS_U:
+        # This restriction comes from the IAM SignBlob API. The SignBlob
+        # API uses a system-managed key which can guarantee validation only
+        # up to 12 hours. b/156160482#comment4
+        raise CommandException(
+            'Max valid duration allowed is %s when -u flag is used. For longer'
+            ' duration, consider using the private-key-file instead of the -u'
+            ' option.' % _MAX_EXPIRATION_TIME_WITH_MINUS_U)
+      elif delta > _MAX_EXPIRATION_TIME:
         raise CommandException('Max valid duration allowed is '
                                '%s' % _MAX_EXPIRATION_TIME)
 

--- a/gslib/commands/signurl.py
+++ b/gslib/commands/signurl.py
@@ -133,7 +133,7 @@ _DETAILED_HELP_TEXT = ("""
                is used.
 
                The max duration allowed is 12 hours when -u option is used.
-               This limitation exists because the system managed key used to
+               This limitation exists because the system-managed key used to
                sign the url is guaranteed to remain valid for at least 12 hours.
 
   -c           Specifies the content type for which the signed url is

--- a/gslib/tests/test_signurl.py
+++ b/gslib/tests/test_signurl.py
@@ -90,6 +90,14 @@ class TestSignUrl(testcase.GsUtilIntegrationTestCase):
     self.assertIn('CommandException: Max valid duration allowed is 7 days',
                   stderr)
 
+  def testSignUrlInvalidDurationWithUseServiceAccount(self):
+    """Tests signurl with -u flag fails duration > 12 hours."""
+    stderr = self.RunGsUtil(['signurl', '-d', '13h', '-u', 'gs://uri'],
+                            return_stderr=True,
+                            expected_status=1)
+    self.assertIn('CommandException: Max valid duration allowed is 12:00:00',
+                  stderr)
+
   def testSignUrlOutputP12(self):
     """Tests signurl output of a sample object with pkcs12 keystore."""
     self._DoTestSignUrlOutput(self._GetKsFile())


### PR DESCRIPTION
When -u flag is used, the SignBlob API is called, which guarantees the key's lifespan for up to 12 hours. This fix adds a restriction on the max duration allowed when the -u flag is used.

More info b/156160482