### PR TITLE
Update linter to use python3 for better forward compatibility.

### DIFF
--- a/test/run_pylint.sh
+++ b/test/run_pylint.sh
@@ -9,4 +9,4 @@ find "$GSUTIL_DIR" \
     -path "$GSUTIL_DIR/gslib/vendored" -prune -o \
     -path "$GSUTIL_DIR/third_party" -prune -o \
     -name "*.py" -print \
-  | xargs python -m pylint --rcfile="$TEST_DIR/.pylintrc_limited"
+  | xargs python3 -m pylint --rcfile="$TEST_DIR/.pylintrc_limited"


### PR DESCRIPTION
Makes developer environment setup a bit simpler because our yapf formatter uses "python3", but lylint was using "python" (version 2).