### PR TITLE
Improve error message when a bucket's name collides with another.

### DIFF
--- a/gslib/gcs_json_api.py
+++ b/gslib/gcs_json_api.py
@@ -2403,8 +2403,12 @@ class GcsJsonApi(CloudApi):
         if 'The bucket you tried to delete was not empty.' in str(e):
           return NotEmptyException('BucketNotEmpty (%s)' % bucket_name,
                                    status=e.status_code)
-        return ServiceException('Bucket %s already exists.' % bucket_name,
-                                status=e.status_code)
+        return ServiceException(
+          'A Cloud Storage bucket named \'%s\' already exists. Try another '
+          'name. Bucket names must be globally unique across all Google Cloud '
+          'projects, including those outside of your '
+          'organization.' % bucket_name,
+          status=e.status_code)
       elif e.status_code == 412:
         return PreconditionException(message, status=e.status_code)
       return ServiceException(message, status=e.status_code)

--- a/gslib/gcs_json_api.py
+++ b/gslib/gcs_json_api.py
@@ -2404,11 +2404,11 @@ class GcsJsonApi(CloudApi):
           return NotEmptyException('BucketNotEmpty (%s)' % bucket_name,
                                    status=e.status_code)
         return ServiceException(
-          'A Cloud Storage bucket named \'%s\' already exists. Try another '
-          'name. Bucket names must be globally unique across all Google Cloud '
-          'projects, including those outside of your '
-          'organization.' % bucket_name,
-          status=e.status_code)
+            'A Cloud Storage bucket named \'%s\' already exists. Try another '
+            'name. Bucket names must be globally unique across all Google Cloud '
+            'projects, including those outside of your '
+            'organization.' % bucket_name,
+            status=e.status_code)
       elif e.status_code == 412:
         return PreconditionException(message, status=e.status_code)
       return ServiceException(message, status=e.status_code)


### PR DESCRIPTION
The error message from the xml apis already contains the information I added here, and gsutil already displays it in full:

```
ServiceException: 409 Bucket already exists.
<?xml version="1.0" encoding="UTF-8"?>
<Error><Code>BucketAlreadyExists</Code><Message>The requested bucket name is not available. The bucket namespace is shared by all users of the system. Please select a different name and try again.</Message><BucketName>asdf</BucketName><RequestId>2CA9EED1F16E66BB</RequestId><HostId>Ai5MUQ9EG3tJq0ZmlNs9InwVP8DSd4Qnz7TzAMAPORUn/d92j5noMKDi/1/4bapX2+wb9LHwJ5E=</HostId></Error>
```

As a result, I only made this change for the gcs json API. 