### PR TITLE
Backfill CL 352809909

### DIFF
--- a/gslib/commands/cp.py
+++ b/gslib/commands/cp.py
@@ -641,14 +641,15 @@ _OPTIONS_TEXT = """
                  When you specify the ``-z`` option, the data from your files is
                  compressed before it is uploaded, but your actual files are
                  left uncompressed on the local disk. The uploaded objects
-                 retain the ``Content-Type`` and name of the original files, but are
-                 given a ``Content-Encoding`` header with the value ``gzip`` to
+                 retain the ``Content-Type`` and name of the original files, but
+                 have their ``Content-Encoding`` metadata set to ``gzip`` to
                  indicate that the object data stored are compressed on the
-                 Cloud Storage servers.
+                 Cloud Storage servers and have their ``Cache-Control`` metadata
+                 set to ``no-transform``.
 
                  For example, the following command:
 
-                   gsutil cp -z html -a public-read \\
+                   gsutil cp -z html \\
                      cattypes.html tabby.jpeg gs://mycats
 
                  does the following:
@@ -660,12 +661,8 @@ _OPTIONS_TEXT = """
                    ``image/jpeg``.
                  - The ``-z`` option compresses the data in the file ``cattypes.html``.
                  - The ``-z`` option also sets the ``Content-Encoding`` for
-                   ``cattypes.html`` to ``gzip``.
-                 - The ``-a`` option sets the ACL for both files to public-read.
-                 - If a user tries to view ``cattypes.html`` in a browser, the
-                   browser uncompresses the data based on the
-                   ``Content-Encoding`` header and renders it as HTML based on
-                   the ``Content-Type`` header.
+                   ``cattypes.html`` to ``gzip`` and the ``Cache-Control`` for
+                   ``cattypes.html`` to ``no-transform``.
 
                  Because the ``-z/-Z`` options compress data prior to upload, they
                  are not subject to the same compression buffer bottleneck that


### PR DESCRIPTION
Properly document the metadata settings on objects when using the `-z` flag.