### PR TITLE
Fix StreamExhausted Error handling for Resumable uploads

### DIFF
--- a/gslib/gcs_json_api.py
+++ b/gslib/gcs_json_api.py
@@ -2297,7 +2297,9 @@ class GcsJsonApi(CloudApi):
         return ResumableUploadAbortException(message or 'Bad Request',
                                              status=e.status_code)
     if isinstance(e, apitools_exceptions.StreamExhausted):
-      return ResumableUploadAbortException(e.message)
+      return ResumableUploadAbortException(
+          '%s; if this issue persists, try deleting the tracker files present'
+          ' under ~/.gsutil/tracker-files/' % str(e))
     if isinstance(e, apitools_exceptions.TransferError):
       if ('Aborting transfer' in str(e) or
           'Not enough bytes in stream' in str(e)):

--- a/gslib/tests/test_copy_helper_funcs.py
+++ b/gslib/tests/test_copy_helper_funcs.py
@@ -371,9 +371,9 @@ class TestCpFuncs(GsUtilUnitTestCase):
     exc = apitools_exceptions.StreamExhausted('Not enough bytes')
     translated_exc = gsutil_api._TranslateApitoolsResumableUploadException(exc)
     self.assertTrue(isinstance(translated_exc, ResumableUploadAbortException))
-    self.assertIn('if this issue persists, try deleting the tracker files'
-                  ' present under ~/.gsutil/tracker-files/',
-                  translated_exc.reason)
+    self.assertIn(
+        'if this issue persists, try deleting the tracker files'
+        ' present under ~/.gsutil/tracker-files/', translated_exc.reason)
 
   def testSetContentTypeFromFile(self):
     """Tests that content type is correctly determined for symlinks."""

--- a/gslib/tests/test_copy_helper_funcs.py
+++ b/gslib/tests/test_copy_helper_funcs.py
@@ -363,6 +363,18 @@ class TestCpFuncs(GsUtilUnitTestCase):
     self.assertIn('this can happen if a file changes size',
                   translated_exc.reason)
 
+  def testTranslateApitoolsResumableUploadExceptionStreamExhausted(self):
+    """Test that StreamExhausted error gets handled."""
+    gsutil_api = GcsJsonApi(GSMockBucketStorageUri,
+                            CreateOrGetGsutilLogger('copy_test'),
+                            DiscardMessagesQueue())
+    exc = apitools_exceptions.StreamExhausted('Not enough bytes')
+    translated_exc = gsutil_api._TranslateApitoolsResumableUploadException(exc)
+    self.assertTrue(isinstance(translated_exc, ResumableUploadAbortException))
+    self.assertIn('if this issue persists, try deleting the tracker files'
+                  ' present under ~/.gsutil/tracker-files/',
+                  translated_exc.reason)
+
   def testSetContentTypeFromFile(self):
     """Tests that content type is correctly determined for symlinks."""
     if system_util.IS_WINDOWS:


### PR DESCRIPTION
StreamExhausted handling is broken currently because it tries to access the `message` member on the error object which does not exist. 

I have also added a message to try cleaning up tracker files if the issue persists.

For context b/144166902
