### PR TITLE
Cap rsa version at 4.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,9 @@ management tasks, including:
 """
 
 requires = [
+    # TODO(b/): Quick fix as rsa dropped support for python 2 in version >4.
+    # This should be dropped later when gcs-oauth2-boto-plugin is updated.
+    'rsa<=4.0 ; python_version < 2.7',
     'argcomplete>=1.9.4',
     'crcmod>=1.7',
     'fasteners>=0.14.1',

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ management tasks, including:
 requires = [
     # TODO(b/158863251): Quick fix as rsa dropped support for python 2 in version >4.
     # This should be dropped later when gcs-oauth2-boto-plugin is updated.
-    'rsa<=4.0 : python_version < "2.7"',
+    'rsa<=4.0; python_version < "2.7"',
     'argcomplete>=1.9.4',
     'crcmod>=1.7',
     'fasteners>=0.14.1',

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ management tasks, including:
 """
 
 requires = [
-    # TODO(b/): Quick fix as rsa dropped support for python 2 in version >4.
+    # TODO(b/158863251): Quick fix as rsa dropped support for python 2 in version >4.
     # This should be dropped later when gcs-oauth2-boto-plugin is updated.
     'rsa<=4.0 ; python_version < 2.7',
     'argcomplete>=1.9.4',

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ management tasks, including:
 requires = [
     # TODO(b/158863251): Quick fix as rsa dropped support for python 2 in version >4.
     # This should be dropped later when gcs-oauth2-boto-plugin is updated.
-    'rsa<=4.0 ; python_version < 2.7',
+    'rsa<=4.0 : python_version < "2.7"',
     'argcomplete>=1.9.4',
     'crcmod>=1.7',
     'fasteners>=0.14.1',


### PR DESCRIPTION
RSA dropped support for python 2 (see the Major changes in 4.1 section [here](https://pypi.org/project/rsa/4.1.1/)), and the latest version of the library includes type annotations that cause travis to fail ([log](https://travisci.org/github/GoogleCloudPlatform/gsutil/jobs/697669414#L431)). To ensure python 2 compatibility we need to use a previous version of rsa. 

It would be cleanest to do this in the dependency that requires rsa: `gcs-oauth2-boto-plugin`, but as it will take some time to upload that to pypi I am including a quick fix here, to be removed when gcs-oauth2-boto-plugin is updated.