### PR TITLE
Link and synopsis fixes in help text

### DIFF
--- a/gslib/commands/kms.py
+++ b/gslib/commands/kms.py
@@ -47,7 +47,7 @@ _ENCRYPTION_SYNOPSIS = """
 """
 
 _SERVICEACCOUNT_SYNOPSIS = """
-  gsutil kms serviceaccount [-p <proj_id]>
+  gsutil kms serviceaccount [-p <proj_id>]
 """
 
 _SYNOPSIS = (_AUTHORIZE_SYNOPSIS + _ENCRYPTION_SYNOPSIS.lstrip('\n') +

--- a/gslib/commands/mb.py
+++ b/gslib/commands/mb.py
@@ -38,7 +38,7 @@ from gslib.utils.text_util import NormalizeStorageClass
 
 _SYNOPSIS = """
   gsutil mb [-b (on|off)] [-c <class>] [-l <location>] [-p <proj_id>]
-            [--<retention time>] gs://<bucket_name>...
+            [--retention <time>] gs://<bucket_name>...
 """
 
 _DETAILED_HELP_TEXT = ("""

--- a/gslib/commands/notification.py
+++ b/gslib/commands/notification.py
@@ -301,8 +301,9 @@ _STOPCHANNEL_DESCRIPTION = """
 """
 
 _DESCRIPTION = """
-  You can use the ``notification`` command to configure `Pub/Sub notifications
-  for Cloud Storage<https://cloud.google.com/storage/docs/pubsub-notifications>`_
+  You can use the ``notification`` command to configure
+  `Pub/Sub notifications for Cloud Storage
+  <https://cloud.google.com/storage/docs/pubsub-notifications>`_
   and `Object change notification
   <https://cloud.google.com/storage/docs/object-change-notification>`_ channels.
 

--- a/gslib/commands/perfdiag.py
+++ b/gslib/commands/perfdiag.py
@@ -79,7 +79,7 @@ _SYNOPSIS = """
   gsutil perfdiag [-i in.json]
   gsutil perfdiag [-o out.json] [-n objects] [-c processes]
       [-k threads] [-p parallelism type] [-y slices] [-s size] [-d directory]
-      [-t tests] [-j ratio] url...
+      [-t tests] [-j ratio] gs://<bucket_name>...
 """
 
 _DETAILED_HELP_TEXT = ("""
@@ -91,10 +91,10 @@ _DETAILED_HELP_TEXT = ("""
   The perfdiag command runs a suite of diagnostic tests for a given Google
   Storage bucket.
 
-  The 'url' parameter must name an existing bucket (e.g. gs://foo) to which
-  the user has write permission. Several test files will be uploaded to and
-  downloaded from this bucket. All test files will be deleted at the completion
-  of the diagnostic if it finishes successfully.
+  The 'bucket_name' parameter must name an existing bucket to which the user
+  has write permission. Several test files will be uploaded to and downloaded
+  from this bucket. All test files will be deleted at the completion of the
+  diagnostic if it finishes successfully.
 
   gsutil performance can be impacted by many factors at the client, server,
   and in-between, such as: CPU speed; available memory; the access path to the


### PR DESCRIPTION
The PR fixes a few typos in command synopses as well as the formatting of a link in the `gsutil notification` file