### PR TITLE
Add support for custom-time metadata

### DIFF
--- a/gslib/commands/setmeta.py
+++ b/gslib/commands/setmeta.py
@@ -119,12 +119,8 @@ _DETAILED_HELP_TEXT = ("""
 # of doing things. This list comes from functionality that was supported by
 # gsutil3 at the time gsutil4 was released.
 SETTABLE_FIELDS = [
-    'cache-control',
-    'content-disposition',
-    'content-encoding',
-    'content-language',
-    'content-type',
-    'custom-time'
+    'cache-control', 'content-disposition', 'content-encoding',
+    'content-language', 'content-type', 'custom-time'
 ]
 
 

--- a/gslib/commands/setmeta.py
+++ b/gslib/commands/setmeta.py
@@ -124,6 +124,7 @@ SETTABLE_FIELDS = [
     'content-encoding',
     'content-language',
     'content-type',
+    'custom-time'
 ]
 
 

--- a/gslib/third_party/storage_apitools/storage_v1_messages.py
+++ b/gslib/third_party/storage_apitools/storage_v1_messages.py
@@ -259,6 +259,19 @@ class Bucket(_messages.Message):
           createdBefore: A date in RFC 3339 format with only the date part
             (for instance, "2013-01-15"). This condition is satisfied when an
             object is created before midnight of the specified date in UTC.
+          customTimeBefore: A timestamp in RFC 3339 format. This condition is
+            satisfied when the custom time on an object is before this
+            timestamp.
+          daysSinceCustomTime: Number of days elapsed since the user-specified
+            timestamp set on an object. The condition is satisfied if the days
+            elapsed is at least this number. If no custom timestamp is
+            specified on an object, the condition does not apply.
+          daysSinceNoncurrentTime: Number of days elapsed since the noncurrent
+            timestamp of an object. The condition is satisfied if the days
+            elapsed is at least this number. This condition is relevant only
+            for versioned objects. The value of the field must be a
+            nonnegative integer. If it's zero, the object version will become
+            eligible for Lifecycle action as soon as it becomes noncurrent.
           isLive: Relevant only for versioned objects. If the value is true,
             this condition matches live objects; if the value is false, it
             matches archived objects.
@@ -266,6 +279,9 @@ class Bucket(_messages.Message):
             specified by this condition will be matched. Values include
             MULTI_REGIONAL, REGIONAL, NEARLINE, COLDLINE, ARCHIVE, STANDARD,
             and DURABLE_REDUCED_AVAILABILITY.
+          noncurrentTimeBefore: A timestamp in RFC 3339 format. This condition
+            is satisfied when the noncurrent time on an object is before this
+            timestamp. This condition is relevant only for versioned objects.
           numNewerVersions: Relevant only for versioned objects. If the value
             is N, this condition is satisfied when there are at least N
             versions (including the live version) newer than this version of
@@ -274,8 +290,12 @@ class Bucket(_messages.Message):
 
         age = _messages.IntegerField(1, variant=_messages.Variant.INT32)
         createdBefore = extra_types.DateField(2)
+        customTimeBefore = _message_types.DateTimeField(6)
+        daysSinceCustomTime = _messages.IntegerField(7, variant=_messages.Variant.INT32)
+        daysSinceNoncurrentTime = _messages.IntegerField(8, variant=_messages.Variant.INT32)
         isLive = _messages.BooleanField(3)
         matchesStorageClass = _messages.StringField(4, repeated=True)
+        noncurrentTimeBefore = _message_types.DateTimeField(9)
         numNewerVersions = _messages.IntegerField(5, variant=_messages.Variant.INT32)
 
       action = _messages.MessageField('ActionValue', 1)
@@ -747,6 +767,8 @@ class Object(_messages.Message):
     crc32c: CRC32c checksum, as described in RFC 4960, Appendix B; encoded
       using base64 in big-endian byte order. For more information about using
       the CRC32c checksum, see Hashes and ETags: Best Practices.
+    customTime: A timestamp in RFC 3339 format specified by the user for an
+      object.
     customerEncryption: Metadata of customer-supplied encryption key, if the
       object is encrypted by such a key.
     etag: HTTP 1.1 Entity tag for the object.
@@ -863,6 +885,7 @@ class Object(_messages.Message):
   contentLanguage = _messages.StringField(7)
   contentType = _messages.StringField(8)
   crc32c = _messages.StringField(9)
+  customTime = _message_types.DateTimeField(32)
   customerEncryption = _messages.MessageField('CustomerEncryptionValue', 10)
   etag = _messages.StringField(11)
   eventBasedHold = _messages.BooleanField(12)

--- a/gslib/utils/ls_helper.py
+++ b/gslib/utils/ls_helper.py
@@ -48,6 +48,7 @@ UNENCRYPTED_FULL_LISTING_FIELDS = [
     'contentEncoding',
     'contentLanguage',
     'contentType',
+    'customTime',
     'kmsKeyName',
     'customerEncryption',
     'etag',
@@ -209,6 +210,8 @@ def PrintFullInfoAboutObject(bucket_listing_ref, incl_acl=True):
   if obj.componentCount:
     text_util.print_to_fd(
         MakeMetadataLine('Component-Count', obj.componentCount))
+  if obj.customTime:
+    text_util.print_to_fd(MakeMetadataLine('Custom-Time', obj.customTime))
   if obj.timeDeleted:
     text_util.print_to_fd(
         MakeMetadataLine('Noncurrent time',

--- a/gslib/utils/translation_helper.py
+++ b/gslib/utils/translation_helper.py
@@ -27,6 +27,7 @@ import xml.etree.ElementTree
 from xml.etree.ElementTree import ParseError as XmlParseError
 
 import six
+from apitools.base.protorpclite.util import decode_datetime
 from apitools.base.py import encoding
 import boto
 from boto.gs.acl import ACL
@@ -60,6 +61,7 @@ CONTENT_ENCODING_REGEX = re.compile(r'^content-encoding', re.I)
 CONTENT_LANGUAGE_REGEX = re.compile(r'^content-language', re.I)
 CONTENT_MD5_REGEX = re.compile(r'^content-md5', re.I)
 CONTENT_TYPE_REGEX = re.compile(r'^content-type', re.I)
+CUSTOM_TIME_REGEX = re.compile(r'^custom-time', re.I)
 GOOG_API_VERSION_REGEX = re.compile(r'^x-goog-api-version', re.I)
 GOOG_GENERATION_MATCH_REGEX = re.compile(r'^x-goog-if-generation-match', re.I)
 GOOG_METAGENERATION_MATCH_REGEX = re.compile(r'^x-goog-if-metageneration-match',
@@ -131,6 +133,8 @@ def ObjectMetadataFromHeaders(headers):
         obj_metadata.contentType = DEFAULT_CONTENT_TYPE
       else:
         obj_metadata.contentType = value.strip()
+    elif CUSTOM_TIME_REGEX.match(header):
+      obj_metadata.customTime = decode_datetime(value.strip())
     elif GOOG_API_VERSION_REGEX.match(header):
       # API version is only relevant for XML, ignore and rely on the XML API
       # to add the appropriate version.
@@ -217,6 +221,11 @@ def HeadersFromObjectMetadata(dst_obj_metadata, provider):
       headers['content-type'] = None
     else:
       headers['content-type'] = dst_obj_metadata.contentType.strip()
+  if dst_obj_metadata.customTime is not None:
+    if not dst_obj_metadata.customTime:
+      headers['custom-time'] = None
+    else:
+      headers['custom-time'] = dst_obj_metadata.customTime.strip()
   if dst_obj_metadata.storageClass:
     header_name = 'storage-class'
     if provider == 'gs':
@@ -274,6 +283,8 @@ def CopyObjectMetadata(src_obj_metadata, dst_obj_metadata, override=False):
     dst_obj_metadata.contentLanguage = src_obj_metadata.contentLanguage
   if override or not dst_obj_metadata.contentType:
     dst_obj_metadata.contentType = src_obj_metadata.contentType
+  if override or not dst_obj_metadata.customTime:
+    dst_obj_metadata.customTime = src_obj_metadata.customTime
   if override or not dst_obj_metadata.md5Hash:
     dst_obj_metadata.md5Hash = src_obj_metadata.md5Hash
   CopyCustomMetadata(src_obj_metadata, dst_obj_metadata, override=override)


### PR DESCRIPTION
b/158838040

Integrates new metadata field with `setmeta` and `ls` commands.

```
$ gsutil setmeta -h custom-time:2045-10-02T10:00:00-05:00 gs://mybucket/hi.txt
Setting metadata on gs://mybucket/hi.txt...
/ [1 objects]                                                                   
Operation completed over 1 objects.

$ gsutil ls -L gs://mybucket/hi.txt
gs://mybucket/hi.txt:
    Creation time:          Fri, 12 Jun 2020 21:22:19 GMT
    Update time:            Mon, 22 Jun 2020 17:54:29 GMT
    Storage class:          NEARLINE
    Content-Language:       en
    Content-Length:         0
    Content-Type:           text/plain
    Custom-Time:            2045-10-02 15:00:00+00:00
    ....
```