### PR TITLE
Fix formatting for empty CORS JSON document

### DIFF
--- a/gslib/commands/cors.py
+++ b/gslib/commands/cors.py
@@ -84,7 +84,7 @@ _DESCRIPTION = ("""
   The following (empty) CORS JSON document removes all CORS configuration for
   a bucket:
 
-  []
+    []
 
   The cors command has two sub-commands:
 """ + '\n'.join([_GET_DESCRIPTION, _SET_DESCRIPTION]) + """


### PR DESCRIPTION
This ensures that a code block is generated in https://cloud.google.com/storage/docs/gsutil/commands/cors?hl=en