### PR TITLE
Small doc edits.

### DIFF
--- a/gslib/addlhelp/apis.py
+++ b/gslib/addlhelp/apis.py
@@ -30,6 +30,11 @@ _DETAILED_HELP_TEXT = ("""
   the XML API), gsutil will silently fall back to using the other API. Also,
   gsutil will automatically fall back to using the XML API when interacting
   with cloud storage providers that only support that API.
+  
+  See documentation about the `JSON API
+  <https://cloud.google.com/storage/docs/json_api>`_ or `XML API
+  <https://cloud.google.com/storage/docs/xml-api/overview>`_ for more
+  information.
 
 <B>CONFIGURING WHICH API IS USED</B>
   To use a certain API for interacting with Google Cloud Storage, you can set
@@ -41,6 +46,9 @@ _DETAILED_HELP_TEXT = ("""
   This will cause gsutil to use that API where possible (falling back to the
   other API in cases as noted above). This applies to the gsutil test command
   as well; it will run integration tests against the preferred API.
+  
+  See documentation about the `Boto configuration file
+  <https://cloud.google.com/storage/docs/boto-gsutil>`_ for more information.
 
 <B>PERFORMANCE AND COST DIFFERENCES BETWEEN APIS</B>
   The XML API uses the boto framework.  This framework re-reads downloaded files

--- a/gslib/addlhelp/retries.py
+++ b/gslib/addlhelp/retries.py
@@ -31,9 +31,10 @@ _DETAILED_HELP_TEXT = ("""
   - Access denied, because the bucket or object you are trying to use has an
     ACL that doesn't permit the action you're trying to perform.
 
-  In other cases errors are retryable - transient network failures and HTTP 429
-  and 5xx error codes. For these cases, gsutil will retry using a truncated
-  binary exponential backoff strategy:
+  In other cases errors are retryable - transient network failures; HTTP 429
+  and 5xx error codes; and HTTP 408 error codes when performing a resumable
+  upload. For these cases, gsutil will retry using a truncated binary
+  exponential backoff strategy:
 
   - Wait a random period between [0..1] seconds and retry;
   - If that fails, wait a random period between [0..2] seconds and retry;

--- a/gslib/commands/acl.py
+++ b/gslib/commands/acl.py
@@ -41,7 +41,7 @@ from gslib.utils.constants import NO_MAX
 from gslib.utils.retry_util import Retry
 
 _SET_SYNOPSIS = """
-  gsutil acl set [-f] [-r] [-a] file-or-canned_acl_name url...
+  gsutil acl set [-f] [-r] [-a] <file-or-canned_acl_name> url...
 """
 
 _GET_SYNOPSIS = """
@@ -56,7 +56,7 @@ _CH_SYNOPSIS = """
     -u <id|email>:<perm>
     -g <id|email|domain|All|AllAuth>:<perm>
     -p <viewers|editors|owners>-<project number>:<perm>
-    -d <id|email|domain|All|AllAuth|<viewers|editors|owners>-<project number>>:<perm>
+    -d <id|email|domain|All|AllAuth|<viewers|editors|owners>-<project number>:<perm>
 """
 
 _GET_DESCRIPTION = """
@@ -68,8 +68,9 @@ _GET_DESCRIPTION = """
 _SET_DESCRIPTION = """
 <B>SET</B>
   The "acl set" command allows you to set an Access Control List on one or
-  more buckets and objects. The simplest way to use it is to specify one of
-  the canned ACLs, e.g.,:
+  more buckets and objects. The file-or-canned_acl_name parameter names either
+  a canned ACL or the path to a file that contains ACL text. The simplest way
+  to use the "acl set" command is to specify one of the canned ACLs, e.g.,:
 
     gsutil acl set private gs://bucket
 

--- a/gslib/commands/rsync.py
+++ b/gslib/commands/rsync.py
@@ -126,8 +126,8 @@ _DETAILED_HELP_TEXT = ("""
     gsutil rsync -r data gs://mybucket/data
 
   If you have a large number of objects to synchronize you might want to use the
-  gsutil -m option, to perform parallel (multi-threaded/multi-processing)
-  synchronization:
+  gsutil -m option (see "gsutil help options"), to perform parallel
+  (multi-threaded/multi-processing) synchronization:
 
     gsutil -m rsync -r data gs://mybucket/data
 


### PR DESCRIPTION
This backfills changes initially proposed in cl/310599519:

* Improved linking.
* Documenting HTTP 408 as retryable.
* Clarifying part of the `gsutil acl` synopsis.