### PR TITLE
Fix kokoro failures on MacOS

### DIFF
--- a/test/ci/kokoro/run_integ_tests.sh
+++ b/test/ci/kokoro/run_integ_tests.sh
@@ -57,6 +57,7 @@ function install_pyenv {
     # For now, only doing this on mac,
     # beacuse that was the only place where it appeared to be missing.
     if [[ $KOKORO_JOB_NAME =~ "macos" ]]; then
+      brew update
       brew install pyenv
       eval "$(pyenv init -)"
     fi


### PR DESCRIPTION
Looks like Kokoro on macOS has been failing since quite a while. Looking at one such failure, the issue seems to be happening because of `brew install pyenv` failure.  https://fusion2.corp.google.com/invocations/bf191791-bdaf-4335-b997-515a4b92b73f/targets/cloud_storage_gsutil%2Fmacos%2Fpy37_json/log

I am trying to run `brew update` before the `brew install pyenv` command.