### PR TITLE
Add CI checks for Python 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [pypy2, 2.7, pypy3, 3.5, 3.6, 3.7]
+        python-version: [pypy2, 2.7, pypy3, 3.5, 3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2
@@ -31,7 +31,7 @@ jobs:
         pip install pylint
         pip install yapf
         test/run_pylint.sh
-        yapf -dr . 
+        yapf -dr .
     - name: Test
       run: |
         set -x

--- a/test/ci/kokoro/linux/py38_json.cfg
+++ b/test/ci/kokoro/linux/py38_json.cfg
@@ -1,0 +1,61 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "/src/gsutil/test/ci/kokoro/run_integ_tests.sh"
+timeout_mins: 60
+
+# Get access keys from Keystore
+# go/kokoro-keystore
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "gsutil_kokoro_service_key"
+    }
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "mtls_test_account_refresh_token"
+    }
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "mtls_test_account_client_id"
+    }
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "mtls_test_account_client_secret"
+    }
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "mtls_test_cert"
+    }
+  }
+}
+
+# Environment variables to specify interpreter version.
+# go/kokoro-env-vars
+env_vars {
+  key: "PYMAJOR"
+  value: "3"
+}
+
+env_vars {
+  key: "PYMINOR"
+  value: "8"
+}
+
+env_vars {
+  key: "API"
+  value: "json"
+}

--- a/test/ci/kokoro/linux/py38_xml.cfg
+++ b/test/ci/kokoro/linux/py38_xml.cfg
@@ -1,0 +1,45 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "/src/gsutil/test/ci/kokoro/run_integ_tests.sh"
+timeout_mins: 60
+
+# Get access keys from Keystore
+# go/kokoro-keystore
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "gsutil_kokoro_service_key"
+    }
+  }
+}
+
+# Environment variables to specify interpreter version.
+# go/kokoro-env-vars
+env_vars {
+  key: "PYMAJOR"
+  value: "3"
+}
+
+env_vars {
+  key: "PYMINOR"
+  value: "8"
+}
+
+env_vars {
+  key: "API"
+  value: "xml"
+}

--- a/test/ci/kokoro/macos/py38_json.cfg
+++ b/test/ci/kokoro/macos/py38_json.cfg
@@ -1,0 +1,62 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "/src/gsutil/test/ci/kokoro/run_integ_tests.sh"
+timeout_mins: 60
+
+
+# Get access keys from Keystore
+# go/kokoro-keystore
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "gsutil_kokoro_service_key"
+    }
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "mtls_test_account_refresh_token"
+    }
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "mtls_test_account_client_id"
+    }
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "mtls_test_account_client_secret"
+    }
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "mtls_test_cert"
+    }
+  }
+}
+
+# Environment variables to specify interpreter version.
+# go/kokoro-env-vars
+env_vars {
+  key: "PYMAJOR"
+  value: "3"
+}
+
+env_vars {
+  key: "PYMINOR"
+  value: "8"
+}
+
+env_vars {
+  key: "API"
+  value: "json"
+}

--- a/test/ci/kokoro/macos/py38_xml.cfg
+++ b/test/ci/kokoro/macos/py38_xml.cfg
@@ -1,0 +1,46 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "/src/gsutil/test/ci/kokoro/run_integ_tests.sh"
+timeout_mins: 60
+
+
+# Get access keys from Keystore
+# go/kokoro-keystore
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "gsutil_kokoro_service_key"
+    }
+  }
+}
+
+# Environment variables to specify interpreter version.
+# go/kokoro-env-vars
+env_vars {
+  key: "PYMAJOR"
+  value: "3"
+}
+
+env_vars {
+  key: "PYMINOR"
+  value: "8"
+}
+
+env_vars {
+  key: "API"
+  value: "xml"
+}

--- a/test/ci/kokoro/run_integ_tests.sh
+++ b/test/ci/kokoro/run_integ_tests.sh
@@ -61,10 +61,10 @@ function install_pyenv {
       eval "$(pyenv init -)"
     fi
   fi
+  pyenv update
 }
 
 function install_python {
-  pyenv update
   pyenv install -s "$PYVERSIONTRIPLET"
 }
 

--- a/test/ci/kokoro/windows/py38_json.cfg
+++ b/test/ci/kokoro/windows/py38_json.cfg
@@ -1,0 +1,74 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "src/gsutil/test/ci/kokoro/windows/run_integ_tests.bat"
+timeout_mins: 60
+
+
+# Get access keys from Keystore
+# go/kokoro-keystore
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "gsutil_kokoro_service_key"
+    }
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "mtls_test_account_refresh_token"
+    }
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "mtls_test_account_client_id"
+    }
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "mtls_test_account_client_secret"
+    }
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "mtls_test_cert"
+    }
+  }
+}
+
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L15
+build_params {
+  key: "GsutilRepoDir"
+  value: "C:\\src\\gsutil"
+}
+
+# Environment variables to specify interpreter version.
+# go/kokoro-env-vars
+env_vars {
+  key: "PYMAJOR"
+  value: "3"
+}
+
+env_vars {
+  key: "PYMINOR"
+  value: "8"
+}
+
+env_vars {
+  key: "API"
+  value: "json"
+}
+
+env_vars {
+  key: "BOTO_CONFIG"
+  value: "T:\\src\\.boto"
+}
+

--- a/test/ci/kokoro/windows/py38_xml.cfg
+++ b/test/ci/kokoro/windows/py38_xml.cfg
@@ -1,0 +1,58 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "src/gsutil/test/ci/kokoro/windows/run_integ_tests.bat"
+timeout_mins: 60
+
+
+# Get access keys from Keystore
+# go/kokoro-keystore
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "gsutil_kokoro_service_key"
+    }
+  }
+}
+
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L15
+build_params {
+  key: "GsutilRepoDir"
+  value: "C:\\src\\gsutil"
+}
+
+# Environment variables to specify interpreter version.
+# go/kokoro-env-vars
+env_vars {
+  key: "PYMAJOR"
+  value: "3"
+}
+
+env_vars {
+  key: "PYMINOR"
+  value: "8"
+}
+
+env_vars {
+  key: "API"
+  value: "xml"
+}
+
+env_vars {
+  key: "BOTO_CONFIG"
+  value: "T:\\src\\.boto"
+}
+


### PR DESCRIPTION
Adds Python 3.8 checks to kokoro and github actions. I also had to edit the `run_integ_tests.sh` script to make sure that `pyenv update` was called before `pyenv install --list` to ensure that Python 3.8 was available. 