### PR TITLE
Tests now use wrapper functions for object clone/set contents

### DIFF
--- a/gslib/tests/test_compose.py
+++ b/gslib/tests/test_compose.py
@@ -49,7 +49,8 @@ class TestCompose(testcase.GsUtilIntegrationTestCase):
         for data in data_list
     ]
 
-    composite = bucket_uri.clone_replace_name(self.MakeTempName('obj'))
+    composite = self.StorageUriCloneReplaceName(bucket_uri,
+                                                self.MakeTempName('obj'))
 
     self.RunGsUtil(['compose'] + components + [composite.uri])
     self.assertEqual(composite.get_contents_as_string(), b''.join(data_list))
@@ -108,7 +109,8 @@ class TestCompose(testcase.GsUtilIntegrationTestCase):
                                    contents=b'world!',
                                    object_name='component2')
 
-    composite = bucket_uri.clone_replace_name(self.MakeTempName('obj'))
+    composite = self.StorageUriCloneReplaceName(bucket_uri,
+                                                self.MakeTempName('obj'))
 
     self.RunGsUtil(['compose', component1.uri, component2.uri, composite.uri])
     self.assertEqual(composite.get_contents_as_string(), b'hello world!')

--- a/gslib/tests/test_cp.py
+++ b/gslib/tests/test_cp.py
@@ -723,7 +723,7 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
         stdin='bar',
         return_stderr=True)
     self.assertIn('Copying from <STDIN>', stderr)
-    key_uri = bucket_uri.clone_replace_name('foo')
+    key_uri = self.StorageUriCloneReplaceName(bucket_uri, 'foo')
     self.assertEqual(key_uri.get_contents_as_string(), b'bar')
 
   @unittest.skipIf(IS_WINDOWS, 'os.mkfifo not available on Windows.')
@@ -757,7 +757,7 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
       self.fail('Reading/writing to the fifo timed out.')
     self.assertIn('Copying from named pipe', list_for_output[0])
 
-    key_uri = bucket_uri.clone_replace_name(object_name)
+    key_uri = self.StorageUriCloneReplaceName(bucket_uri, object_name)
     self.assertEqual(key_uri.get_contents_as_string(), object_contents)
 
   @unittest.skipIf(IS_WINDOWS, 'os.mkfifo not available on Windows.')
@@ -1090,8 +1090,8 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
     k2_uri = self.CreateObject(bucket_uri=bucket_uri, contents=b'data1')
     g1 = urigen(k2_uri)
     self.RunGsUtil(['cp', suri(k1_uri), suri(k2_uri)])
-    k2_uri = bucket_uri.clone_replace_name(k2_uri.object_name)
-    k2_uri = bucket_uri.clone_replace_key(k2_uri.get_key())
+    k2_uri = self.StorageUriCloneReplaceName(bucket_uri, k2_uri.object_name)
+    k2_uri = self.StorageUriCloneReplaceKey(bucket_uri, k2_uri.get_key())
     g2 = urigen(k2_uri)
     k2_uri.set_contents_from_string('data3')
     g3 = urigen(k2_uri)
@@ -1809,7 +1809,7 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
                       contents=b'def')
 
     # Create a placeholder like what can be left over by web GUI tools.
-    key_uri = src_bucket_uri.clone_replace_name('/')
+    key_uri = self.StorageUriCloneReplaceName(src_bucket_uri, '/')
     key_uri.set_contents_from_string('')
     self.AssertNObjectsInBucket(src_bucket_uri, 3)
 
@@ -1837,7 +1837,7 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
                       contents=b'def')
 
     # Create a placeholder like what can be left over by web GUI tools.
-    key_uri = src_bucket_uri.clone_replace_name('foo/')
+    key_uri = self.StorageUriCloneReplaceName(src_bucket_uri, 'foo/')
     key_uri.set_contents_from_string('')
     self.AssertNObjectsInBucket(src_bucket_uri, 3)
 
@@ -1856,11 +1856,12 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
   def test_copy_quiet(self):
     bucket_uri = self.CreateBucket()
     key_uri = self.CreateObject(bucket_uri=bucket_uri, contents=b'foo')
-    stderr = self.RunGsUtil(
-        ['-q', 'cp',
-         suri(key_uri),
-         suri(bucket_uri.clone_replace_name('o2'))],
-        return_stderr=True)
+    stderr = self.RunGsUtil([
+        '-q', 'cp',
+        suri(key_uri),
+        self.StorageUriCloneReplaceName(suri(bucket_uri, 'o2'))
+    ],
+                            return_stderr=True)
     self.assertEqual(stderr.count('Copying '), 0)
 
   def test_cp_md5_match(self):

--- a/gslib/tests/test_cp.py
+++ b/gslib/tests/test_cp.py
@@ -1093,7 +1093,7 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
     k2_uri = self.StorageUriCloneReplaceName(bucket_uri, k2_uri.object_name)
     k2_uri = self.StorageUriCloneReplaceKey(bucket_uri, k2_uri.get_key())
     g2 = urigen(k2_uri)
-    k2_uri.set_contents_from_string('data3')
+    self.StorageUriSetContentsFromString(k2_uri, 'data3')
     g3 = urigen(k2_uri)
 
     fpath = self.CreateTempFile()
@@ -1810,7 +1810,7 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
 
     # Create a placeholder like what can be left over by web GUI tools.
     key_uri = self.StorageUriCloneReplaceName(src_bucket_uri, '/')
-    key_uri.set_contents_from_string('')
+    self.StorageUriSetContentsFromString(key_uri, '')
     self.AssertNObjectsInBucket(src_bucket_uri, 3)
 
     self.RunGsUtil(['cp', '-R', suri(src_bucket_uri), dst_dir])
@@ -1838,7 +1838,7 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
 
     # Create a placeholder like what can be left over by web GUI tools.
     key_uri = self.StorageUriCloneReplaceName(src_bucket_uri, 'foo/')
-    key_uri.set_contents_from_string('')
+    self.StorageUriSetContentsFromString(key_uri, '')
     self.AssertNObjectsInBucket(src_bucket_uri, 3)
 
     self.RunGsUtil(['cp', '-R', suri(src_bucket_uri), dst_dir])

--- a/gslib/tests/test_cp.py
+++ b/gslib/tests/test_cp.py
@@ -1859,7 +1859,7 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
     stderr = self.RunGsUtil([
         '-q', 'cp',
         suri(key_uri),
-        self.StorageUriCloneReplaceName(suri(bucket_uri, 'o2'))
+        suri(self.StorageUriCloneReplaceName(bucket_uri, 'o2'))
     ],
                             return_stderr=True)
     self.assertEqual(stderr.count('Copying '), 0)

--- a/gslib/tests/test_ls.py
+++ b/gslib/tests/test_ls.py
@@ -422,10 +422,10 @@ class TestLs(testcase.GsUtilIntegrationTestCase):
   def test_subdir(self):
     """Tests listing a bucket subdirectory."""
     bucket_uri = self.CreateBucket(test_objects=1)
-    k1_uri = bucket_uri.clone_replace_name('foo')
-    k1_uri.set_contents_from_string('baz')
-    k2_uri = bucket_uri.clone_replace_name('dir/foo')
-    k2_uri.set_contents_from_string('bar')
+    k1_uri = self.StorageUriCloneReplaceName(bucket_uri, 'foo')
+    self.StorageUriSetContentsFromString(k1_uri, 'baz')
+    k2_uri = self.StorageUriCloneReplaceName(bucket_uri, 'dir/foo')
+    self.StorageUriSetContentsFromString(k2_uri, 'bar')
     # Use @Retry as hedge against bucket listing eventual consistency.
     @Retry(AssertionError, tries=3, timeout_secs=1)
     def _Check1():
@@ -444,14 +444,14 @@ class TestLs(testcase.GsUtilIntegrationTestCase):
     to show multiple matching subdirectories.
     """
     bucket_uri = self.CreateBucket(test_objects=1)
-    k1_uri = bucket_uri.clone_replace_name('foo')
-    k1_uri.set_contents_from_string('baz')
-    k2_uri = bucket_uri.clone_replace_name('dir/foo')
-    k2_uri.set_contents_from_string('bar')
-    k3_uri = bucket_uri.clone_replace_name('dir/foo2')
-    k3_uri.set_contents_from_string('foo')
-    k4_uri = bucket_uri.clone_replace_name('dir2/foo3')
-    k4_uri.set_contents_from_string('foo2')
+    k1_uri = self.StorageUriCloneReplaceName(bucket_uri, 'foo')
+    self.StorageUriSetContentsFromString(k1_uri, 'baz')
+    k2_uri = self.StorageUriCloneReplaceName(bucket_uri, 'dir/foo')
+    self.StorageUriSetContentsFromString(k2_uri, 'bar')
+    k3_uri = self.StorageUriCloneReplaceName(bucket_uri, 'dir/foo2')
+    self.StorageUriSetContentsFromString(k3_uri, 'foo')
+    k4_uri = self.StorageUriCloneReplaceName(bucket_uri, 'dir2/foo3')
+    self.StorageUriSetContentsFromString(k4_uri, 'foo2')
     # Use @Retry as hedge against bucket listing eventual consistency.
     @Retry(AssertionError, tries=3, timeout_secs=1)
     def _Check1():
@@ -472,7 +472,7 @@ class TestLs(testcase.GsUtilIntegrationTestCase):
     bucket_list = list(bucket1_uri.list_bucket())
 
     objuri = [
-        bucket1_uri.clone_replace_key(key).versionless_uri
+        self.StorageUriCloneReplaceKey(bucket1_uri, key).versionless_uri
         for key in bucket_list
     ][0]
     self.RunGsUtil(['cp', objuri, suri(bucket2_uri)])
@@ -485,8 +485,10 @@ class TestLs(testcase.GsUtilIntegrationTestCase):
       self.assertNumLines(stdout, 3)
       stdout = self.RunGsUtil(['ls', '-la', suri(bucket2_uri)],
                               return_stdout=True)
-      self.assertIn('%s#' % bucket2_uri.clone_replace_name(bucket_list[0].name),
-                    stdout)
+      self.assertIn(
+          '%s#' %
+          self.StorageUriCloneReplaceName(bucket2_uri, bucket_list[0].name),
+          stdout)
       self.assertIn('metageneration=', stdout)
 
     _Check2()

--- a/gslib/tests/test_mv.py
+++ b/gslib/tests/test_mv.py
@@ -48,7 +48,7 @@ class TestMv(testcase.GsUtilIntegrationTestCase):
 
     # Move two objects from bucket1 to bucket2.
     objs = [
-        bucket1_uri.clone_replace_key(key).versionless_uri
+        self.StorageUriCloneReplaceKey(bucket1_uri, key).versionless_uri
         for key in bucket1_uri.list_bucket()
     ]
     cmd = (['-m', 'mv'] + objs + [suri(bucket2_uri)])
@@ -71,7 +71,7 @@ class TestMv(testcase.GsUtilIntegrationTestCase):
 
     # Remove one of the objects.
     objs = [
-        bucket2_uri.clone_replace_key(key).versionless_uri
+        self.StorageUriCloneReplaceKey(bucket2_uri, key).versionless_uri
         for key in bucket2_uri.list_bucket()
     ]
     obj1 = objs[0]
@@ -82,7 +82,7 @@ class TestMv(testcase.GsUtilIntegrationTestCase):
 
     # Move the 1 remaining object back.
     objs = [
-        suri(bucket2_uri.clone_replace_key(key))
+        self.StorageUriCloneReplaceKey(suri(bucket2_uri, key))
         for key in bucket2_uri.list_bucket()
     ]
     cmd = (['-m', 'mv'] + objs + [suri(bucket1_uri)])

--- a/gslib/tests/test_mv.py
+++ b/gslib/tests/test_mv.py
@@ -82,7 +82,7 @@ class TestMv(testcase.GsUtilIntegrationTestCase):
 
     # Move the 1 remaining object back.
     objs = [
-        self.StorageUriCloneReplaceKey(suri(bucket2_uri, key))
+        suri(self.StorageUriCloneReplaceKey(bucket2_uri, key))
         for key in bucket2_uri.list_bucket()
     ]
     cmd = (['-m', 'mv'] + objs + [suri(bucket1_uri)])

--- a/gslib/tests/test_requester_pays.py
+++ b/gslib/tests/test_requester_pays.py
@@ -189,7 +189,8 @@ class TestRequesterPays(testcase.GsUtilIntegrationTestCase):
         self.CreateObject(bucket_uri=bucket_uri, contents=data).uri
         for data in data_list
     ]
-    composite = bucket_uri.clone_replace_name(self.MakeTempName('obj'))
+    composite = self.StorageUriCloneReplaceName(bucket_uri,
+                                                self.MakeTempName('obj'))
     self._run_non_requester_pays_test(['compose'] + components +
                                       [composite.uri])
 

--- a/gslib/tests/test_rm.py
+++ b/gslib/tests/test_rm.py
@@ -164,10 +164,10 @@ class TestRm(testcase.GsUtilIntegrationTestCase):
   def test_all_versions_current(self):
     """Test that 'rm -a' for an object with a current version works."""
     bucket_uri = self.CreateVersionedBucket()
-    key_uri = bucket_uri.clone_replace_name('foo')
-    key_uri.set_contents_from_string('bar')
+    key_uri = self.StorageUriCloneReplaceName(bucket_uri, 'foo')
+    self.StorageUriSetContentsFromString(key_uri, 'bar')
     g1 = urigen(key_uri)
-    key_uri.set_contents_from_string('baz')
+    self.StorageUriSetContentsFromString(key_uri, 'baz')
     g2 = urigen(key_uri)
 
     def _Check1(stderr_lines):
@@ -198,10 +198,10 @@ class TestRm(testcase.GsUtilIntegrationTestCase):
   def test_all_versions_no_current(self):
     """Test that 'rm -a' for an object without a current version works."""
     bucket_uri = self.CreateVersionedBucket()
-    key_uri = bucket_uri.clone_replace_name('foo')
-    key_uri.set_contents_from_string('bar')
+    key_uri = self.StorageUriCloneReplaceName(bucket_uri, 'foo')
+    self.StorageUriSetContentsFromString(key_uri, 'bar')
     g1 = urigen(key_uri)
-    key_uri.set_contents_from_string('baz')
+    self.StorageUriSetContentsFromString(key_uri, 'baz')
     g2 = urigen(key_uri)
     self._RunRemoveCommandAndCheck(
         ['-m', 'rm', '-a', suri(key_uri)],
@@ -234,14 +234,14 @@ class TestRm(testcase.GsUtilIntegrationTestCase):
   def test_remove_all_versions_recursive_on_bucket(self):
     """Test that 'rm -r' works on bucket."""
     bucket_uri = self.CreateVersionedBucket()
-    k1_uri = bucket_uri.clone_replace_name('foo')
-    k2_uri = bucket_uri.clone_replace_name('foo2')
-    k1_uri.set_contents_from_string('bar')
-    k2_uri.set_contents_from_string('bar2')
+    k1_uri = self.StorageUriCloneReplaceName(bucket_uri, 'foo')
+    k2_uri = self.StorageUriCloneReplaceName(bucket_uri, 'foo2')
+    self.StorageUriSetContentsFromString(k1_uri, 'bar')
+    self.StorageUriSetContentsFromString(k2_uri, 'bar2')
     k1g1 = urigen(k1_uri)
     k2g1 = urigen(k2_uri)
-    k1_uri.set_contents_from_string('baz')
-    k2_uri.set_contents_from_string('baz2')
+    self.StorageUriSetContentsFromString(k1_uri, 'baz')
+    self.StorageUriSetContentsFromString(k2_uri, 'baz2')
     k1g2 = urigen(k1_uri)
     k2g2 = urigen(k2_uri)
 
@@ -271,14 +271,14 @@ class TestRm(testcase.GsUtilIntegrationTestCase):
   def test_remove_all_versions_recursive_on_subdir(self):
     """Test that 'rm -r' works on subdir."""
     bucket_uri = self.CreateVersionedBucket()
-    k1_uri = bucket_uri.clone_replace_name('dir/foo')
-    k2_uri = bucket_uri.clone_replace_name('dir/foo2')
-    k1_uri.set_contents_from_string('bar')
-    k2_uri.set_contents_from_string('bar2')
+    k1_uri = self.StorageUriCloneReplaceName(bucket_uri, 'dir/foo')
+    k2_uri = self.StorageUriCloneReplaceName(bucket_uri, 'dir/foo2')
+    self.StorageUriSetContentsFromString(k1_uri, 'bar')
+    self.StorageUriSetContentsFromString(k2_uri, 'bar2')
     k1g1 = urigen(k1_uri)
     k2g1 = urigen(k2_uri)
-    k1_uri.set_contents_from_string('baz')
-    k2_uri.set_contents_from_string('baz2')
+    self.StorageUriSetContentsFromString(k1_uri, 'baz')
+    self.StorageUriSetContentsFromString(k2_uri, 'baz2')
     k1g2 = urigen(k1_uri)
     k2g2 = urigen(k2_uri)
 
@@ -335,8 +335,8 @@ class TestRm(testcase.GsUtilIntegrationTestCase):
   def test_some_missing(self):
     """Test that 'rm -a' fails when some but not all uris don't exist."""
     bucket_uri = self.CreateVersionedBucket()
-    key_uri = bucket_uri.clone_replace_name('foo')
-    key_uri.set_contents_from_string('bar')
+    key_uri = self.StorageUriCloneReplaceName(bucket_uri, 'foo')
+    self.StorageUriSetContentsFromString(key_uri, 'bar')
     if self.multiregional_buckets:
       self.AssertNObjectsInBucket(bucket_uri, 1, versioned=True)
     stderr = self.RunGsUtil(
@@ -351,8 +351,8 @@ class TestRm(testcase.GsUtilIntegrationTestCase):
   def test_some_missing_force(self):
     """Test that 'rm -af' succeeds despite hidden first uri."""
     bucket_uri = self.CreateVersionedBucket()
-    key_uri = bucket_uri.clone_replace_name('foo')
-    key_uri.set_contents_from_string('bar')
+    key_uri = self.StorageUriCloneReplaceName(bucket_uri, 'foo')
+    self.StorageUriSetContentsFromString(key_uri, 'bar')
     if self.multiregional_buckets:
       self.AssertNObjectsInBucket(bucket_uri, 1, versioned=True)
     stderr = self.RunGsUtil(
@@ -367,10 +367,10 @@ class TestRm(testcase.GsUtilIntegrationTestCase):
   def test_folder_objects_deleted(self):
     """Test for 'rm -r' of a folder with a dir_$folder$ marker."""
     bucket_uri = self.CreateVersionedBucket()
-    key_uri = bucket_uri.clone_replace_name('abc/o1')
-    key_uri.set_contents_from_string('foobar')
-    folder_uri = bucket_uri.clone_replace_name('abc_$folder$')
-    folder_uri.set_contents_from_string('')
+    key_uri = self.StorageUriCloneReplaceName(bucket_uri, 'abc/o1')
+    self.StorageUriSetContentsFromString(key_uri, 'foobar')
+    folder_uri = self.StorageUriCloneReplaceName(bucket_uri, 'abc_$folder$')
+    self.StorageUriSetContentsFromString(folder_uri, '')
 
     def _RemoveAndCheck():
       self.RunGsUtil(['rm', '-r', '%s' % suri(bucket_uri, 'abc')],
@@ -394,10 +394,10 @@ class TestRm(testcase.GsUtilIntegrationTestCase):
   def test_folder_objects_deleted_with_wildcard(self):
     """Test for 'rm -r' of a folder with a dir_$folder$ marker."""
     bucket_uri = self.CreateVersionedBucket()
-    key_uri = bucket_uri.clone_replace_name('abc/o1')
-    key_uri.set_contents_from_string('foobar')
-    folder_uri = bucket_uri.clone_replace_name('abc_$folder$')
-    folder_uri.set_contents_from_string('')
+    key_uri = self.StorageUriCloneReplaceName(bucket_uri, 'abc/o1')
+    self.StorageUriSetContentsFromString(key_uri, 'foobar')
+    folder_uri = self.StorageUriCloneReplaceName(bucket_uri, 'abc_$folder$')
+    self.StorageUriSetContentsFromString(folder_uri, '')
 
     if self.multiregional_buckets:
       self.AssertNObjectsInBucket(bucket_uri, 2, versioned=True)

--- a/gslib/tests/test_rsync.py
+++ b/gslib/tests/test_rsync.py
@@ -2537,8 +2537,8 @@ class TestRsync(testcase.GsUtilIntegrationTestCase):
       listing1 = TailSet(tmpdir, self.FlatListDir(tmpdir))
       listing2 = TailSet(
           suri(bucket_url, 'subdir'),
-          self.FlatListBucket(self.StorageUriCloneReplaceName(
-              bucket_url, 'subdir')))
+          self.FlatListBucket(
+              self.StorageUriCloneReplaceName(bucket_url, 'subdir')))
       # Dir should have un-altered content.
       self.assertEquals(listing1, set(['/obj1', '/.obj2', '/subdir/obj3']))
       # Bucket subdir should have content like dir.

--- a/gslib/tests/test_rsync.py
+++ b/gslib/tests/test_rsync.py
@@ -2200,7 +2200,7 @@ class TestRsync(testcase.GsUtilIntegrationTestCase):
                       contents=b'obj1')
     # Create a placeholder like what can be left over by web GUI tools.
     key_uri = self.StorageUriCloneReplaceName(bucket_uri, '/')
-    key_uri.set_contents_from_string('')
+    self.StorageUriSetContentsFromString(key_uri, '')
 
     # Use @Retry as hedge against bucket listing eventual consistency.
     @Retry(AssertionError, tries=3, timeout_secs=1)

--- a/gslib/tests/test_rsync.py
+++ b/gslib/tests/test_rsync.py
@@ -2199,7 +2199,7 @@ class TestRsync(testcase.GsUtilIntegrationTestCase):
                       object_name='obj1',
                       contents=b'obj1')
     # Create a placeholder like what can be left over by web GUI tools.
-    key_uri = bucket_uri.clone_replace_name('/')
+    key_uri = self.StorageUriCloneReplaceName(bucket_uri, '/')
     key_uri.set_contents_from_string('')
 
     # Use @Retry as hedge against bucket listing eventual consistency.
@@ -2537,7 +2537,8 @@ class TestRsync(testcase.GsUtilIntegrationTestCase):
       listing1 = TailSet(tmpdir, self.FlatListDir(tmpdir))
       listing2 = TailSet(
           suri(bucket_url, 'subdir'),
-          self.FlatListBucket(bucket_url.clone_replace_name('subdir')))
+          self.StorageUriCloneReplaceName(
+              self.FlatListBucket(bucket_url, 'subdir')))
       # Dir should have un-altered content.
       self.assertEquals(listing1, set(['/obj1', '/.obj2', '/subdir/obj3']))
       # Bucket subdir should have content like dir.
@@ -2583,7 +2584,8 @@ class TestRsync(testcase.GsUtilIntegrationTestCase):
       listing1 = TailSet(tmpdir, self.FlatListDir(tmpdir))
       listing2 = TailSet(
           suri(bucket_url, 'foo'),
-          self.FlatListBucket(bucket_url.clone_replace_name('foo')))
+          self.StorageUriCloneReplaceName(self.FlatListBucket(
+              bucket_url, 'foo')))
       # Dir should have un-altered content.
       self.assertEquals(listing1, set(['/obj1', '/.obj2']))
       # Bucket subdir should have content like dir.

--- a/gslib/tests/test_rsync.py
+++ b/gslib/tests/test_rsync.py
@@ -2537,8 +2537,8 @@ class TestRsync(testcase.GsUtilIntegrationTestCase):
       listing1 = TailSet(tmpdir, self.FlatListDir(tmpdir))
       listing2 = TailSet(
           suri(bucket_url, 'subdir'),
-          self.StorageUriCloneReplaceName(
-              self.FlatListBucket(bucket_url, 'subdir')))
+          self.FlatListBucket(self.StorageUriCloneReplaceName(
+              bucket_url, 'subdir')))
       # Dir should have un-altered content.
       self.assertEquals(listing1, set(['/obj1', '/.obj2', '/subdir/obj3']))
       # Bucket subdir should have content like dir.
@@ -2584,7 +2584,7 @@ class TestRsync(testcase.GsUtilIntegrationTestCase):
       listing1 = TailSet(tmpdir, self.FlatListDir(tmpdir))
       listing2 = TailSet(
           suri(bucket_url, 'foo'),
-          self.StorageUriCloneReplaceName(self.FlatListBucket(
+          self.FlatListBucket(self.StorageUriCloneReplaceName(
               bucket_url, 'foo')))
       # Dir should have un-altered content.
       self.assertEquals(listing1, set(['/obj1', '/.obj2']))

--- a/gslib/tests/testcase/integration_testcase.py
+++ b/gslib/tests/testcase/integration_testcase.py
@@ -1242,7 +1242,7 @@ class GsUtilIntegrationTestCase(base.GsUtilTestCase):
       key: new object name
     """
     return storage_uri.clone_replace_name(name)
-  
+
   def StorageUriSetContentsFromString(self, storage_uri, contents):
     """Wrapper for StorageUri.set_contents_from_string().
 
@@ -1251,6 +1251,7 @@ class GsUtilIntegrationTestCase(base.GsUtilTestCase):
       contents: String of the new contents of the object
     """
     return storage_uri.set_contents_from_string(contents)
+
 
 class KmsTestingResources(object):
   """Constants for KMS resource names to be used in integration testing."""

--- a/gslib/tests/testcase/integration_testcase.py
+++ b/gslib/tests/testcase/integration_testcase.py
@@ -1225,6 +1225,32 @@ class GsUtilIntegrationTestCase(base.GsUtilTestCase):
     return self.RunGsUtil(['ls', suri(bucket_url_string, '**')],
                           return_stdout=True)
 
+  def StorageUriCloneReplaceKey(self, storage_uri, key):
+    """Wrapper for StorageUri.clone_replace_key().
+
+    Args:
+      storage_uri: URI representing the object to be cloned
+      key: key for the new StorageUri to represent
+    """
+    return storage_uri.clone_replace_key(key)
+
+  def StorageUriCloneReplaceName(self, storage_uri, name):
+    """Wrapper for StorageUri.clone_replace_name().
+
+    Args:
+      storage_uri: URI representing the object to be cloned
+      key: new object name
+    """
+    return storage_uri.clone_replace_name(name)
+  
+  def StorageUriSetContentsFromString(self, storage_uri, contents):
+    """Wrapper for StorageUri.set_contents_from_string().
+
+    Args:
+      storage_uri: URI representing the object
+      contents: String of the new contents of the object
+    """
+    return storage_uri.set_contents_from_string(contents)
 
 class KmsTestingResources(object):
   """Constants for KMS resource names to be used in integration testing."""

--- a/gslib/tests/testcase/unit_testcase.py
+++ b/gslib/tests/testcase/unit_testcase.py
@@ -445,7 +445,7 @@ class GsUtilUnitTestCase(base.GsUtilTestCase):
     """
     bucket_uri = bucket_uri or self.CreateBucket(provider=self.default_provider)
     object_name = object_name or self.MakeTempName('obj')
-    key_uri = self.StorageUriCloneReplaceName(bucket_uri, object_name)
+    key_uri = bucket_uri.clone_replace_name(object_name)
     if contents is not None:
       key_uri.set_contents_from_string(contents)
     return key_uri

--- a/gslib/tests/testcase/unit_testcase.py
+++ b/gslib/tests/testcase/unit_testcase.py
@@ -445,7 +445,7 @@ class GsUtilUnitTestCase(base.GsUtilTestCase):
     """
     bucket_uri = bucket_uri or self.CreateBucket(provider=self.default_provider)
     object_name = object_name or self.MakeTempName('obj')
-    key_uri = bucket_uri.clone_replace_name(object_name)
+    key_uri = self.StorageUriCloneReplaceName(bucket_uri, object_name)
     if contents is not None:
       key_uri.set_contents_from_string(contents)
     return key_uri


### PR DESCRIPTION
Adding these functions to the test case as it's generally easier to track down when these functions are called if they're centralized.