### PR TITLE
Code sample formatting fix

### DIFF
--- a/gslib/commands/rsync.py
+++ b/gslib/commands/rsync.py
@@ -433,7 +433,7 @@ _DETAILED_HELP_TEXT = ("""
                  which is set to 2 GiB by default. This compression buffer
                  size can be changed to a higher limit, e.g.:
 
-                   gsutil -o "GSUtil:max_upload_compression_buffer_size=8G" \
+                   gsutil -o "GSUtil:max_upload_compression_buffer_size=8G" \\
                      -m rsync -j html,txt /local/source/dir gs://bucket/path
 
   -J             Applies gzip transport encoding to file uploads. This option


### PR DESCRIPTION
The second slash is needed in the -j example in order to convert correctly into cloud.google.com documentation