### PR TITLE
Fix multithread race condition for cp/mv command when multiple operations are attempting to create the same directory

### DIFF
--- a/gslib/commands/cp.py
+++ b/gslib/commands/cp.py
@@ -927,7 +927,12 @@ class CpCommand(Command):
     if (copy_object_info.exp_dst_url.IsFileUrl() and
         not os.path.exists(copy_object_info.exp_dst_url.object_name) and
         have_multiple_srcs):
-      os.makedirs(copy_object_info.exp_dst_url.object_name)
+
+      try:
+        os.makedirs(copy_object_info.exp_dst_url.object_name)
+      except OSError as e:
+        if e.errno != errno.EEXIST:
+          raise
 
     dst_url = copy_helper.ConstructDstUrl(
         src_url,

--- a/gslib/commands/cp.py
+++ b/gslib/commands/cp.py
@@ -20,6 +20,7 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import unicode_literals
 
+import errno
 import itertools
 import logging
 import os

--- a/gslib/utils/copy_helper.py
+++ b/gslib/utils/copy_helper.py
@@ -3307,8 +3307,13 @@ def _CopyFileToFile(src_url, dst_url, status_queue=None, src_obj_metadata=None):
   """
   src_fp = GetStreamFromFileUrl(src_url)
   dir_name = os.path.dirname(dst_url.object_name)
-  if dir_name and not os.path.exists(dir_name):
+
+  try:
     os.makedirs(dir_name)
+  except OSError as e:
+    if e.errno != errno.EEXIST:
+      raise
+
   with open(dst_url.object_name, 'wb') as dst_fp:
     start_time = time.time()
     shutil.copyfileobj(src_fp, dst_fp)

--- a/gslib/utils/copy_helper.py
+++ b/gslib/utils/copy_helper.py
@@ -3308,11 +3308,12 @@ def _CopyFileToFile(src_url, dst_url, status_queue=None, src_obj_metadata=None):
   src_fp = GetStreamFromFileUrl(src_url)
   dir_name = os.path.dirname(dst_url.object_name)
 
-  try:
-    os.makedirs(dir_name)
-  except OSError as e:
-    if e.errno != errno.EEXIST:
-      raise
+  if dir_name:
+    try:
+      os.makedirs(dir_name)
+    except OSError as e:
+      if e.errno != errno.EEXIST:
+        raise
 
   with open(dst_url.object_name, 'wb') as dst_fp:
     start_time = time.time()


### PR DESCRIPTION
See title. Basically if you invoke `gsutil cp` from 2 different processes to copy files into the same non-existent destination directory, there's a potential race condition in creating the destination directory(s). This is the thread-safe directory creation method thats compatible with python 2.7.