### PR TITLE
Fix tests using wrong AWS credentials.

### DIFF
--- a/gslib/tests/testcase/integration_testcase.py
+++ b/gslib/tests/testcase/integration_testcase.py
@@ -1137,8 +1137,13 @@ class GsUtilIntegrationTestCase(base.GsUtilTestCase):
 
     with SetBotoConfigForTest(boto_config_for_test, use_existing_config=False):
       # Make sure to reset Developer Shell credential port so that the child
-      # gsutil process is really anonymous.
-      with SetEnvironmentForTest({'DEVSHELL_CLIENT_PORT': None}):
+      # gsutil process is really anonymous. Also, revent Boto from falling back
+      # on credentials from other files like ~/.aws/credentials or environment
+      # variables.
+      with SetEnvironmentForTest({
+          'DEVSHELL_CLIENT_PORT': None,
+          'AWS_SECRET_ACCESS_KEY': '_'
+      }):
         yield
 
   def _VerifyLocalMode(self, path, expected_mode):


### PR DESCRIPTION
Boto falls back on other credentials files or environment variables when fields aren't present in a Boto config file.
For those with AWS CLI installed, this meant an `~/.aws/credentials` file was giving Boto credentials even when we tried to anonymize a test client.

Documentation:
http://boto.cloudhackers.com/en/latest/boto_config_tut.html