### PR TITLE
Use is_alive in favour of isAlive for Python 3.9 compatibility.

### DIFF
--- a/gslib/tests/test_seek_ahead_thread.py
+++ b/gslib/tests/test_seek_ahead_thread.py
@@ -96,7 +96,7 @@ class TestSeekAheadThread(testcase.GsUtilUnitTestCase):
       seek_ahead_thread.join(self.thread_wait_time)
       status_queue.put(_ZERO_TASKS_TO_DO_ARGUMENT)
       ui_thread.join(self.thread_wait_time)
-      if seek_ahead_thread.isAlive():
+      if seek_ahead_thread.is_alive():
         seek_ahead_thread.terminate = True
         self.fail(
             'Cancellation issued after %s iterations, but SeekAheadThread '
@@ -138,7 +138,7 @@ class TestSeekAheadThread(testcase.GsUtilUnitTestCase):
     seek_ahead_thread.join(self.thread_wait_time)
     status_queue.put(_ZERO_TASKS_TO_DO_ARGUMENT)
     ui_thread.join(self.thread_wait_time)
-    if seek_ahead_thread.isAlive():
+    if seek_ahead_thread.is_alive():
       seek_ahead_thread.terminate = True
       self.fail('SeekAheadThread is still alive.')
 
@@ -181,7 +181,7 @@ class TestSeekAheadThread(testcase.GsUtilUnitTestCase):
     status_queue.put(_ZERO_TASKS_TO_DO_ARGUMENT)
     ui_thread.join(self.thread_wait_time)
 
-    if seek_ahead_thread.isAlive():
+    if seek_ahead_thread.is_alive():
       seek_ahead_thread.terminate = True
       self.fail('SeekAheadThread is still alive.')
 
@@ -226,7 +226,7 @@ class TestSeekAheadThread(testcase.GsUtilUnitTestCase):
     status_queue.put(_ZERO_TASKS_TO_DO_ARGUMENT)
     ui_thread.join(self.thread_wait_time)
 
-    if seek_ahead_thread.isAlive():
+    if seek_ahead_thread.is_alive():
       seek_ahead_thread.terminate = True
       self.fail('SeekAheadThread is still alive.')
 

--- a/gslib/tests/test_ui.py
+++ b/gslib/tests/test_ui.py
@@ -94,7 +94,7 @@ def JoinThreadAndRaiseOnTimeout(ui_thread, thread_wait_time=THREAD_WAIT_TIME):
     Exception: Warns UIThread is still alive.
   """
   ui_thread.join(thread_wait_time)
-  if ui_thread.isAlive():
+  if ui_thread.is_alive():
     raise Exception('UIThread is still alive')
 
 


### PR DESCRIPTION
Fixes #1120 