### PR TITLE
Docs updates

### DIFF
--- a/gslib/commands/acl.py
+++ b/gslib/commands/acl.py
@@ -93,16 +93,16 @@ _SET_DESCRIPTION = """
 
     gsutil acl set acl.txt gs://cats/file.txt
 
-  Note that you can set an ACL on multiple buckets or objects at once,
-  for example:
+  Note that you can set an ACL on multiple buckets or objects at once. For
+  example, to set ACLs on all .jpg files found in a bucket::
 
-    gsutil acl set acl.txt gs://bucket/*.jpg
+    gsutil acl set acl.txt gs://bucket/**.jpg
 
   If you have a large number of ACLs to update you might want to use the
   gsutil -m option, to perform a parallel (multi-threaded/multi-processing)
   update:
 
-    gsutil -m acl set acl.txt gs://bucket/*.jpg
+    gsutil -m acl set acl.txt gs://bucket/**.jpg
 
   Note that multi-threading/multi-processing is only done when the named URLs
   refer to objects, which happens either if you name specific objects or
@@ -163,9 +163,9 @@ _CH_DESCRIPTION = """
     gsutil acl ch -u john.doe@example.com:WRITE gs://example-bucket
 
   Grant the group admins@example.com OWNER access to all jpg files in
-  the top level of example-bucket:
+  example-bucket:
 
-    gsutil acl ch -g admins@example.com:O gs://example-bucket/*.jpg
+    gsutil acl ch -g admins@example.com:O gs://example-bucket/**.jpg
 
   Grant the owners of project example-project WRITE access to the bucket
   example-bucket:

--- a/gslib/commands/rsync.py
+++ b/gslib/commands/rsync.py
@@ -494,7 +494,7 @@ _DETAILED_HELP_TEXT = ("""
                  storage class.
 
   -x pattern     Causes files/objects matching pattern to be excluded, i.e., any
-                 matching files/objects will not be copied or deleted. Note that
+                 matching files/objects are not copied or deleted. Note that
                  the pattern is a Python regular expression, not a wildcard (so,
                  matching any string ending in "abc" would be specified using
                  ".*abc$" rather than "*abc"). Note also that the exclude path
@@ -503,17 +503,19 @@ _DETAILED_HELP_TEXT = ("""
 
                    gsutil rsync -x "data./.*\.txt$" dir gs://my-bucket
 
-                 it will skip the file dir/data1/a.txt.
+                 it skips the file dir/data1/a.txt.
 
                  You can use regex alternation to specify multiple exclusions,
                  for example:
 
                    gsutil rsync -x ".*\.txt$|.*\.jpg$" dir gs://my-bucket
 
-                 will skip all .txt and .jpg files in dir.
+                 skips all .txt and .jpg files in dir.
 
-                 NOTE: When using this on the Windows command line, use ^ as an
-                 escape character instead of \ and escape the | character.
+                 NOTE: When using the Windows cmd.exe command line interpreter,
+                 use ^ as an escape character instead of \ and escape the |
+                 character. When using Windows PowerShell, use ' instead of "
+                 and surround the | character with ".
 """)
 # pylint: enable=anomalous-backslash-in-string
 


### PR DESCRIPTION
Backfill changes from CL 319998445 and CL 319797225:

-- Add a note about Cloud Powershell regex.
-- Update examples that use wildcards to be simpler.
-- Remove some uses of the future tense.