### PR TITLE
Scrub "overwrite" from the docs

### DIFF
--- a/gslib/addlhelp/encoding.py
+++ b/gslib/addlhelp/encoding.py
@@ -104,7 +104,7 @@ _DETAILED_HELP_TEXT = ("""
   cloud, it is stored as named. But if you use gsutil rysnc to bring the file to
   a macOS machine and edit the file, then when you use gsutil rsync to bring
   this version back to the cloud, you end up with two different objects, instead
-  of overwriting the original. This is because macOS converted the filename to
+  of replacing the original. This is because macOS converted the filename to
   a decomposed form, and Cloud Storage sees this as a different object name.
 
 

--- a/gslib/addlhelp/versions.py
+++ b/gslib/addlhelp/versions.py
@@ -27,14 +27,14 @@ _DETAILED_HELP_TEXT = ("""
   a way to un-delete data that you accidentally deleted, or to retrieve older
   versions of your data. You can turn versioning on or off for a bucket at any
   time. Turning versioning off leaves existing object versions in place and
-  simply causes the bucket to overwrite the live version of the object whenever
-  a new version is uploaded.
+  simply causes the bucket to delete the existing live version of the object
+  whenever a new version is uploaded.
 
   Regardless of whether you have enabled versioning on a bucket, every object
   has two associated positive integer fields:
 
-  - the generation, which is updated when the content of an object is
-    overwritten.
+  - the generation, which is updated when a new object replaces an existing
+    object with the same name.
   - the metageneration, which identifies the metadata generation. It starts
     at 1; is updated every time the metadata (e.g., ACL or Content-Type) for a
     given content generation is updated; and gets reset when the generation
@@ -263,7 +263,7 @@ _DETAILED_HELP_TEXT = ("""
       x-goog-if-metageneration-match:3 acl set public-read \\
       gs://bucket/object#1360699153986000
 
-  Without adding these headers, the update would simply overwrite the existing
+  Without adding these headers, the update would simply replace the existing
   ACL. Note that in contrast, the "gsutil acl ch" command uses these headers
   automatically, because it performs a read-modify-write cycle in order to edit
   ACLs.

--- a/gslib/commands/cp.py
+++ b/gslib/commands/cp.py
@@ -338,8 +338,8 @@ _RESUMABLE_TRANSFERS_TEXT = """
   the boto configuration file.
 
   Until the upload has completed successfully, it is not visible at the destination
-  object and does not replace any existing object the upload is intended to
-  overwrite. However, parallel composite uploads may leave temporary component
+  object and does not supersede any existing object the upload is intended to
+  replace. However, parallel composite uploads may leave temporary component
   objects in place during the upload process. See Parallel Composite Uploads for more
   information.
 
@@ -347,7 +347,7 @@ _RESUMABLE_TRANSFERS_TEXT = """
   HTTP Range GET operations whenever you use the ``cp`` command, unless the
   destination is a stream. In this case, a partially downloaded temporary file
   is visible in the destination directory. Upon completion, the original
-  file is deleted and overwritten with the downloaded contents.
+  file is deleted and replaced with the downloaded contents.
 
   Resumable uploads and downloads store state information in files under
   ~/.gsutil, named by the destination object or file. If you attempt to resume a
@@ -655,7 +655,7 @@ _OPTIONS_TEXT = """
                  "gsutil help rsync".
 
   -n             No-clobber. When specified, existing files or objects at the
-                 destination are not overwritten. Any items that are skipped
+                 destination are not replaced. Any items that are skipped
                  by this option are reported as skipped. gsutil
                  performs an additional GET request to check if an item
                  exists before attempting to upload the data. This saves gsutil

--- a/gslib/commands/iam.py
+++ b/gslib/commands/iam.py
@@ -107,7 +107,7 @@ _GET_DESCRIPTION = """
 _SET_DESCRIPTION = """
 <B>SET</B>
   The ``iam set`` command sets a Cloud IAM policy on one or more buckets or objects,
-  overwriting the existing policy on those buckets or objects. For an example of the correct
+  replacing the existing policy on those buckets or objects. For an example of the correct
   formatting for a Cloud IAM policy, see the output of the ``iam get`` command.
 
   You can use the ``iam ch`` command to edit an existing policy, even in the

--- a/gslib/commands/rm.py
+++ b/gslib/commands/rm.py
@@ -117,7 +117,7 @@ _DETAILED_HELP_TEXT = ("""
   developers a high amount of flexibility and control over their data, and
   Google maintains strict controls over the processing and purging of deleted
   data. If you have concerns that your application software or your users may
-  at some point erroneously delete or overwrite data, see
+  at some point erroneously delete or replace data, see
   `Best practices for deleting data
   <https://cloud.google.com/storage/docs/best-practices#deleting>`_ for ways to
   protect your data from accidental data deletion.

--- a/gslib/commands/rsync.py
+++ b/gslib/commands/rsync.py
@@ -361,7 +361,7 @@ _DETAILED_HELP_TEXT = ("""
   2. The gsutil rsync command considers only the live object version in
      the source and destination buckets when deciding what to copy / delete. If
      versioning is enabled in the destination bucket then gsutil rsync's
-     overwriting or deleting objects will end up creating versions, but the
+     replacing or deleting objects will end up creating versions, but the
      command doesn't try to make any noncurrent versions match in the source
      and destination buckets.
 
@@ -376,9 +376,9 @@ _DETAILED_HELP_TEXT = ("""
   4. The gsutil rsync command copies changed files in their entirety and does
      not employ the
      `rsync delta-transfer algorithm <https://rsync.samba.org/tech_report/>`_
-     to transfer portions of a changed file. This is because cloud objects are
-     immutable and no facility exists to read partial cloud object checksums or
-     perform partial overwrites.
+     to transfer portions of a changed file. This is because Cloud Storage
+     objects are immutable and no facility exists to read partial object
+     checksums or perform partial replacements.
 
 <B>OPTIONS</B>
   -a canned_acl  Sets named canned_acl when uploaded objects created. See


### PR DESCRIPTION
This change backfills cl/333787211: The term overwrite doesn't have an exact meaning in our docs (and at times the use of the word is inconsistent with the actual behavior of GCS). Using "replace" instead should aid in reader comprehension easier and reduce confusion.