### PR TITLE
Initialize user agent to fix a web doc generation error

### DIFF
--- a/gslib/__init__.py
+++ b/gslib/__init__.py
@@ -92,6 +92,7 @@ if not os.path.isfile(os.path.join(PROGRAM_FILES_DIR, 'VERSION')):
 # Give USER_AGENT a default value for web doc generation.
 USER_AGENT = ''
 
+
 def _AddVendoredDepsToPythonPath():
   """Fix our Python path so that it correctly finds our vendored libraries."""
   vendored_path = os.path.join(GSLIB_DIR, 'vendored')

--- a/gslib/__init__.py
+++ b/gslib/__init__.py
@@ -89,6 +89,9 @@ if not os.path.isfile(os.path.join(PROGRAM_FILES_DIR, 'VERSION')):
   PROGRAM_FILES_DIR = os.path.normpath(os.path.join(GSLIB_DIR, '..'))
   IS_EDITABLE_INSTALL = True
 
+# Give USER_AGENT a default value for web doc generation.
+USER_AGENT = ''
+
 def _AddVendoredDepsToPythonPath():
   """Fix our Python path so that it correctly finds our vendored libraries."""
   vendored_path = os.path.join(GSLIB_DIR, 'vendored')

--- a/gslib/__init__.py
+++ b/gslib/__init__.py
@@ -22,8 +22,8 @@
 """Package marker file."""
 
 from __future__ import absolute_import
-from __future__ import print_function
 from __future__ import division
+from __future__ import print_function
 from __future__ import unicode_literals
 
 import os
@@ -89,7 +89,6 @@ if (not os.path.isfile(os.path.join(PROGRAM_FILES_DIR, 'VERSION')) and
 if not os.path.isfile(os.path.join(PROGRAM_FILES_DIR, 'VERSION')):
   PROGRAM_FILES_DIR = os.path.normpath(os.path.join(GSLIB_DIR, '..'))
   IS_EDITABLE_INSTALL = True
-
 
 def _AddVendoredDepsToPythonPath():
   """Fix our Python path so that it correctly finds our vendored libraries."""

--- a/gslib/__init__.py
+++ b/gslib/__init__.py
@@ -37,7 +37,6 @@ from gslib.utils.version_check import check_python_version_support
 supported, err = check_python_version_support()
 if not supported:
   raise gslib.exception.CommandException(err)
-  sys.exit(1)
 
 coverage_outfile = os.getenv('GSUTIL_COVERAGE_OUTPUT_FILE', None)
 if coverage_outfile:


### PR DESCRIPTION
[This line](https://github.com/GoogleCloudPlatform/gsutil/blob/4598a5cfb868201abc0de0226da96089adcbbd1a/gslib/third_party/storage_apitools/storage_v1_client.py#L38) makes `sphinx-build` break as `gslib.USER_AGENT` is created only when we run the gsutil command. 

This PR fixes that error by initializing `gslib.USER_AGENT` in `__init__.py`