### PR TITLE
Show satisifiesPZS info in bucket info listing (ls -Lb)

### DIFF
--- a/gslib/commands/ls.py
+++ b/gslib/commands/ls.py
@@ -437,8 +437,7 @@ class LsCommand(Command):
          '\tLabels:\t\t\t\t{labels}\n' +
          '\tDefault KMS key:\t\t{default_kms_key}\n' + time_created_line +
          time_updated_line + metageneration_line +
-         bucket_policy_only_enabled_line +
-         satisifies_pzs_line +
+         bucket_policy_only_enabled_line + satisifies_pzs_line +
          '\tACL:\t\t\t\t{acl}\n'
          '\tDefault ACL:\t\t\t{default_acl}').format(**fields))
     if bucket_blr.storage_url.scheme == 's3':

--- a/gslib/commands/ls.py
+++ b/gslib/commands/ls.py
@@ -378,6 +378,8 @@ class LsCommand(Command):
     if bucket.iamConfiguration and bucket.iamConfiguration.bucketPolicyOnly:
       enabled = bucket.iamConfiguration.bucketPolicyOnly.enabled
       fields['bucket_policy_only_enabled'] = enabled
+    if bucket.satisfiesPZS:
+      fields['satisfies_pzs'] = bucket.satisfiesPZS
 
     # For field values that are multiline, add indenting to make it look
     # prettier.
@@ -401,6 +403,7 @@ class LsCommand(Command):
     default_eventbased_hold_line = ''
     retention_policy_line = ''
     bucket_policy_only_enabled_line = ''
+    satisifies_pzs_line = ''
     if 'location_type' in fields:
       location_type_line = '\tLocation type:\t\t\t{location_type}\n'
     if 'metageneration' in fields:
@@ -417,6 +420,8 @@ class LsCommand(Command):
     if 'bucket_policy_only_enabled' in fields:
       bucket_policy_only_enabled_line = ('\tBucket Policy Only enabled:\t'
                                          '{bucket_policy_only_enabled}\n')
+    if 'satisfies_pzs' in fields:
+      satisifies_pzs_line = '\tSatisfies PZS:\t\t\t{satisfies_pzs}\n'
 
     text_util.print_to_fd(
         ('{bucket} :\n'
@@ -432,7 +437,9 @@ class LsCommand(Command):
          '\tLabels:\t\t\t\t{labels}\n' +
          '\tDefault KMS key:\t\t{default_kms_key}\n' + time_created_line +
          time_updated_line + metageneration_line +
-         bucket_policy_only_enabled_line + '\tACL:\t\t\t\t{acl}\n'
+         bucket_policy_only_enabled_line +
+         satisifies_pzs_line +
+         '\tACL:\t\t\t\t{acl}\n'
          '\tDefault ACL:\t\t\t{default_acl}').format(**fields))
     if bucket_blr.storage_url.scheme == 's3':
       text_util.print_to_fd(
@@ -549,6 +556,7 @@ class LsCommand(Command):
             'metageneration',
             'retentionPolicy',
             'defaultEventBasedHold',
+            'satisfiesPZS',
             'storageClass',
             'timeCreated',
             'updated',

--- a/gslib/tests/test_ls.py
+++ b/gslib/tests/test_ls.py
@@ -159,9 +159,7 @@ class TestLsUnit(testcase.GsUtilUnitTestCase):
   @mock.patch.object(ls.LsCommand, 'WildcardIterator')
   def test_object_and_prefix_same_name(self, mock_wildcard):
     bucket_uri = self.CreateBucket(bucket_name='foo')
-    bucket_metadata = apitools_messages.Bucket(
-        name='foo',
-        satisfiesPZS=True)
+    bucket_metadata = apitools_messages.Bucket(name='foo', satisfiesPZS=True)
     bucket_uri.root_object = bucket_metadata
     bucket_uri.url_string = 'foo'
     bucket_uri.storage_url = mock.Mock()

--- a/gslib/tests/test_ls.py
+++ b/gslib/tests/test_ls.py
@@ -157,7 +157,7 @@ class TestLsUnit(testcase.GsUtilUnitTestCase):
         datetime.strftime(new_update_time, '%a, %d %b %Y %H:%M:%S GMT'))
 
   @mock.patch.object(ls.LsCommand, 'WildcardIterator')
-  def test_object_and_prefix_same_name(self, mock_wildcard):
+  def test_satisfies_pzs_is_displayed_if_present(self, mock_wildcard):
     bucket_uri = self.CreateBucket(bucket_name='foo')
     bucket_metadata = apitools_messages.Bucket(name='foo', satisfiesPZS=True)
     bucket_uri.root_object = bucket_metadata

--- a/gslib/third_party/storage_apitools/storage_v1_messages.py
+++ b/gslib/third_party/storage_apitools/storage_v1_messages.py
@@ -105,6 +105,7 @@ class Bucket(_messages.Message):
       retention policy cannot be removed or shortened in duration for the
       lifetime of the bucket. Attempting to remove or decrease period of a
       locked retention policy will result in a PERMISSION_DENIED error.
+    satisfiesPZS: Reserved for future use.
     selfLink: The URI of this bucket.
     storageClass: The bucket's default storage class, used whenever no
       storageClass is specified for a newly-created object. This defines how
@@ -404,12 +405,13 @@ class Bucket(_messages.Message):
   owner = _messages.MessageField('OwnerValue', 18)
   projectNumber = _messages.IntegerField(19, variant=_messages.Variant.UINT64)
   retentionPolicy = _messages.MessageField('RetentionPolicyValue', 20)
-  selfLink = _messages.StringField(21)
-  storageClass = _messages.StringField(22)
-  timeCreated = _message_types.DateTimeField(23)
-  updated = _message_types.DateTimeField(24)
-  versioning = _messages.MessageField('VersioningValue', 25)
-  website = _messages.MessageField('WebsiteValue', 26)
+  satisfiesPZS = _messages.BooleanField(21)
+  selfLink = _messages.StringField(22)
+  storageClass = _messages.StringField(23)
+  timeCreated = _message_types.DateTimeField(24)
+  updated = _message_types.DateTimeField(25)
+  versioning = _messages.MessageField('VersioningValue', 26)
+  website = _messages.MessageField('WebsiteValue', 27)
 
 
 class BucketAccessControl(_messages.Message):


### PR DESCRIPTION
The new field, if present, would look like this:

```
$ gsutil ls -Lb gs://bucket/
gs://bucket/ :
        Storage class:                  STANDARD
        Location type:                  multi-region
        Location constraint:            US
        Versioning enabled:             None
        Logging configuration:          None
        Website configuration:          None
        CORS configuration:             None
        Lifecycle configuration:        None
        Requester Pays enabled:         None
        Labels:                         None
        Default KMS key:                None
        Time created:                   Wed, 16 Sep 2020 23:07:02 GMT
        Time updated:                   Wed, 02 Dec 2020 22:45:24 GMT
        Metageneration:                 4
        Bucket Policy Only enabled:     False
        Satisfies PZS:                  True
        ACL:

```