### PR TITLE
Add allow pypy installation by allowing openssl 1.0.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+env:
+  - CRYPTOGRAPHY_ALLOW_OPENSSL_102=1
+
 language: python
 
 matrix:


### PR DESCRIPTION
Travis CI for pypy fails with the following error
https://travis-ci.org/github/GoogleCloudPlatform/gsutil/jobs/741939544
```
RuntimeError: You are linking against OpenSSL 1.0.2, which is no longer supported by the OpenSSL project. To use this version of cryptography you need to upgrade to a newer version of OpenSSL. For this version only you can also set the environment variable CRYPTOGRAPHY_ALLOW_OPENSSL_102 to allow OpenSSL 1.0.2.
```

As a quick solution, setting the env variable.