### PR TITLE
Headers can now be removed

### DIFF
--- a/gslib/gcs_json_api.py
+++ b/gslib/gcs_json_api.py
@@ -1376,6 +1376,16 @@ class GcsJsonApi(CloudApi):
                         PredefinedAclValueValuesEnum(
                             self._ObjectCannedAclToPredefinedAcl(canned_acl)))
 
+    # Provide the ability to delete response headers from metadata.
+    if metadata.cacheControl == '':
+      apitools_include_fields.append('cacheControl')
+    if metadata.contentDisposition == '':
+      apitools_include_fields.append('contentDisposition')
+    if metadata.contentEncoding == '':
+      apitools_include_fields.append('contentEncoding')
+    if metadata.contentLanguage == '':
+      apitools_include_fields.append('contentLanguage')
+
     apitools_request = apitools_messages.StorageObjectsPatchRequest(
         bucket=bucket_name,
         object=object_name,

--- a/gslib/tests/test_setmeta.py
+++ b/gslib/tests/test_setmeta.py
@@ -222,6 +222,23 @@ class TestSetMeta(testcase.GsUtilIntegrationTestCase):
     stdout = self.RunGsUtil(['stat', suri(objuri)], return_stdout=True)
     self.assertRegex(stdout, r'CaSe:\s+SeNsItIvE')
 
+  def test_remove_header(self):
+    """Tests removing a header"""
+    objuri = self.CreateObject(contents=b'foo')
+
+    def _Check1():
+      self.RunGsUtil(['setmeta', '-h', 'content-disposition:br', suri(objuri)])
+      stdout = self.RunGsUtil(['stat', suri(objuri)], return_stdout=True)
+      self.assertRegex(stdout, r'Content-Disposition')
+
+    def _Check2():
+      self.RunGsUtil(['setmeta', '-h', 'content-disposition', suri(objuri)])
+      stdout = self.RunGsUtil(['stat', suri(objuri)], return_stdout=True)
+      self.assertRegex(stdout, r'(?!Content-Disposition)')
+
+    _Check1()
+    _Check2()
+
   def test_disallowed_header(self):
     stderr = self.RunGsUtil(
         ['setmeta', '-h', 'Content-Length:5', 'gs://foo/bar'],


### PR DESCRIPTION
Previously the JSON API would not delete the headers `cache-control`, `content-disposition`, `content-encoding`, and `content-language`. 