### PR TITLE
Fixes regex conflicts with CloudSDK detection

### DIFF
--- a/gslib/tests/test_user_agent_helper.py
+++ b/gslib/tests/test_user_agent_helper.py
@@ -37,54 +37,69 @@ class TestUserAgentHelper(testcase.GsUtilUnitTestCase):
   @mock.patch.object(system_util, 'IsRunningInteractively')
   def testInteractiveFlag(self, mock_interactive):
     mock_interactive.return_value = True
-    self.assertRegexpMatches(GetUserAgent([]), r"interactive/True$")
+    self.assertRegexpMatches(GetUserAgent([]), r"interactive/True")
     mock_interactive.return_value = False
-    self.assertRegexpMatches(GetUserAgent([]), r"interactive/False$")
+    self.assertRegexpMatches(GetUserAgent([]), r"interactive/False")
 
   def testHelp(self):
-    self.assertRegexpMatches(GetUserAgent(['help']), r"command/help$")
+    self.assertRegexpMatches(GetUserAgent(['help']), r"command/help")
 
-  def testCp(self):
+  @mock.patch.object(system_util, 'InvokedViaCloudSdk')
+  def testCp(self, mock_invoked):
+    mock_invoked = False
     self.assertRegexpMatches(
         GetUserAgent(['cp', '-r', '-Z', '1.txt', 'gs://dst']), r"command/cp$")
 
-  def testCpNotEnoughArgs(self):
+  @mock.patch.object(system_util, 'InvokedViaCloudSdk')
+  def testCpNotEnoughArgs(self, mock_invoked):
+    mock_invoked = False
     self.assertRegexpMatches(GetUserAgent(['cp']), r"command/cp$")
     self.assertRegexpMatches(GetUserAgent(['cp', '1.txt']), r"command/cp$")
     self.assertRegexpMatches(GetUserAgent(['cp', '-r', '1.ts']), r"command/cp$")
-
-  def testCpEncoding(self):
+ 
+  @mock.patch.object(system_util, 'InvokedViaCloudSdk')
+  def testCpEncoding(self, mock_invoked):
+    mock_invoked = False
     self.assertRegexpMatches(GetUserAgent(['cp', 'öne', 'twö']), r"command/cp$")
 
-  def testRsync(self):
+  @mock.patch.object(system_util, 'InvokedViaCloudSdk')
+  def testRsync(self, mock_invoked):
+    mock_invoked = False
     self.assertRegexpMatches(GetUserAgent(['rsync', '1.txt', 'gs://dst']),
                              r"command/rsync$")
 
-  def testMv(self):
+  @mock.patch.object(system_util, 'InvokedViaCloudSdk')
+  def testMv(self, mock_invoked):
+    mock_invoked = False
     self.assertRegexpMatches(
         GetUserAgent(['mv', 'gs://src/1.txt', 'gs://dst/1.txt']),
         r"command/mv$")
 
-  def testCpCloudToCloud(self):
+  @mock.patch.object(system_util, 'InvokedViaCloudSdk')
+  def testCpCloudToCloud(self, mock_invoked):
+    mock_invoked = False
     self.assertRegexpMatches(GetUserAgent(['cp', '-r', 'gs://src', 'gs://dst']),
                              r"command/cp$")
-
-  def testCpForcedDaisyChain(self):
+  @mock.patch.object(system_util, 'InvokedViaCloudSdk')
+  def testCpForcedDaisyChain(self, mock_invoked):
+    mock_invoked = False
     self.assertRegexpMatches(GetUserAgent(['cp', '-D', 'gs://src', 'gs://dst']),
                              r"command/cp$")
 
   def testCpDaisyChain(self):
     self.assertRegexpMatches(
         GetUserAgent(['cp', '-r', '-Z', 'gs://src', 's3://dst']),
-        r"command/cp-DaisyChain$")
+        r"command/cp-DaisyChain")
     self.assertRegexpMatches(
         GetUserAgent(['mv', 'gs://src/1.txt', 's3://dst/1.txt']),
-        r"command/mv-DaisyChain$")
+        r"command/mv-DaisyChain")
     self.assertRegexpMatches(
         GetUserAgent(['rsync', '-r', 'gs://src', 's3://dst']),
-        r"command/rsync-DaisyChain$")
+        r"command/rsync-DaisyChain")
 
-  def testPassOnInvalidUrlError(self):
+  @mock.patch.object(system_util, 'InvokedViaCloudSdk')
+  def testPassOnInvalidUrlError(self, mock_invoked):
+    mock_invoked = False
     self.assertRegexpMatches(
         GetUserAgent(['cp', '-r', '-Z', 'bad://src', 's3://dst']),
         r"command/cp$")

--- a/gslib/tests/test_user_agent_helper.py
+++ b/gslib/tests/test_user_agent_helper.py
@@ -46,43 +46,43 @@ class TestUserAgentHelper(testcase.GsUtilUnitTestCase):
 
   @mock.patch.object(system_util, 'InvokedViaCloudSdk')
   def testCp(self, mock_invoked):
-    mock_invoked = False
+    mock_invoked.return_value = False
     self.assertRegexpMatches(
         GetUserAgent(['cp', '-r', '-Z', '1.txt', 'gs://dst']), r"command/cp$")
 
   @mock.patch.object(system_util, 'InvokedViaCloudSdk')
   def testCpNotEnoughArgs(self, mock_invoked):
-    mock_invoked = False
+    mock_invoked.return_value = False
     self.assertRegexpMatches(GetUserAgent(['cp']), r"command/cp$")
     self.assertRegexpMatches(GetUserAgent(['cp', '1.txt']), r"command/cp$")
     self.assertRegexpMatches(GetUserAgent(['cp', '-r', '1.ts']), r"command/cp$")
  
   @mock.patch.object(system_util, 'InvokedViaCloudSdk')
   def testCpEncoding(self, mock_invoked):
-    mock_invoked = False
+    mock_invoked.return_value = False
     self.assertRegexpMatches(GetUserAgent(['cp', 'öne', 'twö']), r"command/cp$")
 
   @mock.patch.object(system_util, 'InvokedViaCloudSdk')
   def testRsync(self, mock_invoked):
-    mock_invoked = False
+    mock_invoked.return_value = False
     self.assertRegexpMatches(GetUserAgent(['rsync', '1.txt', 'gs://dst']),
                              r"command/rsync$")
 
   @mock.patch.object(system_util, 'InvokedViaCloudSdk')
   def testMv(self, mock_invoked):
-    mock_invoked = False
+    mock_invoked.return_value = False
     self.assertRegexpMatches(
         GetUserAgent(['mv', 'gs://src/1.txt', 'gs://dst/1.txt']),
         r"command/mv$")
 
   @mock.patch.object(system_util, 'InvokedViaCloudSdk')
   def testCpCloudToCloud(self, mock_invoked):
-    mock_invoked = False
+    mock_invoked.return_value = False
     self.assertRegexpMatches(GetUserAgent(['cp', '-r', 'gs://src', 'gs://dst']),
                              r"command/cp$")
   @mock.patch.object(system_util, 'InvokedViaCloudSdk')
   def testCpForcedDaisyChain(self, mock_invoked):
-    mock_invoked = False
+    mock_invoked.return_value = False
     self.assertRegexpMatches(GetUserAgent(['cp', '-D', 'gs://src', 'gs://dst']),
                              r"command/cp$")
 
@@ -99,7 +99,7 @@ class TestUserAgentHelper(testcase.GsUtilUnitTestCase):
 
   @mock.patch.object(system_util, 'InvokedViaCloudSdk')
   def testPassOnInvalidUrlError(self, mock_invoked):
-    mock_invoked = False
+    mock_invoked.return_value = False
     self.assertRegexpMatches(
         GetUserAgent(['cp', '-r', '-Z', 'bad://src', 's3://dst']),
         r"command/cp$")

--- a/gslib/tests/test_user_agent_helper.py
+++ b/gslib/tests/test_user_agent_helper.py
@@ -56,7 +56,7 @@ class TestUserAgentHelper(testcase.GsUtilUnitTestCase):
     self.assertRegexpMatches(GetUserAgent(['cp']), r"command/cp$")
     self.assertRegexpMatches(GetUserAgent(['cp', '1.txt']), r"command/cp$")
     self.assertRegexpMatches(GetUserAgent(['cp', '-r', '1.ts']), r"command/cp$")
- 
+
   @mock.patch.object(system_util, 'InvokedViaCloudSdk')
   def testCpEncoding(self, mock_invoked):
     mock_invoked.return_value = False
@@ -80,6 +80,7 @@ class TestUserAgentHelper(testcase.GsUtilUnitTestCase):
     mock_invoked.return_value = False
     self.assertRegexpMatches(GetUserAgent(['cp', '-r', 'gs://src', 'gs://dst']),
                              r"command/cp$")
+
   @mock.patch.object(system_util, 'InvokedViaCloudSdk')
   def testCpForcedDaisyChain(self, mock_invoked):
     mock_invoked.return_value = False


### PR DESCRIPTION
I cases where tests are run via a version of Gsutil invoked via CloudSDK, the user agent will have a CloudSDK suffix appended, which will interfere with a `$` in regex comparisons of the resulting user agent string. I've now mocked out the CloudSDK detection completely in cases where the `$` is necessary (i.e. when checking whether we are looking at `command/cp` or `command/cp-DaisyChain`), and removed it where it was superfluous.