### PR TITLE
Raise error in setmeta if no headers are provided.

### DIFF
--- a/gslib/commands/setmeta.py
+++ b/gslib/commands/setmeta.py
@@ -189,6 +189,11 @@ class SetMetaCommand(Command):
     for header in metadata_minus:
       self.metadata_change[header] = ''
 
+    if not self.metadata_change:
+      raise CommandException(
+          'gsutil setmeta requires one or more headers to be provided with the'
+          ' -h flag. See "gsutil help setmeta" for more information.')
+
     if len(self.args) == 1 and not self.recursion_requested:
       url = StorageUrlFromString(self.args[0])
       if not (url.IsCloudUrl() and url.IsObject()):

--- a/gslib/tests/test_setmeta.py
+++ b/gslib/tests/test_setmeta.py
@@ -282,3 +282,12 @@ class TestSetMeta(testcase.GsUtilIntegrationTestCase):
                             expected_status=1,
                             return_stderr=True)
     self.assertIn('Invalid non-ASCII value', stderr)
+
+  def test_setmeta_raises_error_if_not_provided_headers(self):
+    bucket_uri = self.CreateBucket()
+    stderr = self.RunGsUtil(['setmeta', suri(bucket_uri)],
+                            expected_status=1,
+                            return_stderr=True)
+    self.assertIn(
+        'gsutil setmeta requires one or more headers to be provided with the'
+        ' -h flag. See "gsutil help setmeta" for more information.', stderr)


### PR DESCRIPTION
Without headers, the command just iterates over the objects it matches and doesn't do anything.