### PR TITLE
Text update from "archived time" to "noncurrent time" because now we …

### DIFF
--- a/gslib/tests/test_stat.py
+++ b/gslib/tests/test_stat.py
@@ -66,7 +66,7 @@ class TestStat(testcase.GsUtilIntegrationTestCase):
     stdout = self.RunGsUtil(['stat', old_object_uri.version_specific_uri],
                             return_stdout=True)
 
-    self.assertIn('Archived time', stdout)
+    self.assertIn('Noncurrent time', stdout)
 
   def test_stat_output(self):
     """Tests stat output of a single object."""

--- a/gslib/utils/ls_helper.py
+++ b/gslib/utils/ls_helper.py
@@ -211,7 +211,7 @@ def PrintFullInfoAboutObject(bucket_listing_ref, incl_acl=True):
         MakeMetadataLine('Component-Count', obj.componentCount))
   if obj.timeDeleted:
     text_util.print_to_fd(
-        MakeMetadataLine('Archived time',
+        MakeMetadataLine('Noncurrent time',
                          obj.timeDeleted.strftime('%a, %d %b %Y %H:%M:%S GMT')))
   marker_props = {}
   if obj.metadata and obj.metadata.additionalProperties:


### PR DESCRIPTION
Now we have an "archived" object class that the old text might cause confusion with.
Full details: http://b/144785578

Accompanied by CL changing public documentation for: https://cloud.google.com/storage/docs/using-object-versioning#list