### PR TITLE
rsync now tries to patch before overwriting, rather than checking ACL

### DIFF
--- a/gslib/commands/rsync.py
+++ b/gslib/commands/rsync.py
@@ -39,6 +39,7 @@ from boto import config
 import crcmod
 from gslib.bucket_listing_ref import BucketListingObject
 from gslib.cloud_api import NotFoundException
+from gslib.cloud_api import ServiceException
 from gslib.command import Command
 from gslib.command import DummyArgChecker
 from gslib.command_argument import CommandArgument
@@ -1471,7 +1472,8 @@ def _RsyncFunc(cls, diff_to_apply, thread_state=None):
                                          obj_metadata,
                                          provider=dst_url.scheme,
                                          generation=dst_url.generation)
-        except:
+        except ServiceException as err:
+          cls.logger.debug('Error while trying to patch: %s', err)
           # We don't have permission to patch apparently, so it must be copied.
           cls.logger.info(
               'Copying whole file/object for %s instead of patching'
@@ -1517,7 +1519,8 @@ def _RsyncFunc(cls, diff_to_apply, thread_state=None):
                                          obj_metadata,
                                          provider=dst_url.scheme,
                                          generation=dst_url.generation)
-        except:
+        except ServiceException as err:
+          cls.logger.debug('Error while trying to patch: %s', err)
           # Apparently we don't have object ownership, so it must be copied.
           cls.logger.info(
               'Copying whole file/object for %s instead of patching'
@@ -1733,8 +1736,6 @@ class RsyncCommand(Command):
           gzip_arg_all = GZIP_ALL_FILES
         elif o == '-n':
           self.dryrun = True
-        elif o == '-O':
-          self.assert_ownership = True
         elif o == '-p':
           self.preserve_acl = True
         elif o == '-P':

--- a/gslib/commands/rsync.py
+++ b/gslib/commands/rsync.py
@@ -1691,7 +1691,6 @@ class RsyncCommand(Command):
     # state rather than CopyHelperOpts.
     self.continue_on_error = False
     self.delete_extras = False
-    self.assert_ownership = False
     self.preserve_acl = False
     self.preserve_posix_attrs = False
     self.compute_file_checksums = False

--- a/gslib/commands/rsync.py
+++ b/gslib/commands/rsync.py
@@ -447,10 +447,6 @@ _DETAILED_HELP_TEXT = ("""
                  what would be copied or deleted without actually doing any
                  copying/deleting.
 
-  -O             Assert ownership of objects. This is useful if uniform bucket-
-                 level access (UBLA) is enabled for a destination bucket that
-                 you control.
-
   -p             Causes ACLs to be preserved when objects are copied. Note that
                  rsync will decide whether or not to perform a copy based only
                  on object size and modification time, not current ACL state.


### PR DESCRIPTION
This fixes a bug with `rsync` where it was previously checking ACL's to determine whether a patch or rewrite should be applied. This didn't work at all in most cases and especially didn't work for UBLA buckets where object ACL's don't exist. Now we'll simply attempt a patch first before falling back to rewrites.