### PR TITLE
Open files in non-append mode to make stripe functionality work in Lustre file sytems

### DIFF
--- a/gslib/utils/copy_helper.py
+++ b/gslib/utils/copy_helper.py
@@ -2697,7 +2697,7 @@ def _DoSlicedDownload(src_url,
                                       num_components)
 
   # Resize the download file so each child process can seek to its start byte.
-  with open(download_file_name, 'ab') as fp:
+  with open(download_file_name, 'r+b') as fp:
     fp.truncate(src_obj_metadata.size)
   # Assign a start FileMessage to each component
   for (i, component) in enumerate(components_to_download):

--- a/gslib/utils/copy_helper.py
+++ b/gslib/utils/copy_helper.py
@@ -2338,8 +2338,9 @@ def _GetDownloadFile(dst_url, src_obj_metadata, logger):
 
   # Downloads open the temporary download file in r+b mode, which requires it
   # to already exist, so we create it here if it doesn't exist already.
-  fp = open(download_file_name, 'ab')
-  fp.close()
+  if not os.path.exists(download_file_name):
+    fp = open(download_file_name, 'w')
+    fp.close()
   return download_file_name, need_to_unzip
 
 


### PR DESCRIPTION
A bug was filed where files downloaded using gsutil were not getting striped on a Lustre File System. It was brought to our notice that this happens because of the APPEND mode. Changing the append mode to r+b mode fixes this issue.