### PR TITLE
Remove access key id munging logic in signurl.py

### DIFF
--- a/gslib/commands/signurl.py
+++ b/gslib/commands/signurl.py
@@ -310,8 +310,7 @@ def _GenSignedUrl(key,
 
 def _ReadKeystore(ks_contents, passwd):
   ks = load_pkcs12(ks_contents, passwd)
-  client_email = ks.get_certificate().get_subject().CN.replace(
-      '.apps.googleusercontent.com', '@developer.gserviceaccount.com')
+  client_email = ks.get_certificate().get_subject().CN
 
   return ks.get_privatekey(), client_email
 


### PR DESCRIPTION
The same logic has been moved to GCS FE. 
Remove the duplicate logic here to obtain more accurate metrics.

See b/156829173 for more details.