### PR TITLE
mTLS Part 2/3: Connect to Endpoint

### DIFF
--- a/gslib/__main__.py
+++ b/gslib/__main__.py
@@ -84,6 +84,7 @@ import httplib2
 import oauth2client
 from google_reauth import reauth_creds
 from google_reauth import errors as reauth_errors
+from gslib import context_config
 from gslib import wildcard_iterator
 from gslib.cloud_api import AccessDeniedException
 from gslib.cloud_api import ArgumentException
@@ -398,6 +399,9 @@ def main():
       oauth2client.transport._LOGGER.setLevel(oa2c_logger_level)
       reauth_creds._LOGGER.setLevel(oa2c_logger_level)
       # pylint: enable=protected-access
+
+    # Initialize context configuration for device mTLS.
+    context_config.create_context_config(logging.getLogger())
 
     # TODO(reauth): Fix once reauth pins to pyu2f version newer than 0.1.3.
     # Fixes pyu2f v0.1.3 bug.

--- a/gslib/cloud_api_delegator.py
+++ b/gslib/cloud_api_delegator.py
@@ -21,6 +21,7 @@ from __future__ import unicode_literals
 
 import boto
 from boto import config
+from gslib import context_config
 from gslib.cloud_api import ArgumentException
 from gslib.cloud_api import CloudApi
 from gslib.cs_api_map import ApiMapConstants
@@ -209,6 +210,15 @@ class CloudApiDelegator(CloudApi):
     elif self.prefer_api in (
         self.api_map[ApiMapConstants.SUPPORT_MAP][selected_provider]):
       api = self.prefer_api
+
+    if (api == ApiSelector.XML and context_config.get_context_config() and
+        context_config.get_context_config().use_client_certificate):
+      raise ArgumentException(
+          'User enabled mTLS by setting "use_client_certificate", but mTLS'
+          ' is not supported for the selected XML API. Try configuring for '
+          ' the GCS JSON API or setting "use_client_certificate" to "False" in'
+          ' the Boto config.')
+
     return api
 
   def GetServiceAccountId(self, provider=None):

--- a/gslib/context_config.py
+++ b/gslib/context_config.py
@@ -122,7 +122,7 @@ class _ContextConfig(object):
     self.logger = logger
 
     self.use_client_certificate = config.getbool('Credentials',
-                                                 'use_client_certificate', None)
+                                                 'use_client_certificate')
     self.client_cert_path = None
     self.client_cert_password = None
 
@@ -162,7 +162,10 @@ class _ContextConfig(object):
       if command_process.returncode != 0:
         raise CertProvisionError(command_stderr)
 
-      sections = _SplitPemIntoSections(command_stdout, self.logger)
+      # Python 3 outputs bytes from communicate() by default.
+      command_stdout_string = str(command_stdout)
+
+      sections = _SplitPemIntoSections(command_stdout_string, self.logger)
       with open(cert_path, 'w+') as f:
         f.write(sections['CERTIFICATE'])
         f.write(sections['ENCRYPTED PRIVATE KEY'])

--- a/gslib/tests/test_boto_util.py
+++ b/gslib/tests/test_boto_util.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for boto_util.py."""
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import division
+from __future__ import unicode_literals
+
+from gslib import cloud_api
+from gslib.utils import boto_util
+from gslib import context_config
+from gslib.tests import testcase
+from gslib.tests.testcase import base
+from gslib.tests.util import unittest
+
+from six import add_move, MovedModule
+add_move(MovedModule('mock', 'mock', 'unittest.mock'))
+from six.moves import mock
+
+
+class TestBotoUtil(testcase.GsUtilUnitTestCase):
+  """Test utils that make use of the Boto dependency."""
+
+  @mock.patch.object(context_config, 'get_context_config')
+  def testSetsHostBaseToMtlsIfClientCertificateEnabled(self,
+                                                       mock_get_context_config):
+    mock_context_config = mock.Mock()
+    mock_context_config.use_client_certificate = True
+    mock_context_config.client_cert_path = 'path'
+    mock_context_config.client_cert_password = 'password'
+    mock_get_context_config.return_value = mock_context_config
+
+    mock_http_class = mock.Mock(return_value=mock.Mock())
+    mock_http = boto_util.GetNewHttp(mock_http_class)
+    mock_http.add_certificate.assert_called_once_with(
+        key='path',
+        cert='path',
+        domain='',
+        password='password',
+    )

--- a/gslib/tests/test_cloud_api_delegator.py
+++ b/gslib/tests/test_cloud_api_delegator.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for cloud_api_delegator.py."""
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import division
+from __future__ import unicode_literals
+
+from gslib import cloud_api
+from gslib import cloud_api_delegator
+from gslib import context_config
+from gslib import cs_api_map
+from gslib.tests import testcase
+from gslib.tests.testcase import base
+from gslib.tests.util import unittest
+
+from six import add_move, MovedModule
+add_move(MovedModule('mock', 'mock', 'unittest.mock'))
+from six.moves import mock
+
+
+class TestCloudApiDelegator(testcase.GsUtilUnitTestCase):
+  """Test delegator class for cloud provider API clients."""
+
+  @mock.patch.object(context_config, 'get_context_config')
+  def testRaisesErrorIfMtlsUsedWithXml(self, mock_get_context_config):
+    mock_context_config = mock.Mock()
+    mock_context_config.use_client_certificate = True
+    mock_get_context_config.return_value = mock_context_config
+
+    # api_map setup from command_runner.py.
+    api_map = cs_api_map.GsutilApiMapFactory.GetApiMap(
+        gsutil_api_class_map_factory=cs_api_map.GsutilApiClassMapFactory,
+        support_map={'s3': [cs_api_map.ApiSelector.XML]},
+        default_map={'s3': cs_api_map.ApiSelector.XML})
+    delegator = cloud_api_delegator.CloudApiDelegator(None, api_map, None, None)
+
+    with self.assertRaises(cloud_api.ArgumentException):
+      delegator.GetApiSelector(provider='s3')

--- a/gslib/tests/test_context_config.py
+++ b/gslib/tests/test_context_config.py
@@ -27,6 +27,7 @@ import six
 
 from gslib import context_config
 from gslib.tests import testcase
+from gslib.tests.testcase import base
 from gslib.tests.util import SetBotoConfigForTest
 from gslib.tests.util import unittest
 
@@ -152,6 +153,8 @@ class TestPemFileParser(testcase.GsUtilUnitTestCase):
     self.assertIsNone(sections.get('ENCRYPTED PRIVATE KEY'))
 
 
+# Setting global context_config singleton causes issues in parallel.
+@base.NotParallelizable
 @testcase.integration_testcase.SkipForS3('mTLS only runs on GCS JSON API.')
 @testcase.integration_testcase.SkipForXML('mTLS only runs on GCS JSON API.')
 class TestContextConfig(testcase.GsUtilUnitTestCase):
@@ -160,7 +163,6 @@ class TestContextConfig(testcase.GsUtilUnitTestCase):
   def setUp(self):
     super(TestContextConfig, self).setUp()
     self.mock_logger = mock.Mock()
-    context_config._singleton_config = None
 
   def testContextConfigIsASingleton(self):
     first = context_config.create_context_config(self.mock_logger)

--- a/gslib/tests/test_gcs_json_api.py
+++ b/gslib/tests/test_gcs_json_api.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for gcs_json_api.py."""
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import division
+from __future__ import unicode_literals
+
+from gslib import cloud_api
+from gslib import gcs_json_api
+from gslib import context_config
+from gslib.tests import testcase
+from gslib.tests.testcase import base
+from gslib.tests.util import SetBotoConfigForTest
+from gslib.tests.util import unittest
+
+from six import add_move, MovedModule
+add_move(MovedModule('mock', 'mock', 'unittest.mock'))
+from six.moves import mock
+
+
+class TestGcsJsonApi(testcase.GsUtilUnitTestCase):
+  """Test logic for interacting with GCS JSON API."""
+
+  @mock.patch.object(context_config, 'get_context_config')
+  def testSetsHostBaseToMtlsIfClientCertificateEnabled(self,
+                                                       mock_get_context_config):
+    mock_context_config = mock.Mock()
+    mock_context_config.use_client_certificate = True
+    mock_get_context_config.return_value = mock_context_config
+
+    with SetBotoConfigForTest([('Credentials', 'gs_json_host', None),
+                               ('Credentials', 'gs_host', None)]):
+      client = gcs_json_api.GcsJsonApi(None, None, None, None)
+      self.assertEqual(client.host_base, gcs_json_api.MTLS_HOST)
+
+  @mock.patch.object(context_config, 'get_context_config')
+  def testRaisesErrorIfConflictingJsonAndMtlsHost(self,
+                                                  mock_get_context_config):
+    mock_context_config = mock.Mock()
+    mock_context_config.use_client_certificate = True
+    mock_get_context_config.return_value = mock_context_config
+
+    with SetBotoConfigForTest([('Credentials', 'gs_json_host', 'host')]):
+      with self.assertRaises(cloud_api.ArgumentException):
+        gcs_json_api.GcsJsonApi(None, None, None, None)
+
+  def testSetsCustomJsonHost(self):
+    with SetBotoConfigForTest([('Credentials', 'gs_json_host', 'host')]):
+      client = gcs_json_api.GcsJsonApi(None, None, None, None)
+      self.assertEqual(client.host_base, 'host')
+
+  def testSetsDefaultHost(self):
+    with SetBotoConfigForTest([('Credentials', 'gs_json_host', None),
+                               ('Credentials', 'gs_host', None)]):
+      client = gcs_json_api.GcsJsonApi(None, None, None, None)
+      self.assertEqual(client.host_base, gcs_json_api.DEFAULT_HOST)

--- a/gslib/utils/boto_util.py
+++ b/gslib/utils/boto_util.py
@@ -38,6 +38,7 @@ from boto.provider import Provider
 from boto.pyami.config import BotoConfigLocations
 
 import gslib
+from gslib import context_config
 from gslib.exception import CommandException
 from gslib.utils import system_util
 from gslib.utils.constants import DEFAULT_GCS_JSON_API_VERSION
@@ -294,6 +295,14 @@ def GetNewHttp(http_class=httplib2.Http, **kwargs):
   http = http_class(proxy_info=proxy_info, **kwargs)
   http.disable_ssl_certificate_validation = (not config.getbool(
       'Boto', 'https_validate_certificates'))
+
+  global_context_config = context_config.get_context_config()
+  if global_context_config and global_context_config.use_client_certificate:
+    http.add_certificate(key=global_context_config.client_cert_path,
+                         cert=global_context_config.client_cert_path,
+                         domain='',
+                         password=global_context_config.client_cert_password)
+
   return http
 
 


### PR DESCRIPTION
Configure gsutil to optionally connect to the mTLS endpoint, using a device certificate.

Sets up an E2E test to automatically confirm this authentication type continues working.

Builds on: https://github.com/GoogleCloudPlatform/gsutil/pull/1115
Next: https://github.com/GoogleCloudPlatform/gsutil/pull/1142