### PR TITLE
Add new line after stat error output

### DIFF
--- a/gslib/commands/stat.py
+++ b/gslib/commands/stat.py
@@ -160,14 +160,14 @@ class StatCommand(Command):
       except AccessDeniedException:
         if logging.getLogger().isEnabledFor(logging.INFO):
           sys.stderr.write('You aren\'t authorized to read %s - skipping' %
-                           url_str)
+                           url_str + '\n')
       except InvalidUrlError:
         raise
       except NotFoundException:
         pass
       if not arg_matches:
         if logging.getLogger().isEnabledFor(logging.INFO):
-          sys.stderr.write(NO_URLS_MATCHED_TARGET % url_str)
+          sys.stderr.write(NO_URLS_MATCHED_TARGET % url_str + '\n')
         found_nonmatching_arg = True
     if found_nonmatching_arg:
       return 1


### PR DESCRIPTION
https://issuetracker.google.com/issues/158692016

Fixes a problem where the `stat` command did not add a new line after certain errors were logged, e.g.:

```
prompt $ gsutil stat s3://asdf/test3.txt
You aren't authorized to read s3://asdf/test3.txt - skippingNo URLs matched: s3://asdf/test3.txtprompt $
```

After this change the same command outputs the following:
```
prompt $ gsutil stat s3://asdf/test3.txt
You aren't authorized to read s3://asdf/test3.txt - skipping
No URLs matched: s3://asdf/test3.txt
prompt $
```