### PR TITLE
Fix stdout ordering issue in hash command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
       python: "3.7"
     - os: linux
       dist: xenial
-      python: "pypy3.6"
+      python: "pypy3"
   fast_finish: true
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
       python: "3.7"
     - os: linux
       dist: xenial
-      python: "pypy3.5"
+      python: "pypy3.6"
   fast_finish: true
 
 before_install:

--- a/gslib/commands/hash.py
+++ b/gslib/commands/hash.py
@@ -223,12 +223,11 @@ class HashCommand(Command):
             hash_dict['md5'] = obj_metadata.md5Hash
           if crc32c_present:
             hash_dict['crc32c'] = obj_metadata.crc32c
-        text_util.print_to_fd('Hashes [%s] for %s:' %
-                              (output_format, file_name))
+        print('Hashes [%s] for %s:' % (output_format, file_name))
         for name, digest in six.iteritems(hash_dict):
-          text_util.print_to_fd('\tHash (%s):\t\t%s' %
-                                (name, (format_func(digest) if url.IsFileUrl()
-                                        else cloud_format_func(digest))))
+          print('\tHash (%s):\t\t%s' % (name,
+                                        (format_func(digest) if url.IsFileUrl()
+                                         else cloud_format_func(digest))))
 
     if not matched_one:
       raise CommandException('No files matched')


### PR DESCRIPTION
The stdout and stderr ordering gets messed up in Python3 as shown below. b/147895168. This happens because for python3, the [print_to_fd](https://github.com/GoogleCloudPlatform/gsutil/blob/05b4c88e53e21d9b919111500594d4547f48f44f/gslib/commands/hash.py#L226) function writes to stdout.buffer instead of stdout directly which causes content from `sys.stderr` to show before `sys.stdout`

Before:
```
$ python2 ./gsutil hash ~/temp/junk/chair.png
Hashes [base64] for /usr/local/google/home/dpednekar/temp/junk/chair.png:
        Hash (crc32c):          Yd1Nag==
        Hash (md5):             z2yKupEgoWkutTtcBMgpoQ==

Operation completed over 1 objects/3.3 KiB.

$ python3 ./gsutil hash ~/temp/junk/chair.png
/ [1 files][  3.3 KiB/  3.3 KiB]
Operation completed over 1 objects/3.3 KiB.
Hashes [base64] for /usr/local/google/home/dpednekar/temp/junk/chair.png:
        Hash (crc32c):          Yd1Nag==
        Hash (md5):             z2yKupEgoWkutTtcBMgpoQ==
```

After:
```
$ python2 ./gsutil hash ~/temp/junk/chair.png
Hashes [base64] for /usr/local/google/home/dpednekar/temp/junk/chair.png:
        Hash (crc32c):          Yd1Nag==
        Hash (md5):             z2yKupEgoWkutTtcBMgpoQ==

Operation completed over 1 objects/3.3 KiB.

$ python3 ./gsutil hash ~/temp/junk/chair.png
Hashes [base64] for /usr/local/google/home/dpednekar/temp/junk/chair.png:
        Hash (crc32c):          Yd1Nag==
        Hash (md5):             z2yKupEgoWkutTtcBMgpoQ==

Operation completed over 1 objects/3.3 KiB.
```