### PR TITLE
Fix daisy chain for windows

### DIFF
--- a/gslib/daisy_chain_wrapper.py
+++ b/gslib/daisy_chain_wrapper.py
@@ -269,7 +269,7 @@ class DaisyChainWrapper(object):
       # return 'foo', and in the subsequent calls
       # we will return 'barba' and 'z'. This is done with the assumption
       # that the length of data that gets written to self.buffer is always
-      # a multiple of "amt", which means the chances of such cases are pretty
+      # a multiple of "amt", which means the chance of such cases are pretty
       # rare. This assumption helps us keep this logic simple and avoid
       # string concatenations and splits ('foo' + 'ba' in the above case).
       if not valid_data:

--- a/gslib/daisy_chain_wrapper.py
+++ b/gslib/daisy_chain_wrapper.py
@@ -262,15 +262,15 @@ class DaisyChainWrapper(object):
         # Buffer was empty, yield thread priority so the download thread can fill.
         time.sleep(0)
     with self.lock:
-      # Note that we are not handling the rare case where len(valid_data) < amt
+      # Note that we are not handling the rare case where len(valid_data) < amt,
       # and there are elements in the buffer.
-      # For e.g if valid_data = 'foo' and amt = 5, and we have 'barbaz' in
+      # e.g if valid_data = 'foo' and amt = 5, and we have 'barbaz' in
       # self.buffer, instead of returning 'fooba' in the current call, we
-      # return 'foo' and in the subsequent calls we will return 'barba' and 'z'
-      # This is done with the assumption in mind that the length of data
-      # that gets written to self.buffer is always in the multiple of "amt",
-      # which means the chances of such cases are pretty rare.
-      # This assumption helps us keep this logic simple and avoid
+      # return 'foo', and in the subsequent calls
+      # we will return 'barba' and 'z'. This is done with the assumption
+      # that the length of data that gets written to self.buffer is always
+      # a multiple of "amt", which means the chances of such cases are pretty
+      # rare. This assumption helps us keep this logic simple and avoid
       # string concatenations and splits ('foo' + 'ba' in the above case).
       if not valid_data:
         data = self.buffer.popleft()

--- a/gslib/daisy_chain_wrapper.py
+++ b/gslib/daisy_chain_wrapper.py
@@ -262,15 +262,14 @@ class DaisyChainWrapper(object):
         # Buffer was empty, yield thread priority so the download thread can fill.
         time.sleep(0)
     with self.lock:
-      # Note that we are not handling the rare case where len(valid_data) < amt,
-      # and there are elements in the buffer.
-      # e.g if valid_data = 'foo' and amt = 5, and we have 'barbaz' in
-      # self.buffer, instead of returning 'fooba' in the current call, we
-      # return 'foo', and in the subsequent calls
-      # we will return 'barba' and 'z'. This is done with the assumption
-      # that the length of data that gets written to self.buffer is always
-      # a multiple of "amt", which means the chance of such cases are pretty
-      # rare. This assumption helps us keep this logic simple and avoid
+      # In a rare case where len(valid_data) < amt, and there are
+      # elements in the buffer, e.g let's say valid_data = 'foo' and amt = 5,
+      # and we have 'barbaz' in self.buffer, instead of returning 'fooba'
+      # in the current call, we return 'foo', and in the subsequent calls
+      # we will return 'barba' and 'z'. Given that we set
+      # TRANSFER_BUFFER_SIZE as a multiple of the amt (8KiB),
+      # we can safely assume that this will never happen practically.
+      # This assumption helps us keep the logic simple and avoid
       # string concatenations and splits ('foo' + 'ba' in the above case).
       if not valid_data:
         data = self.buffer.popleft()

--- a/gslib/tests/test_daisy_chain_wrapper.py
+++ b/gslib/tests/test_daisy_chain_wrapper.py
@@ -151,6 +151,38 @@ class TestDaisyChainWrapper(testcase.GsUtilUnitTestCase):
       with open(self.test_data_file, 'rb') as download_stream:
         self.assertEqual(upload_stream.read(), download_stream.read())
 
+  def testDownloadWithDifferentChunkSize(self):
+    """Tests multiple calls to GetObjectMedia."""
+    upload_file = self.CreateTempFile()
+    write_values = []
+    with open(self.test_data_file, 'rb') as stream:
+      # Use an arbitrary size for writing data to the buffer.
+      # For reading from the buffer WriteFromWrapperToFile will
+      # use TRANSFER_BUFFER_SIZE.
+      buffer_write_size = TRANSFER_BUFFER_SIZE * 2 + 10
+      while True:
+        # Write data with size
+        data = stream.read(buffer_write_size)
+        if not data:
+          break
+        write_values.append(data)
+    mock_api = self.MockDownloadCloudApi(write_values)
+    daisy_chain_wrapper = DaisyChainWrapper(
+        self._dummy_url,
+        self.test_data_file_len,
+        mock_api,
+        download_chunk_size=TRANSFER_BUFFER_SIZE)
+    self._WriteFromWrapperToFile(daisy_chain_wrapper, upload_file)
+    num_expected_calls = self.test_data_file_len // TRANSFER_BUFFER_SIZE
+    if self.test_data_file_len % TRANSFER_BUFFER_SIZE:
+      num_expected_calls += 1
+    # Since the chunk size is < the file size, multiple calls to GetObjectMedia
+    # should be made.
+    self.assertEqual(mock_api.get_calls, num_expected_calls)
+    with open(upload_file, 'rb') as upload_stream:
+      with open(self.test_data_file, 'rb') as download_stream:
+        self.assertEqual(upload_stream.read(), download_stream.read())
+
   def testDownloadWithZeroWrites(self):
     """Tests 0-byte writes to the download stream from GetObjectMedia."""
     write_values = []

--- a/gslib/tests/test_daisy_chain_wrapper.py
+++ b/gslib/tests/test_daisy_chain_wrapper.py
@@ -19,6 +19,7 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import unicode_literals
 
+import math
 import os
 import pkgutil
 
@@ -156,12 +157,12 @@ class TestDaisyChainWrapper(testcase.GsUtilUnitTestCase):
     upload_file = self.CreateTempFile()
     write_values = []
     with open(self.test_data_file, 'rb') as stream:
-      # Use an arbitrary size for writing data to the buffer.
-      # For reading from the buffer WriteFromWrapperToFile will
-      # use TRANSFER_BUFFER_SIZE.
+      # Use an arbitrary size greater than TRANSFER_BUFFER_SIZE for writing
+      # data to the buffer. For reading from the buffer
+      # WriteFromWrapperToFile will use TRANSFER_BUFFER_SIZE.
       buffer_write_size = TRANSFER_BUFFER_SIZE * 2 + 10
       while True:
-        # Write data with size
+        # Write data with size.
         data = stream.read(buffer_write_size)
         if not data:
           break
@@ -173,9 +174,8 @@ class TestDaisyChainWrapper(testcase.GsUtilUnitTestCase):
         mock_api,
         download_chunk_size=TRANSFER_BUFFER_SIZE)
     self._WriteFromWrapperToFile(daisy_chain_wrapper, upload_file)
-    num_expected_calls = self.test_data_file_len // TRANSFER_BUFFER_SIZE
-    if self.test_data_file_len % TRANSFER_BUFFER_SIZE:
-      num_expected_calls += 1
+    num_expected_calls = math.ceil(
+        self.test_data_file_len / TRANSFER_BUFFER_SIZE)
     # Since the chunk size is < the file size, multiple calls to GetObjectMedia
     # should be made.
     self.assertEqual(mock_api.get_calls, num_expected_calls)

--- a/gslib/tests/test_daisy_chain_wrapper.py
+++ b/gslib/tests/test_daisy_chain_wrapper.py
@@ -174,8 +174,8 @@ class TestDaisyChainWrapper(testcase.GsUtilUnitTestCase):
         mock_api,
         download_chunk_size=TRANSFER_BUFFER_SIZE)
     self._WriteFromWrapperToFile(daisy_chain_wrapper, upload_file)
-    num_expected_calls = math.ceil(
-        self.test_data_file_len / TRANSFER_BUFFER_SIZE)
+    num_expected_calls = math.ceil(self.test_data_file_len /
+                                   TRANSFER_BUFFER_SIZE)
     # Since the chunk size is < the file size, multiple calls to GetObjectMedia
     # should be made.
     self.assertEqual(mock_api.get_calls, num_expected_calls)


### PR DESCRIPTION
The Daisy chain copy for GCS to S3 is broken on windows because of different read and write size which happens as Windows uses 64KB TRANSFER_BUFFER_SIZE as of https://github.com/GoogleCloudPlatform/gsutil/commit/ffa1eb7d4d9fe8dd877452f28f55fdf51c2a6c12 and the daisy chain logic expects same read and write size. However, the http.client module will read in 8KiB chunks. 

This PR modifies the read logic so that a read size < TRANSFER_BUFFER_SIZE can be handled.

For reference: b/185961088