### PR TITLE
Remove unused credentials from Kokoro build.

### DIFF
--- a/test/ci/kokoro/config_generator.sh
+++ b/test/ci/kokoro/config_generator.sh
@@ -33,8 +33,4 @@ test_hmac_list_service_account = sa-hmac-list@bigstore-gsutil-testing.iam.gservi
 test_hmac_alt_service_account = sa-hmac2@bigstore-gsutil-testing.iam.gserviceaccount.com
 test_impersonate_service_account = bigstore-gsutil-impersonation@bigstore-gsutil-testing.iam.gserviceaccount.com
 test_impersonate_failure_account = no-impersonation@bigstore-gsutil-testing.iam.gserviceaccount.com
-
-[OAuth2]
-client_id = 909320924072.apps.googleusercontent.com
-client_secret = p3RlpR10xMFh9ZXBS/ZNLYUu
 EOM

--- a/test/ci/kokoro/windows/config_generator.ps1
+++ b/test/ci/kokoro/windows/config_generator.ps1
@@ -28,8 +28,5 @@ $stream.WriteLine("test_hmac_list_service_account = sa-hmac-list@bigstore-gsutil
 $stream.WriteLine("test_hmac_alt_service_account = sa-hmac2@bigstore-gsutil-testing.iam.gserviceaccount.com")
 $stream.WriteLine("test_impersonate_service_account = bigstore-gsutil-impersonation@bigstore-gsutil-testing.iam.gserviceaccount.com")
 $stream.WriteLine("test_impersonate_failure_account = no-impersonation@bigstore-gsutil-testing.iam.gserviceaccount.com")
-$stream.WriteLine("[OAuth2]")
-$stream.WriteLine("client_id = 909320924072.apps.googleusercontent.com")
-$stream.WriteLine("client_secret = p3RlpR10xMFh9ZXBS/ZNLYUu")
 $stream.close()
 


### PR DESCRIPTION
These credentials return a `401` error when used by themselves.
We only need the key file earlier in the config for authentication.