### PR TITLE
Delete connections after fork.

### DIFF
--- a/gslib/command.py
+++ b/gslib/command.py
@@ -1267,6 +1267,11 @@ class Command(HelpProvider):
     # onto the same socket (and garbling the underlying SSL session).
     # We ensure each process gets its own set of connections here by
     # reinitializing state that tracks connections.
+    connection_pool = StorageUri.provider_pool
+    if connection_pool:
+      for i in connection_pool:
+        connection_pool[i].connection.close()
+
     StorageUri.provider_pool = {}
     StorageUri.connection = None
 

--- a/gslib/command.py
+++ b/gslib/command.py
@@ -1266,11 +1266,9 @@ class Command(HelpProvider):
     # the server to avoid writes from different OS processes interleaving
     # onto the same socket (and garbling the underlying SSL session).
     # We ensure each process gets its own set of connections here by
-    # closing all connections in the storage provider connection pool.
-    connection_pool = StorageUri.provider_pool
-    if connection_pool:
-      for i in connection_pool:
-        connection_pool[i].connection.close()
+    # reinitializing state that tracks connections.
+    StorageUri.provider_pool = {}
+    StorageUri.connection = None
 
   def _GetProcessAndThreadCount(self, process_count, thread_count,
                                 parallel_operations_override):

--- a/gslib/tests/test_parallelism_framework.py
+++ b/gslib/tests/test_parallelism_framework.py
@@ -46,7 +46,6 @@ from gslib.command import DummyArgChecker
 from gslib.tests.mock_cloud_api import MockCloudApi
 from gslib.tests.mock_logging_handler import MockLoggingHandler
 import gslib.tests.testcase as testcase
-from gslib.tests.testcase.base import NotParallelizable
 from gslib.tests.testcase.base import RequiresIsolation
 from gslib.tests.util import unittest
 from gslib.utils.parallelism_framework_util import CheckMultiprocessingAvailableAndInit

--- a/gslib/tests/test_parallelism_framework.py
+++ b/gslib/tests/test_parallelism_framework.py
@@ -30,12 +30,12 @@ import functools
 import mock
 import os
 import signal
+import six
 import threading
 import textwrap
 import time
-import mock
 
-import six
+import boto
 from boto.storage_uri import BucketStorageUri
 from boto.storage_uri import StorageUri
 from gslib import cs_api_map
@@ -845,8 +845,10 @@ class TestParallelismFramework(testcase.GsUtilUnitTestCase):
     logger.removeHandler(mock_log_handler)
 
   def testResetConnectionPoolDeletesConnectionState(self):
-    StorageUri.connection = 'connection'
-    StorageUri.provider_pool = {'s3': 'connection'}
+    StorageUri.connection = mock.Mock(spec=boto.s3.connection.S3Connection)
+    StorageUri.provider_pool = {
+        's3': mock.Mock(spec=boto.s3.connection.S3Connection)
+    }
 
     self.command_class(True)._ResetConnectionPool()
 


### PR DESCRIPTION
The existing code was still resulting in connections being reused across processes. Overwriting the state used to track them with default values works as expected.