### PR TITLE
mTLS Part 1/2: Config Setup

### DIFF
--- a/gslib/commands/config.py
+++ b/gslib/commands/config.py
@@ -992,8 +992,8 @@ class ConfigCommand(Command):
             '#%s_impersonate_service_account = <service account email>\n\n')
 
     # Add device certificate mTLS fields.
-    config_file.write(textwrap.dedent(
-        """\
+    config_file.write(
+        textwrap.dedent("""\
         # This configuration setting enables or disables mutual TLS
         # authentication. The default value for this setting is "false". When
         # set to "true", gsutil uses the configured client certificate as
@@ -1010,8 +1010,7 @@ class ConfigCommand(Command):
         #cert_provider_command = <Absolute path to command to run for
         #                         certification. Ex: "/scripts/gen_cert.sh">
 
-        """
-    ))
+        """))
 
     # Write the config file Boto section.
     config_file.write('%s\n' % CONFIG_BOTO_SECTION_CONTENT)

--- a/gslib/commands/config.py
+++ b/gslib/commands/config.py
@@ -990,7 +990,28 @@ class ConfigCommand(Command):
             '# To impersonate a service account for "%s://" URIs over\n'
             '# JSON API, edit and uncomment the following line:\n'
             '#%s_impersonate_service_account = <service account email>\n\n')
-      config_file.write('\n')
+
+    # Add device certificate mTLS fields.
+    config_file.write(textwrap.dedent(
+        """\
+        # This configuration setting enables or disables mutual TLS
+        # authentication. The default value for this setting is "false". When
+        # set to "true", gsutil uses the configured client certificate as
+        # transport credential to access the APIs. The use of mTLS ensures that
+        # the access originates from a trusted enterprise device. When enabled,
+        # the client certificate is auto discovered using the endpoint
+        # verification agent. When set to "true" but no client certificate or
+        # key is found, users receive an error.
+        #use_client_certificate = False
+
+        # The command line to execute, which prints the
+        # certificate, private key, or password to use in
+        # conjunction with “use_client_certificate = True”.
+        #cert_provider_command = <Absolute path to command to run for
+        #                         certification. Ex: "/scripts/gen_cert.sh">
+
+        """
+    ))
 
     # Write the config file Boto section.
     config_file.write('%s\n' % CONFIG_BOTO_SECTION_CONTENT)

--- a/gslib/context_config.py
+++ b/gslib/context_config.py
@@ -1,0 +1,213 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Manages device context mTLS certificates."""
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import division
+from __future__ import unicode_literals
+
+import atexit
+import os
+import subprocess
+
+from boto import config
+
+import gslib
+
+# Maintain a single context configuration.
+_singleton_config = None
+
+
+class CertProvisionError(Exception):
+  """Represents errors when provisioning a client certificate."""
+  pass
+
+
+class ContextConfigSingletonAlreadyExistsError(Exception):
+  """Error for when create_context_config is called multiple times."""
+  pass
+
+
+def _IsPemSectionMarker(line):
+  """Returns (begin:bool, end:bool, name:str)."""
+  if line.startswith('-----BEGIN ') and line.endswith('-----'):
+    return True, False, line[11:-5]
+  elif line.startswith('-----END ') and line.endswith('-----'):
+    return False, True, line[9:-5]
+  else:
+    return False, False, ''
+
+
+def _SplitPemIntoSections(contents, logger):
+  """Returns dict with {name: section} by parsing contents in PEM format.
+
+  A simple parser for PEM file. Please see RFC 7468 for the format of PEM
+  file. Not using regex to improve performance catching nested matches.
+  Note: This parser requires the post-encapsulation label of a section to
+  match its pre-encapsulation label. It ignores a section without a
+  matching label.
+
+  Args:
+    contents (str): Contents of a PEM file.
+    logger (logging.logger): gsutil logger.
+
+  Returns:
+    A dict of the PEM file sections.
+  """
+  result = {}
+  pem_lines = []
+  pem_section_name = None
+
+  for line in contents.splitlines():
+    line = line.strip()
+    if not line:
+      continue
+
+    begin, end, name = _IsPemSectionMarker(line)
+    if begin:
+      if pem_section_name:
+        logger.warning('Section %s missing end line and will be ignored.' %
+                       pem_section_name)
+      if name in result.keys():
+        logger.warning('Section %s already exists, and the older section will '
+                       'be ignored.' % name)
+      pem_section_name = name
+      pem_lines = []
+    elif end:
+      if not pem_section_name:
+        logger.warning(
+            'Section %s missing a beginning line and will be ignored.' % name)
+      elif pem_section_name != name:
+        logger.warning('Section %s missing a matching end line. Found: %s' %
+                       (pem_section_name, name))
+        pem_section_name = None
+
+    if pem_section_name:
+      pem_lines.append(line)
+      if end:
+        result[name] = '\n'.join(pem_lines) + '\n'
+        pem_section_name = None
+
+  if pem_section_name:
+    logger.warning('Section %s missing an end line.' % pem_section_name)
+
+  return result
+
+
+class _ContextConfig(object):
+  """Represents the configurations associated with context aware access.
+
+  Only one instance of Config can be created for the program.
+  """
+
+  def __init__(self, logger):
+    """Initializes config.
+
+    Args:
+      logger (logging.logger): gsutil logger.
+    """
+    self.logger = logger
+
+    self.use_client_certificate = config.getbool('Credentials',
+                                                 'use_client_certificate', None)
+    self.client_cert_path = None
+    self.client_cert_password = None
+
+    if not self.use_client_certificate:
+      # Don't spend time generating values gsutil won't need.
+      return
+
+    # Generates certificate and deletes it afterwards.
+    atexit.register(self._UnprovisionClientCert)
+    command_string = config.get('Credentials', 'cert_provider_command', None)
+    if not command_string:
+      raise CertProvisionError('No cert provider detected.')
+
+    self.client_cert_path = os.path.join(gslib.GSUTIL_DIR, 'caa_cert.pem')
+    try:
+      # Certs provisioned using endpoint verification are stored as a
+      # single file holding both the public certificate and the private key.
+      self._ProvisionClientCert(command_string, self.client_cert_path)
+    except CertProvisionError as e:
+      self.logger.error('Failed to provision client certificate: %s' % e)
+
+  def _ProvisionClientCert(self, command_string, cert_path):
+    """Executes certificate provider to obtain client certificate and keys."""
+    # Monkey-patch command line args to get password-protected certificate.
+    # Adds password flag if it's not already there.
+    password_arg = ' --with_passphrase'
+    if ('--print_certificate' in command_string and
+        password_arg not in command_string):
+      command_string += password_arg
+
+    try:
+      command_process = subprocess.Popen(command_string.split(' '),
+                                         stdout=subprocess.PIPE,
+                                         stderr=subprocess.PIPE)
+
+      command_stdout, command_stderr = command_process.communicate()
+      if command_process.returncode != 0:
+        raise CertProvisionError(command_stderr)
+
+      sections = _SplitPemIntoSections(command_stdout, self.logger)
+      with open(cert_path, 'w+') as f:
+        f.write(sections['CERTIFICATE'])
+        f.write(sections['ENCRYPTED PRIVATE KEY'])
+      self.client_cert_password = sections['PASSPHRASE'].splitlines()[1]
+    except OSError as e:
+      raise CertProvisionError(e)
+    except KeyError as e:
+      raise CertProvisionError(
+          'Invalid output format from certificate provider, no %s' % e)
+
+  def _UnprovisionClientCert(self):
+    """Cleans up any files or resources provisioned during config init."""
+    if self.client_cert_path is not None:
+      try:
+        os.remove(self.client_cert_path)
+        self.logger.debug('Unprovisioned client cert: %s' %
+                          self.client_cert_path)
+      except OSError as e:
+        self.logger.error('Failed to remove client certificate: %s' % e)
+
+
+def create_context_config(logger):
+  """Should be run once at gsutil startup. Creates global singleton.
+
+  Args:
+    logger (logging.logger): For logging during config functions.
+
+  Returns:
+    New ContextConfig singleton.
+
+  Raises:
+    Exception if singleton already exists.
+  """
+  global _singleton_config
+  if not _singleton_config:
+    _singleton_config = _ContextConfig(logger)
+    return _singleton_config
+  raise ContextConfigSingletonAlreadyExistsError
+
+
+def get_context_config():
+  """Retrieves ContextConfig global singleton.
+
+  Returns:
+    ContextConfig or None if global singleton doesn't exist.
+  """
+  global _singleton_config
+  return _singleton_config

--- a/gslib/tests/test_context_config.py
+++ b/gslib/tests/test_context_config.py
@@ -1,0 +1,327 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for context_config.py."""
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import division
+from __future__ import unicode_literals
+
+import mock
+import os
+import subprocess
+
+import six
+
+from gslib import context_config
+from gslib.tests import testcase
+from gslib.tests.util import SetBotoConfigForTest
+from gslib.tests.util import unittest
+
+CERT_SECTION = """-----BEGIN CERTIFICATE-----
+LKJHLSDJKFHLEUIORWUYERWEHJHL
+KLJHGFDLSJKH(@#*&$)@*#KJHFLKJDSFSD
+-----END CERTIFICATE-----
+"""
+KEY_SECTION = """-----BEGIN ENCRYPTED PRIVATE KEY-----
+LKJWE:RUWEORIU)(#*&$@(#$KJHLKDJHF(I*F@YLFHSLDKJFS
+-----END ENCRYPTED PRIVATE KEY-----
+"""
+CERT_KEY_SECTION = CERT_SECTION + KEY_SECTION
+PASSWORD = '##invalid-password##'
+PASSWORD_SECTION = """
+-----BEGIN PASSPHRASE-----
+%s
+-----END PASSPHRASE-----
+""" % PASSWORD
+FULL_CERT = CERT_KEY_SECTION + PASSWORD_SECTION
+
+BAD_CERT_KEY_EMBEDDED_SECTION = """-----BEGIN CERTIFICATE-----
+LKJHLSDJKFHLEUIORWUYERWEHJHL
+KLJHGFDLSJKH(@#*&$)@*#KJHFLKJDSFSD
+-----BEGIN ENCRYPTED PRIVATE KEY-----
+LKJWE:RUWEORIU)(#*&$@(#$KJHLKDJHF(I*F@YLFHSLDKJFS
+-----END ENCRYPTED PRIVATE KEY-----
+-----END CERTIFICATE-----
+"""
+BAD_CERT_KEY_MISSING_END = """-----BEGIN CERTIFICATE-----
+LKJHLSDJKFHLEUIORWUYERWEHJHL
+KLJHGFDLSJKH(@#*&$)@*#KJHFLKJDSFSD
+-----END CERTIFICATE-----
+-----BEGIN ENCRYPTED PRIVATE KEY-----
+LKJWE:RUWEORIU)(#*&$@(#$KJHLKDJHF(I*F@YLFHSLDKJFS
+"""
+BAD_CERT_KEY_MISSING_BEGIN = """-----END CERTIFICATE-----
+-----BEGIN ENCRYPTED PRIVATE KEY-----
+LKJWE:RUWEORIU)(#*&$@(#$KJHLKDJHF(I*F@YLFHSLDKJFS
+-----END ENCRYPTED PRIVATE KEY-----
+"""
+BAD_CERT_KEY_MISMATCH = """-----BEGIN CERTIFICATE-----
+LKJHLSDJKFHLEUIORWUYERWEHJHL
+KLJHGFDLSJKH(@#*&$)@*#KJHFLKJDSFSD
+-----END ENCRYPTED PRIVATE KEY-----
+"""
+CERT_KEY_WITH_COMMENT_AT_BEGIN = """SOMECOMMENTS
+-----BEGIN CERTIFICATE-----
+LKJHLSDJKFHLEUIORWUYERWEHJHL
+KLJHGFDLSJKH(@#*&$)@*#KJHFLKJDSFSD
+-----END CERTIFICATE-----
+-----BEGIN ENCRYPTED PRIVATE KEY-----
+LKJWE:RUWEORIU)(#*&$@(#$KJHLKDJHF(I*F@YLFHSLDKJFS
+-----END ENCRYPTED PRIVATE KEY-----
+"""
+CERT_KEY_WITH_COMMENT_AT_END = """-----BEGIN CERTIFICATE-----
+LKJHLSDJKFHLEUIORWUYERWEHJHL
+KLJHGFDLSJKH(@#*&$)@*#KJHFLKJDSFSD
+-----END CERTIFICATE-----
+-----BEGIN ENCRYPTED PRIVATE KEY-----
+LKJWE:RUWEORIU)(#*&$@(#$KJHLKDJHF(I*F@YLFHSLDKJFS
+-----END ENCRYPTED PRIVATE KEY-----
+SOMECOMMENT
+"""
+CERT_KEY_WITH_COMMENT_IN_BETWEEN = """-----BEGIN CERTIFICATE-----
+LKJHLSDJKFHLEUIORWUYERWEHJHL
+KLJHGFDLSJKH(@#*&$)@*#KJHFLKJDSFSD
+-----END CERTIFICATE-----
+SOMECOMMENT
+-----BEGIN ENCRYPTED PRIVATE KEY-----
+LKJWE:RUWEORIU)(#*&$@(#$KJHLKDJHF(I*F@YLFHSLDKJFS
+-----END ENCRYPTED PRIVATE KEY-----
+"""
+
+OPEN_TO_PATCH = '__builtin__.open' if six.PY2 else 'builtins.open'
+
+
+@testcase.integration_testcase.SkipForS3('mTLS only runs on GCS JSON API.')
+@testcase.integration_testcase.SkipForXML('mTLS only runs on GCS JSON API.')
+class TestPemFileParser(testcase.GsUtilUnitTestCase):
+  """Test PEM-format certificate parsing for mTLS."""
+
+  def testPemFileWithCommentAtBegin(self):
+    sections = context_config._SplitPemIntoSections(
+        CERT_KEY_WITH_COMMENT_AT_BEGIN, self.logger)
+    self.assertEqual(sections['CERTIFICATE'], CERT_SECTION)
+    self.assertEqual(sections['ENCRYPTED PRIVATE KEY'], KEY_SECTION)
+
+  def testPemFileWithCommentAtEnd(self):
+    sections = context_config._SplitPemIntoSections(
+        CERT_KEY_WITH_COMMENT_AT_END, self.logger)
+    self.assertEqual(sections['CERTIFICATE'], CERT_SECTION)
+    self.assertEqual(sections['ENCRYPTED PRIVATE KEY'], KEY_SECTION)
+
+  def testPemFileWithCommentInBetween(self):
+    sections = context_config._SplitPemIntoSections(
+        CERT_KEY_WITH_COMMENT_IN_BETWEEN, self.logger)
+    self.assertEqual(sections['CERTIFICATE'], CERT_SECTION)
+    self.assertEqual(sections['ENCRYPTED PRIVATE KEY'], KEY_SECTION)
+
+  def testPemFileWithBadFormatEmbeddedSection(self):
+    sections = context_config._SplitPemIntoSections(
+        BAD_CERT_KEY_EMBEDDED_SECTION, self.logger)
+    self.assertIsNone(sections.get('CERTIFICATE'))
+    self.assertEqual(sections.get('ENCRYPTED PRIVATE KEY'), KEY_SECTION)
+
+  def testPemFileWithBadFormatMissingEnd(self):
+    sections = context_config._SplitPemIntoSections(BAD_CERT_KEY_MISSING_END,
+                                                    self.logger)
+    self.assertEqual(sections.get('CERTIFICATE'), CERT_SECTION)
+    self.assertIsNone(sections.get('ENCRYPTED PRIVATE KEY'))
+
+  def testPemFileWithBadFormatMissingBegin(self):
+    sections = context_config._SplitPemIntoSections(BAD_CERT_KEY_MISSING_BEGIN,
+                                                    self.logger)
+    self.assertIsNone(sections.get('CERTIFICATE'))
+    self.assertEqual(sections.get('ENCRYPTED PRIVATE KEY'), KEY_SECTION)
+
+  def testPemFileWithBadFormatMismatch(self):
+    sections = context_config._SplitPemIntoSections(BAD_CERT_KEY_MISMATCH,
+                                                    self.logger)
+    self.assertIsNone(sections.get('CERTIFICATE'))
+    self.assertIsNone(sections.get('ENCRYPTED PRIVATE KEY'))
+
+
+@testcase.integration_testcase.SkipForS3('mTLS only runs on GCS JSON API.')
+@testcase.integration_testcase.SkipForXML('mTLS only runs on GCS JSON API.')
+class TestContextConfig(testcase.GsUtilUnitTestCase):
+  """Test the global ContextConfig singleton."""
+
+  def setUp(self):
+    super(TestContextConfig, self).setUp()
+    self.mock_logger = mock.Mock()
+    context_config._singleton_config = None
+
+  def testContextConfigIsASingleton(self):
+    first = context_config.create_context_config(self.mock_logger)
+
+    with self.assertRaises(
+        context_config.ContextConfigSingletonAlreadyExistsError):
+      context_config.create_context_config(self.mock_logger)
+
+    second = context_config.get_context_config()
+    self.assertEqual(first, second)
+
+  @mock.patch.object(subprocess, 'Popen')
+  def testDoesNotProvisionIfUseClientCertificateNotTrue(self, mock_Popen):
+    context_config.create_context_config(self.mock_logger)
+    mock_Popen.assert_not_called()
+
+  def testRaisesErrorIfCertProviderCommandAbsent(self):
+    with SetBotoConfigForTest([('Credentials', 'use_client_certificate', 'True')
+                              ]):
+      with self.assertRaises(context_config.CertProvisionError):
+        context_config.create_context_config(self.mock_logger)
+
+  @mock.patch.object(subprocess, 'Popen')
+  def testConvertsAndLogsProvisoningCertProviderUnexpectedExitError(
+      self, mock_Popen):
+    mock_command_process = mock.Mock()
+    mock_command_process.communicate.return_value = (None, 'oh no')
+    mock_Popen.return_value = mock_command_process
+
+    with SetBotoConfigForTest([
+        ('Credentials', 'use_client_certificate', 'True'),
+        ('Credentials', 'cert_provider_command', 'some/path')
+    ]):
+      context_config.create_context_config(self.mock_logger)
+      self.mock_logger.error.assert_called_once_with(
+          'Failed to provision client certificate: oh no')
+
+  @mock.patch.object(subprocess, 'Popen')
+  def testConvertsAndLogsProvisioningOSError(self, mock_Popen):
+    mock_Popen.side_effect = OSError('foobar')
+
+    with SetBotoConfigForTest([
+        ('Credentials', 'use_client_certificate', 'True'),
+        ('Credentials', 'cert_provider_command', 'some/path')
+    ]):
+      context_config.create_context_config(self.mock_logger)
+      self.mock_logger.error.assert_called_once_with(
+          'Failed to provision client certificate: foobar')
+
+  @mock.patch.object(subprocess, 'Popen')
+  def testConvertsAndLogsProvisoningKeyError(self, mock_Popen):
+    # Mocking f.write would make more sense, but mocking Popen earlier in the
+    # function results in much less code and tests the same error handling.
+    mock_Popen.side_effect = KeyError('foobar')
+
+    with SetBotoConfigForTest([
+        ('Credentials', 'use_client_certificate', 'True'),
+        ('Credentials', 'cert_provider_command', 'some/path')
+    ]):
+      context_config.create_context_config(self.mock_logger)
+
+      unicode_escaped_error_string = "'foobar'" if six.PY3 else "u'foobar'"
+      self.mock_logger.error.assert_called_once_with(
+          "Failed to provision client certificate:"
+          " Invalid output format from certificate provider, no " +
+          unicode_escaped_error_string)
+
+  @mock.patch.object(subprocess, 'Popen')
+  def testDoesNotAddPasswordFlagToCommandIfPrintCertificateFlagAbsent(
+      self, mock_Popen):
+    # Purposely end execution here to avoid writing a file.
+    with SetBotoConfigForTest([
+        ('Credentials', 'use_client_certificate', 'True'),
+        ('Credentials', 'cert_provider_command', 'some/path')
+    ]):
+      with self.assertRaises(ValueError):
+        context_config.create_context_config(self.mock_logger)
+
+        mock_Popen.assert_called_once_with(os.path.realpath('some/path'),
+                                           stdout=subprocess.PIPE,
+                                           stderr=subprocess.PIPE)
+
+  @mock.patch.object(subprocess, 'Popen')
+  def testDoesNotAddPasswordFlagToCommandIfAlreadyThere(self, mock_Popen):
+    with SetBotoConfigForTest([
+        ('Credentials', 'use_client_certificate', 'True'),
+        ('Credentials', 'cert_provider_command', 'path --with_passphrase')
+    ]):
+      # Purposely end execution here to avoid writing a file.
+      with self.assertRaises(ValueError):
+        context_config.create_context_config(self.mock_logger)
+
+        mock_Popen.assert_called_once_with(
+            os.path.realpath('path --with_passphrase'),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE)
+
+  @mock.patch.object(subprocess, 'Popen')
+  def testAddsPasswordFlagIfMissingAndPrintCertificateFlagPresent(
+      self, mock_Popen):
+    with SetBotoConfigForTest([
+        ('Credentials', 'use_client_certificate', 'True'),
+        ('Credentials', 'cert_provider_command',
+         'some/path --print_certificate --with_passphrase')
+    ]):
+      # Purposely end execution here to avoid writing a file.
+      with self.assertRaises(ValueError):
+        context_config.create_context_config(self.mock_logger)
+
+        mock_Popen.assert_called_once_with(
+            os.path.realpath('some/path --print_certificate --with_passphrase'),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE)
+
+  @mock.patch.object(os, 'remove')
+  def testDoesNotUnprovisionIfNoClientCertificate(self, mock_remove):
+    context_config.create_context_config(self.mock_logger)
+    context_config._singleton_config._UnprovisionClientCert()
+    mock_remove.assert_not_called()
+
+  @mock.patch.object(os, 'remove')
+  def testHandlesAndLogsUnprovisioningOSError(self, mock_remove):
+    mock_remove.side_effect = OSError('no')
+
+    context_config.create_context_config(self.mock_logger)
+    context_config._singleton_config.client_cert_path = 'some/path'
+    context_config._singleton_config._UnprovisionClientCert()
+
+    self.mock_logger.error.assert_called_once_with(
+        'Failed to remove client certificate: no')
+
+  @mock.patch(OPEN_TO_PATCH, new_callable=mock.mock_open)
+  @mock.patch.object(os, 'remove')
+  @mock.patch.object(subprocess, 'Popen')
+  def testWritesAndDeletesCertificateFileStoringPasswordToMemory(
+      self, mock_Popen, mock_remove, mock_open):
+    mock_command_process = mock.Mock()
+    mock_command_process.returncode = 0
+    mock_command_process.communicate.return_value = (FULL_CERT, None)
+    mock_Popen.return_value = mock_command_process
+
+    with SetBotoConfigForTest([
+        ('Credentials', 'use_client_certificate', 'True'),
+        ('Credentials', 'cert_provider_command', 'path --print_certificate')
+    ]):
+      # Mock logger argument to avoid atexit hook writing to stderr.
+      test_config = context_config.create_context_config(mock.Mock())
+
+      # Test writes certificate file.
+      # Can't check whole mock_calls list because SetBotoConfigForTest also
+      # uses the mock in Python 3. Should work with any_order=False based on
+      # docs description but does not in current environment.
+      mock_open.assert_has_calls([
+          mock.call(test_config.client_cert_path, 'w+'),
+          mock.call().write(CERT_SECTION),
+          mock.call().write(KEY_SECTION),
+      ],
+                                 any_order=True)
+      # Test saves certificate password to memory.
+      self.assertEqual(context_config._singleton_config.client_cert_password,
+                       PASSWORD)
+      # Test deletes certificate file.
+      context_config._singleton_config._UnprovisionClientCert()
+      mock_remove.assert_called_once_with(test_config.client_cert_path)


### PR DESCRIPTION
Sets up config files needed for mTLS.
Does not actually attempted to connect to mTLS endpoints yet.

Note: Since the context_config.py file hasn't been tested against a live backend, it will probably require tweaking later.
However, I think I got close to full unit test coverage. PEM parsing logic and tests were copied from gcloud, so I didn't look too deep into coverage there.