### PR TITLE
Better error message for cp with empty source directory

### DIFF
--- a/gslib/commands/rm.py
+++ b/gslib/commands/rm.py
@@ -30,7 +30,7 @@ from gslib.command import DecrementFailureCount
 from gslib.command_argument import CommandArgument
 from gslib.cs_api_map import ApiSelector
 from gslib.exception import CommandException
-from gslib.exception import NO_URLS_MATCHED_GENERIC
+from gslib.exception import NO_URLS_MATCHED_PREFIX
 from gslib.exception import NO_URLS_MATCHED_TARGET
 from gslib.name_expansion import NameExpansionIterator
 from gslib.name_expansion import SeekAheadNameExpansionIterator
@@ -170,7 +170,7 @@ def _RemoveExceptionHandler(cls, e):
 # pylint: disable=unused-argument
 def _RemoveFoldersExceptionHandler(cls, e):
   """When removing folders, we don't mind if none exist."""
-  if ((isinstance(e, CommandException) and NO_URLS_MATCHED_GENERIC in e.reason)
+  if ((isinstance(e, CommandException) and NO_URLS_MATCHED_PREFIX in e.reason)
       or isinstance(e, NotFoundException)):
     DecrementFailureCount()
   else:
@@ -368,7 +368,7 @@ class RmCommand(Command):
                      fail_on_error=False)
         except CommandException as e:
           # Ignore exception from name expansion due to an absent folder file.
-          if not e.reason.startswith(NO_URLS_MATCHED_GENERIC):
+          if not e.reason.startswith(NO_URLS_MATCHED_PREFIX):
             raise
 
     # Now that all data has been deleted, delete any bucket URLs.

--- a/gslib/exception.py
+++ b/gslib/exception.py
@@ -31,8 +31,10 @@ from __future__ import unicode_literals
 
 import six
 
-NO_URLS_MATCHED_GENERIC = 'No URLs matched'
-NO_URLS_MATCHED_TARGET = 'No URLs matched: %s'
+NO_URLS_MATCHED_PREFIX = 'No URLs matched'
+NO_URLS_MATCHED_GENERIC = (NO_URLS_MATCHED_PREFIX +
+                           '. Do the files you\'re operating on exist?')
+NO_URLS_MATCHED_TARGET = NO_URLS_MATCHED_PREFIX + ': %s'
 
 if six.PY3:
   # StandardError was removed, so use the base exception type instead

--- a/gslib/tests/test_naming.py
+++ b/gslib/tests/test_naming.py
@@ -44,6 +44,7 @@ from gslib.cloud_api import ServiceException
 from gslib.exception import CommandException
 from gslib.exception import InvalidUrlError
 from gslib.exception import NO_URLS_MATCHED_GENERIC
+from gslib.exception import NO_URLS_MATCHED_TARGET
 from gslib.storage_url import StorageUrlFromString
 import gslib.tests.testcase as testcase
 from gslib.tests.util import ObjectToURI as suri
@@ -1429,7 +1430,7 @@ class GsUtilCommandTests(testcase.GsUtilUnitTestCase):
       self.RunCommand('rm', [suri(dst_bucket_uri, 'non_existent')])
       self.fail('Did not get expected CommandException')
     except CommandException as e:
-      self.assertIn(NO_URLS_MATCHED_GENERIC, e.reason)
+      self.assertIn(NO_URLS_MATCHED_TARGET % dst_bucket_uri, e.reason)
 
   # Now that gsutil ver computes a checksum it adds 1-3 seconds to test run
   # time (for in memory mocked tests that otherwise take ~ 0.1 seconds). Since

--- a/gslib/tests/test_rm.py
+++ b/gslib/tests/test_rm.py
@@ -21,7 +21,7 @@ from __future__ import unicode_literals
 
 import re
 
-from gslib.exception import NO_URLS_MATCHED_GENERIC
+from gslib.exception import NO_URLS_MATCHED_PREFIX
 from gslib.exception import NO_URLS_MATCHED_TARGET
 import gslib.tests.testcase as testcase
 from gslib.tests.testcase.base import MAX_BUCKET_LENGTH
@@ -121,7 +121,7 @@ class TestRm(testcase.GsUtilIntegrationTestCase):
         update_lines = True
         # Retry 404's and 409's due to eventual listing consistency, but don't
         # add the output to the set.
-        if (NO_URLS_MATCHED_GENERIC in stderr or
+        if (NO_URLS_MATCHED_PREFIX in stderr or
             '409 BucketNotEmpty' in stderr or
             '409 VersionedBucketNotEmpty' in stderr):
           update_lines = False


### PR DESCRIPTION
Make error message more clear for case where user tries to copy, and source files do not exist.
http://b/150820007