### PR TITLE
gslib/command_runner.py: set HAS_NON_DEFAULT_GS_HOST=False if tests fail to import

### DIFF
--- a/gslib/command_runner.py
+++ b/gslib/command_runner.py
@@ -61,7 +61,10 @@ from gslib.utils.text_util import InsistAsciiHeaderValue
 from gslib.utils.text_util import print_to_fd
 from gslib.utils.unit_util import SECONDS_PER_DAY
 from gslib.utils.update_util import LookUpGsutilVersion
-from gslib.tests.util import HAS_NON_DEFAULT_GS_HOST
+try:
+  from gslib.tests.util import HAS_NON_DEFAULT_GS_HOST
+except ImportError:
+  HAS_NON_DEFAULT_GS_HOST = False
 
 
 def HandleHeaderCoding(headers):


### PR DESCRIPTION
The HAS_NON_DEFAULT_GS_HOST variable seems needed mostly for testing. When
using pyinstaller to generate a binary app, this causes the following
error:

```
Traceback (most recent call last):
  File "pbsync.py", line 1, in <module>
  File "/home/user/.local/lib/python3.8/site-packages/PyInstaller/loader/pyimod03_importers.py", line 493, in exec_module
    exec(bytecode, module.__dict__)
  File "pbtools.py", line 19, in <module>
  File "/home/user/.local/lib/python3.8/site-packages/PyInstaller/loader/pyimod03_importers.py", line 493, in exec_module
    exec(bytecode, module.__dict__)
  File "pbunreal.py", line 15, in <module>
  File "/home/user/.local/lib/python3.8/site-packages/PyInstaller/loader/pyimod03_importers.py", line 493, in exec_module
    exec(bytecode, module.__dict__)
  File "gslib/command_runner.py", line 65, in <module>
ModuleNotFoundError: No module named 'gslib.tests'
[13966] Failed to execute script pbsync
```

Adding an ImportError on this fixes this and the generated binary works.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>