### PR TITLE
Fix resumable upload tests

### DIFF
--- a/gslib/tests/test_cp.py
+++ b/gslib/tests/test_cp.py
@@ -2873,10 +2873,10 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
     tmp_dir = self.CreateTempDir()
     fpath = self.CreateTempFile(file_name='foo',
                                 tmpdir=tmp_dir,
-                                contents=b'a' * ONE_KIB * 512)
+                                contents=b'a' * ONE_KIB * ONE_KIB)
     test_callback_file = self.CreateTempFile(contents=pickle.dumps(
         HaltingCopyCallbackHandler(True,
-                                   int(ONE_KIB) * 384)))
+                                   int(ONE_KIB) * 512)))
     resumable_threshold_for_test = ('GSUtil', 'resumable_threshold',
                                     str(ONE_KIB))
     resumable_chunk_size_for_test = ('GSUtil', 'json_resumable_chunk_size',
@@ -2892,7 +2892,7 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
       self.assertIn('Artifically halting upload', stderr)
       fpath = self.CreateTempFile(file_name='foo',
                                   tmpdir=tmp_dir,
-                                  contents=b'b' * ONE_KIB * 512)
+                                  contents=b'b' * ONE_KIB * ONE_KIB)
       stderr = self.RunGsUtil(['cp', fpath, suri(bucket_uri)],
                               expected_status=1,
                               return_stderr=True)
@@ -2908,10 +2908,10 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
     tmp_dir = self.CreateTempDir()
     fpath = self.CreateTempFile(file_name='foo',
                                 tmpdir=tmp_dir,
-                                contents=b'a' * ONE_KIB * 512)
+                                contents=b'a' * ONE_KIB * ONE_KIB)
     test_callback_file = self.CreateTempFile(contents=pickle.dumps(
         HaltingCopyCallbackHandler(True,
-                                   int(ONE_KIB) * 384)))
+                                   int(ONE_KIB) * 512)))
     resumable_threshold_for_test = ('GSUtil', 'resumable_threshold',
                                     str(ONE_KIB))
     resumable_chunk_size_for_test = ('GSUtil', 'json_resumable_chunk_size',
@@ -2927,7 +2927,7 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
       self.assertIn('Artifically halting upload', stderr)
       fpath = self.CreateTempFile(file_name='foo',
                                   tmpdir=tmp_dir,
-                                  contents=b'a' * ONE_KIB)
+                                  contents=b'a' * ONE_KIB * ONE_KIB)
       stderr = self.RunGsUtil(['cp', fpath, suri(bucket_uri)],
                               expected_status=1,
                               return_stderr=True)

--- a/gslib/tests/util.py
+++ b/gslib/tests/util.py
@@ -667,11 +667,10 @@ class HaltingCopyCallbackHandler(object):
   def call(self, total_bytes_transferred, total_size):
     """Forcibly exits if the transfer has passed the halting point.
 
-    Note that this function is only called when the linked conditions are
-    met: https://github.com/GoogleCloudPlatform/gsutil/blob/master/gslib/progress_callback.py#L128.
-
-    This means that self._halt_at_byte is only precise if it's divisible by
-    progress_callback._START_BYTES_PER_CALLBACK.
+    Note that this function is only called when the conditions in
+    gslib.progress_callback.ProgressCallbackWithTimeout.Progress are met, so
+    self._halt_at_byte is only precise if it's divisible by
+    gslib.progress_callback._START_BYTES_PER_CALLBACK.
     """
     if total_bytes_transferred >= self._halt_at_byte:
       sys.stderr.write(

--- a/gslib/tests/util.py
+++ b/gslib/tests/util.py
@@ -665,7 +665,14 @@ class HaltingCopyCallbackHandler(object):
 
   # pylint: disable=invalid-name
   def call(self, total_bytes_transferred, total_size):
-    """Forcibly exits if the transfer has passed the halting point."""
+    """Forcibly exits if the transfer has passed the halting point.
+
+    Note that this function is only called when the linked conditions are
+    met: https://github.com/GoogleCloudPlatform/gsutil/blob/master/gslib/progress_callback.py#L128.
+
+    This means that self._halt_at_byte is only precise if it's divisible by
+    progress_callback._START_BYTES_PER_CALLBACK.
+    """
     if total_bytes_transferred >= self._halt_at_byte:
       sys.stderr.write(
           'Halting transfer after byte %s. %s/%s transferred.\r\n' %


### PR DESCRIPTION
Some tests weren't working as intended because progress callbacks are called less frequently than they assumed. See the conditions [here](https://github.com/GoogleCloudPlatform/gsutil/blob/master/gslib/progress_callback.py#L128). 