### PR TITLE
Register integration test failures in kokoro script

### DIFF
--- a/gslib/tests/test_cat.py
+++ b/gslib/tests/test_cat.py
@@ -162,6 +162,3 @@ class TestCat(testcase.GsUtilIntegrationTestCase):
       stdout = self.RunGsUtil(
           ['cat', '-r 1-3', suri(object_uri)], return_stdout=True)
       self.assertEqual(stdout, '123')
-
-  def test_kokoro_registers_failures(self):
-    raise Exception

--- a/gslib/tests/test_cat.py
+++ b/gslib/tests/test_cat.py
@@ -162,3 +162,6 @@ class TestCat(testcase.GsUtilIntegrationTestCase):
       stdout = self.RunGsUtil(
           ['cat', '-r 1-3', suri(object_uri)], return_stdout=True)
       self.assertEqual(stdout, '123')
+
+  def test_kokoro_registers_failures(self):
+    raise Exception

--- a/test/ci/kokoro/run_integ_tests.sh
+++ b/test/ci/kokoro/run_integ_tests.sh
@@ -107,6 +107,9 @@ update_submodules
 python "$GSUTIL_ENTRYPOINT" version -l
 # Run integration tests
 python "$GSUTIL_ENTRYPOINT" test -p "$PROCS"
+if ! [[ $? == 0 ]]; then
+  exit 1
+fi
 
 # Run mTLS authentication test.
 if [[ $API == "json" ]]; then

--- a/test/ci/kokoro/run_integ_tests.sh
+++ b/test/ci/kokoro/run_integ_tests.sh
@@ -103,13 +103,12 @@ init_configs
 init_python
 update_submodules
 
+set -e
+
 # Check that we're using the correct config
 python "$GSUTIL_ENTRYPOINT" version -l
 # Run integration tests
 python "$GSUTIL_ENTRYPOINT" test -p "$PROCS"
-if ! [[ $? == 0 ]]; then
-  exit 1
-fi
 
 # Run mTLS authentication test.
 if [[ $API == "json" ]]; then

--- a/test/ci/kokoro/windows/run_integ_tests.bat
+++ b/test/ci/kokoro/windows/run_integ_tests.bat
@@ -30,7 +30,7 @@ git submodule update --init --recursive
 rem Print config info prior to running tests
 %PyExePath% %GsutilRepoDir%\gsutil.py version -l
 
-PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%GsutilRepoDir%\test\ci\kokoro\windows\run_integ_tests.ps1' -GsutilRepoDir '%GsutilRepoDir%' -PyExe '%PyExePath%'"
+PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%GsutilRepoDir%\test\ci\kokoro\windows\run_integ_tests.ps1' -GsutilRepoDir '%GsutilRepoDir%' -PyExe '%PyExePath%'" || exit /B 1
 
 rem mTLS tests only run on GCS JSON.
 if not "json" == "%API%" exit /B 0


### PR DESCRIPTION
Kokoro marks runs as failed when the exit code of run_integ_tests.sh is != 0. Since the exit code of a .sh file is the exit code of the last command if not otherwise specified, when we added mTLS checks to the end of the script we were hiding failures from other parts of the test suite.