### PR TITLE
Add perf-trace-token support for resumable uploads.

### DIFF
--- a/gslib/gcs_json_api.py
+++ b/gslib/gcs_json_api.py
@@ -1534,6 +1534,7 @@ class GcsJsonApi(CloudApi):
             'user-agent': self.api_client.user_agent,
         }
         additional_headers.update(encryption_headers)
+        self._AddPerfTraceTokenToHeaders(additional_headers)
 
         return self._PerformResumableUpload(
             upload_stream, self.authorized_upload_http, content_type, size,


### PR DESCRIPTION
Trace token was being lost in the headers reset for resumable uploads.