### PR TITLE
Fix OSError on interrupted rsync -d

### DIFF
--- a/gslib/commands/rsync.py
+++ b/gslib/commands/rsync.py
@@ -1359,7 +1359,13 @@ def _RsyncFunc(cls, diff_to_apply, thread_state=None):
     else:
       cls.logger.info('Removing %s', dst_url)
       if dst_url.IsFileUrl():
-        os.unlink(dst_url.object_name)
+        try:
+          os.unlink(dst_url.object_name)
+        except FileNotFoundError:
+          # Missing file errors occur occasionally with .gstmp files
+          # and can be ignored for deletes.
+          cls.logger.debug('%s was already removed', dst_url)
+          pass
       else:
         try:
           gsutil_api.DeleteObject(dst_url.bucket_name,

--- a/gslib/sig_handling.py
+++ b/gslib/sig_handling.py
@@ -143,8 +143,10 @@ def MultithreadedMainSignalHandler(signal_num, cur_stack_frame):
              '    %s' % (signal_num, re.sub('\\n', '\n    ', stack_trace)))
       try:
         sys.stderr.write(err.encode(UTF8))
-      except UnicodeDecodeError:
+      except (UnicodeDecodeError, TypeError) as e:
         # Can happen when outputting invalid Unicode filenames.
+        # or in python3, where stderr only accepts arguments of type
+        # str, not bytes.
         sys.stderr.write(err)
     else:
       sys.stderr.write('Caught CTRL-C (signal %d) - exiting\n' % signal_num)


### PR DESCRIPTION
https://issuetracker.google.com/issues/148845060

`gsutil rsync -d src dest` currently raises an `OSError` if it is retried after being interrupted. This is because if there's a file `name.txt` in `src` not present in `dest`, `rsync` makes a call to copy, which generates a `name.txt_.gstmp` file in `dest` that is used to hold data during a transfer. the `_.gstmp` file is renamed `name.txt` after the transfer is completed, but if the transfer is interrupted the file is never renamed. 

When `gsutil rsync -d src dest` is retried after being interrupted, it first builds a diff between the two directories, scheduling `name.txt_.gstmp` for deletion. The problem arises when the copy occurs before the remove operation, since copy will delete the `name.txt_.gstmp,` causing the rsync remove step to raise a `FileNotFound` exception.

The fix here silences the `FileNotFound` exception, replacing it with a debug log message.

Changing copy so that it cleans up its own temporary files is also possible, but resumable downloads use `_.gstmp` files to store temporary download data, meaning we would not want to delete `_.gstmp` files in all cases, and would still need to handle `FileNotFound` exceptions if one of these transfers was interrupted during rsync. 

While debugging this, I also found that the logging for the ctrl+c event handler was not working correctly in python3, and included a fix for that. That logic only applied to files stored in `/tmp` though, not those stored in a synced directory which end in `_gstmp`.