### PR TITLE
Improve reliability when multiple instances of gsutil transfer to the same destination

### DIFF
--- a/gslib/tests/test_cp.py
+++ b/gslib/tests/test_cp.py
@@ -4537,6 +4537,30 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
         'CommandException: Cannot upload from a stream when using gsutil -m',
         stderr)
 
+  @SequentialAndParallelTransfer
+  def test_cp_overwrites_existing_destination(self):
+    key_uri = self.CreateObject(contents=b'foo')
+    fpath = self.CreateTempFile(contents=b'bar')
+    stderr = self.RunGsUtil(['cp', suri(key_uri), fpath], return_stderr=True)
+    with open(fpath, 'rb') as f:
+      self.assertEqual(f.read(), b'foo')
+
+  @SequentialAndParallelTransfer
+  def test_downloads_are_reliable_with_more_than_one_gsutil_instance(self):
+    test_file_count = 10
+    temporary_directory = self.CreateTempDir()
+    bucket_uri = self.CreateBucket(test_objects=test_file_count)
+
+    cp_args = ['cp', suri(bucket_uri, '*'), temporary_directory]
+    process_1 = multiprocessing.Process(target=self.RunGsUtil, args=[cp_args])
+    process_2 = multiprocessing.Process(target=self.RunGsUtil, args=[cp_args])
+    process_1.start()
+    process_2.start()
+    process_1.join()
+    process_2.join()
+
+    self.assertEqual(len(os.listdir(temporary_directory)), test_file_count)
+
 
 class TestCpUnitTests(testcase.GsUtilUnitTestCase):
   """Unit tests for gsutil cp."""
@@ -4583,28 +4607,3 @@ class TestCpUnitTests(testcase.GsUtilUnitTestCase):
     self.assertEquals(1, len(warning_messages))
     self.assertIn('Found no hashes to validate object upload',
                   warning_messages[0])
-
-  @SequentialAndParallelTransfer
-  def test_cp_overwrites_existing_destination(self):
-    key_uri = self.CreateObject(contents=b'foo')
-    fpath = self.CreateTempFile(contents=b'bar')
-    stderr = self.RunGsUtil(['cp', suri(key_uri), fpath],
-                            return_stderr=True)
-    with open(fpath, 'rb') as f:
-      self.assertEqual(f.read(), b'foo')
-
-  @SequentialAndParallelTransfer
-  def test_downloads_are_reliable_with_more_than_one_gsutil_instance(self):
-    test_file_count = 10
-    temporary_directory = self.CreateTempDir()
-    bucket_uri = self.CreateBucket(test_objects=test_file_count)
-
-    cp_args = ['cp', suri(bucket_uri, '*'), temporary_directory]
-    process_1 = multiprocessing.Process(target=self.RunGsUtil, args=[cp_args])
-    process_2 = multiprocessing.Process(target=self.RunGsUtil, args=[cp_args])
-    process_1.start()
-    process_2.start()
-    process_1.join()
-    process_2.join()
-
-    self.assertEqual(len(os.listdir(temporary_directory)), test_file_count)

--- a/gslib/tests/test_cp.py
+++ b/gslib/tests/test_cp.py
@@ -591,12 +591,13 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
 
   @SequentialAndParallelTransfer
   def test_cp_overwrites_existing_destinations(self):
-    key_uri = self.CreateObject(contents=b'foo')
+    ten_mb_string = b'1' * 10 * 1024 * 1024
+    key_uri = self.CreateObject(contents=ten_mb_string)
     fpath = self.CreateTempFile(contents=b'bar')
     stderr = self.RunGsUtil(['cp', suri(key_uri), fpath],
                             return_stderr=True)
     with open(fpath, 'rb') as f:
-      self.assertEqual(f.read(), b'foo')
+      self.assertEqual(f.read(), ten_mb_string)
 
   @SequentialAndParallelTransfer
   def test_noclobber(self):

--- a/gslib/tests/test_cp.py
+++ b/gslib/tests/test_cp.py
@@ -590,6 +590,15 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
     list_for_return_value.append(self.RunGsUtil(arg_list, **kwargs))
 
   @SequentialAndParallelTransfer
+  def test_cp_overwrites_existing_destinations(self):
+    key_uri = self.CreateObject(contents=b'foo')
+    fpath = self.CreateTempFile(contents=b'bar')
+    stderr = self.RunGsUtil(['cp', suri(key_uri), fpath],
+                            return_stderr=True)
+    with open(fpath, 'rb') as f:
+      self.assertEqual(f.read(), b'foo')
+
+  @SequentialAndParallelTransfer
   def test_noclobber(self):
     key_uri = self.CreateObject(contents=b'foo')
     fpath = self.CreateTempFile(contents=b'bar')

--- a/gslib/tests/test_cp.py
+++ b/gslib/tests/test_cp.py
@@ -26,7 +26,6 @@ import datetime
 import gzip
 import hashlib
 import logging
-import multiprocessing
 import os
 import pickle
 import pkgutil
@@ -4552,12 +4551,12 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
     bucket_uri = self.CreateBucket(test_objects=test_file_count)
 
     cp_args = ['cp', suri(bucket_uri, '*'), temporary_directory]
-    process_1 = multiprocessing.Process(target=self.RunGsUtil, args=[cp_args])
-    process_2 = multiprocessing.Process(target=self.RunGsUtil, args=[cp_args])
-    process_1.start()
-    process_2.start()
-    process_1.join()
-    process_2.join()
+    threads = []
+    for _ in range(2):
+      thread = threading.Thread(target=self.RunGsUtil, args=[cp_args])
+      thread.start()
+      threads.append(thread)
+    [t.join() for t in threads]
 
     self.assertEqual(len(os.listdir(temporary_directory)), test_file_count)
 

--- a/gslib/utils/copy_helper.py
+++ b/gslib/utils/copy_helper.py
@@ -3298,8 +3298,8 @@ def _ValidateAndCompleteDownload(logger,
 
   if file_name != final_file_name:
     # Data is still in a temporary file, so move it to a permanent location.
-    if os.path.exists(final_file_name):
-      os.unlink(final_file_name)
+    # if os.path.exists(final_file_name):
+    #   os.unlink(final_file_name)
     os.rename(file_name, final_file_name)
   ParseAndSetPOSIXAttributes(final_file_name,
                              src_obj_metadata,

--- a/gslib/utils/copy_helper.py
+++ b/gslib/utils/copy_helper.py
@@ -3298,8 +3298,6 @@ def _ValidateAndCompleteDownload(logger,
 
   if file_name != final_file_name:
     # Data is still in a temporary file, so move it to a permanent location.
-    # if os.path.exists(final_file_name):
-    #   os.unlink(final_file_name)
     os.rename(file_name, final_file_name)
   ParseAndSetPOSIXAttributes(final_file_name,
                              src_obj_metadata,


### PR DESCRIPTION
Gsutil used to complete downloads in the following steps:

1. Download data to a temporary file.
2. Unlink any existing files at the final destination.
3. Rename the temporary file with the final file name.

This was a problem when two instances of gsutil were running, since they'd use the same name for the temporary destination file. This meant that after one instance completed steps 2 and 3, it'd remove the temporary file the second instance was writing to. As a result, instance 2 could find a file at the final destination and remove it in step 2, but would not have anything to rename with the final file name in step 3. This would make it look like no data was transferred.

This PR removes the unlink operation in step 2, which potentially introduces other problems, since the `os.rename` call raises a `FileExistsError` on some OSes if the destination already exists ([docs](https://docs.python.org/3/library/os.html#os.rename)). The likelihood of encountering this is actually quite low, since gsutil already deletes existing files at the destination at the beginning of a download ([code](https://github.com/GoogleCloudPlatform/gsutil/blob/master/gslib/utils/copy_helper.py#L2335)). To see this error, a user would have to write a file to the destination between starting the download and completing it.