### PR TITLE
Clarification to unset configuration

### DIFF
--- a/gslib/commands/web.py
+++ b/gslib/commands/web.py
@@ -47,7 +47,7 @@ _SET_DESCRIPTION = """
 <B>SET</B>
   The "gsutil web set" command allows you to configure or disable
   Website Configuration on your bucket(s). The "set" sub-command has the
-  following options (leave both options blank to disable):
+  following options (omit both options to unset configuration):
 
 <B>SET OPTIONS</B>
   -m <index.html>      Specifies the object name to serve when a bucket


### PR DESCRIPTION
The original phrasing suggests passing empty parameter values to remove configuration (`gsutil web set -m -e gs://www.example.com`).

That's not correct. The correct to command to unset existing configuration is simply `gsutil web set gs://www.example.com`. The updating phrasing hopefully clarifies this. An example would be even clearer.