### PR TITLE
E2E Tests for Persisting Custom Endpoints

### DIFF
--- a/gslib/tests/test_psc.py
+++ b/gslib/tests/test_psc.py
@@ -28,7 +28,6 @@ from gslib.tests.util import ObjectToURI
 from gslib.tests.util import SetBotoConfigForTest
 from gslib.tests.util import unittest
 
-
 # Get full output from stdout, which might not be piped in Python 3.
 PYTHON_UNBUFFERED_ENV_VAR = {'PYTHONUNBUFFERED': '1'}
 
@@ -48,7 +47,8 @@ class TestPsc(testcase.GsUtilIntegrationTestCase):
     temporary_directory = self.CreateTempDir()
     with SetBotoConfigForTest([
         ('GSUtil', 'sliced_object_download_threshold', '1B'),
-        ('GSUtil', 'sliced_object_download_component_size', '1B')]):
+        ('GSUtil', 'sliced_object_download_component_size', '1B')
+    ]):
       bucket_uri = self.CreateBucket()
       key_uri = self.CreateObject(bucket_uri=bucket_uri, contents=b'foo')
 
@@ -72,12 +72,14 @@ class TestPsc(testcase.GsUtilIntegrationTestCase):
     temporary_directory = self.CreateTempDir()
     with SetBotoConfigForTest([
         ('GSUtil', 'sliced_object_download_threshold', '1B'),
-        ('GSUtil', 'sliced_object_download_component_size', '1B')]):
+        ('GSUtil', 'sliced_object_download_component_size', '1B')
+    ]):
       bucket_uri = self.CreateBucket()
       key_uri = self.CreateObject(bucket_uri=bucket_uri, contents=b'foo')
       stdout, stderr = self.RunGsUtil(
           ['-D', 'cp', ObjectToURI(key_uri), temporary_directory],
-          return_stdout=True, return_stderr=True)
+          return_stdout=True,
+          return_stderr=True)
 
     output = stdout + stderr
 
@@ -86,7 +88,8 @@ class TestPsc(testcase.GsUtilIntegrationTestCase):
 
   @integration_testcase.SkipForXML('JSON test.')
   @integration_testcase.SkipForS3('Custom endpoints not available for S3.')
-  def test_persists_custom_endpoint_through_json_parallel_composite_upload(self):
+  def test_persists_custom_endpoint_through_json_parallel_composite_upload(
+      self):
     gs_host = config.get('Credentials', 'gs_json_host', DEFAULT_HOST)
     if gs_host == DEFAULT_HOST:
       # Captures case where user may have manually set gs_host to the
@@ -96,10 +99,12 @@ class TestPsc(testcase.GsUtilIntegrationTestCase):
     temporary_file = self.CreateTempFile(contents=b'foo')
     with SetBotoConfigForTest([
         ('GSUtil', 'parallel_composite_upload_threshold', '1B'),
-        ('GSUtil', 'parallel_composite_upload_component_size', '1B')]):
+        ('GSUtil', 'parallel_composite_upload_component_size', '1B')
+    ]):
       bucket_uri = self.CreateBucket()
       stdout = self.RunGsUtil(
-          ['-DD', 'cp', temporary_file, ObjectToURI(bucket_uri)],
+          ['-DD', 'cp', temporary_file,
+           ObjectToURI(bucket_uri)],
           env_vars=PYTHON_UNBUFFERED_ENV_VAR,
           return_stdout=True)
 
@@ -118,11 +123,14 @@ class TestPsc(testcase.GsUtilIntegrationTestCase):
     temporary_file = self.CreateTempFile(contents=b'foo')
     with SetBotoConfigForTest([
         ('GSUtil', 'parallel_composite_upload_threshold', '1B'),
-        ('GSUtil', 'parallel_composite_upload_component_size', '1B')]):
+        ('GSUtil', 'parallel_composite_upload_component_size', '1B')
+    ]):
       bucket_uri = self.CreateBucket()
       stdout, stderr = self.RunGsUtil(
-          ['-D', 'cp', temporary_file, ObjectToURI(bucket_uri)],
-          return_stdout=True, return_stderr=True)
+          ['-D', 'cp', temporary_file,
+           ObjectToURI(bucket_uri)],
+          return_stdout=True,
+          return_stderr=True)
 
     output = stdout + stderr
     self.assertIn(gs_host, output)

--- a/gslib/tests/test_psc.py
+++ b/gslib/tests/test_psc.py
@@ -1,0 +1,129 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for private service connect custom endpoints."""
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import division
+from __future__ import unicode_literals
+
+from boto import config
+
+from gslib.gcs_json_api import DEFAULT_HOST
+from gslib.tests import testcase
+from gslib.tests.testcase import integration_testcase
+from gslib.tests.util import ObjectToURI
+from gslib.tests.util import SetBotoConfigForTest
+from gslib.tests.util import unittest
+
+
+# Get full output from stdout, which might not be piped in Python 3.
+PYTHON_UNBUFFERED_ENV_VAR = {'PYTHONUNBUFFERED': '1'}
+
+
+class TestPsc(testcase.GsUtilIntegrationTestCase):
+  """Integration tests for PSC custom endpoints."""
+
+  @integration_testcase.SkipForXML('JSON test.')
+  @integration_testcase.SkipForS3('Custom endpoints not available for S3.')
+  def test_persists_custom_endpoint_through_json_sliced_download(self):
+    gs_host = config.get('Credentials', 'gs_json_host', DEFAULT_HOST)
+    if gs_host == DEFAULT_HOST:
+      # Captures case where user may have manually set gs_json_host to the
+      # value of DEFAULT_HOST.
+      return
+
+    temporary_directory = self.CreateTempDir()
+    with SetBotoConfigForTest([
+        ('GSUtil', 'sliced_object_download_threshold', '1B'),
+        ('GSUtil', 'sliced_object_download_component_size', '1B')]):
+      bucket_uri = self.CreateBucket()
+      key_uri = self.CreateObject(bucket_uri=bucket_uri, contents=b'foo')
+
+      stdout = self.RunGsUtil(
+          ['-DD', 'cp', ObjectToURI(key_uri), temporary_directory],
+          env_vars=PYTHON_UNBUFFERED_ENV_VAR,
+          return_stdout=True)
+
+    self.assertIn(gs_host, stdout)
+    self.assertNotIn(DEFAULT_HOST, stdout)
+
+  @integration_testcase.SkipForJSON('XML test.')
+  @integration_testcase.SkipForS3('Custom endpoints not available for S3.')
+  def test_persists_custom_endpoint_through_xml_sliced_download(self):
+    gs_host = config.get('Credentials', 'gs_host', DEFAULT_HOST)
+    if gs_host == DEFAULT_HOST:
+      # Captures case where user may have manually set gs_host to the
+      # value of DEFAULT_HOST.
+      return
+
+    temporary_directory = self.CreateTempDir()
+    with SetBotoConfigForTest([
+        ('GSUtil', 'sliced_object_download_threshold', '1B'),
+        ('GSUtil', 'sliced_object_download_component_size', '1B')]):
+      bucket_uri = self.CreateBucket()
+      key_uri = self.CreateObject(bucket_uri=bucket_uri, contents=b'foo')
+      stdout, stderr = self.RunGsUtil(
+          ['-D', 'cp', ObjectToURI(key_uri), temporary_directory],
+          return_stdout=True, return_stderr=True)
+
+    output = stdout + stderr
+
+    self.assertIn(gs_host, output)
+    self.assertNotIn('hostname=' + DEFAULT_HOST, output)
+
+  @integration_testcase.SkipForXML('JSON test.')
+  @integration_testcase.SkipForS3('Custom endpoints not available for S3.')
+  def test_persists_custom_endpoint_through_json_parallel_composite_upload(self):
+    gs_host = config.get('Credentials', 'gs_json_host', DEFAULT_HOST)
+    if gs_host == DEFAULT_HOST:
+      # Captures case where user may have manually set gs_host to the
+      # value of DEFAULT_HOST.
+      return
+
+    temporary_file = self.CreateTempFile(contents=b'foo')
+    with SetBotoConfigForTest([
+        ('GSUtil', 'parallel_composite_upload_threshold', '1B'),
+        ('GSUtil', 'parallel_composite_upload_component_size', '1B')]):
+      bucket_uri = self.CreateBucket()
+      stdout = self.RunGsUtil(
+          ['-DD', 'cp', temporary_file, ObjectToURI(bucket_uri)],
+          env_vars=PYTHON_UNBUFFERED_ENV_VAR,
+          return_stdout=True)
+
+    self.assertIn(gs_host, stdout)
+    self.assertNotIn(DEFAULT_HOST, stdout)
+
+  @integration_testcase.SkipForJSON('XML test.')
+  @integration_testcase.SkipForS3('Custom endpoints not available for S3.')
+  def test_persists_custom_endpoint_through_xml_parallel_composite_upload(self):
+    gs_host = config.get('Credentials', 'gs_host', DEFAULT_HOST)
+    if gs_host == DEFAULT_HOST:
+      # Captures case where user may have manually set gs_host to the
+      # value of DEFAULT_HOST.
+      return
+
+    temporary_file = self.CreateTempFile(contents=b'foo')
+    with SetBotoConfigForTest([
+        ('GSUtil', 'parallel_composite_upload_threshold', '1B'),
+        ('GSUtil', 'parallel_composite_upload_component_size', '1B')]):
+      bucket_uri = self.CreateBucket()
+      stdout, stderr = self.RunGsUtil(
+          ['-D', 'cp', temporary_file, ObjectToURI(bucket_uri)],
+          return_stdout=True, return_stderr=True)
+
+    output = stdout + stderr
+    self.assertIn(gs_host, output)
+    self.assertNotIn('hostname=' + DEFAULT_HOST, output)

--- a/test/ci/kokoro/run_integ_tests.sh
+++ b/test/ci/kokoro/run_integ_tests.sh
@@ -106,10 +106,18 @@ update_submodules
 
 set -e
 
-# Check that we're using the correct config
+# Check that we're using the correct config.
 python "$GSUTIL_ENTRYPOINT" version -l
-# Run integration tests
+# Run integration tests.
 python "$GSUTIL_ENTRYPOINT" test -p "$PROCS"
+# Run custom endpoint tests.
+# We don't generate a .boto for these tests since there are only a few settings.
+python "$GSUTIL_ENTRYPOINT" \
+  -o "Credentials:gs_host=storage-psc.p.googleapis.com" \
+  -o "Credentials:gs_host_header=storage.googleapis.com" \
+  -o "Credentials:gs_json_host=storage-psc.p.googleapis.com" \
+  -o "Credentials:gs_json_host_header=www.googleapis.com" \
+  test gslib.tests.test_psc
 
 # Run mTLS authentication test.
 if [[ $API == "json" ]]; then

--- a/test/ci/kokoro/windows/run_integ_tests.bat
+++ b/test/ci/kokoro/windows/run_integ_tests.bat
@@ -32,6 +32,14 @@ rem Print config info prior to running tests
 
 PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%GsutilRepoDir%\test\ci\kokoro\windows\run_integ_tests.ps1' -GsutilRepoDir '%GsutilRepoDir%' -PyExe '%PyExePath%'" || exit /B 1
 
+rem Run custom endpont tests.
+rem Not enough settings to merit generating a boto config.
+set PscConfig=-o "Credentials:gs_host=storage-psc.p.googleapis.com"^
+ -o "Credentials:gs_host_header=storage.googleapis.com"^
+ -o "Credentials:gs_json_host=storage-psc.p.googleapis.com"^
+ -o "Credentials:gs_json_host_header=www.googleapis.com"
+PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%GsutilRepoDir%\test\ci\kokoro\windows\run_integ_tests.ps1' -GsutilRepoDir '%GsutilRepoDir%' -PyExe '%PyExePath%' -Tests 'psc' -TopLevelFlags '%PscConfig%'" || exit /B 1
+
 rem mTLS tests only run on GCS JSON.
 if not "json" == "%API%" exit /B 0
 

--- a/test/ci/kokoro/windows/run_integ_tests.ps1
+++ b/test/ci/kokoro/windows/run_integ_tests.ps1
@@ -24,12 +24,16 @@
   to run tests in test_cp.py and test_label.py, one should pass the string
   "cp,label". To run individual cp tests, one might pass
   "cp.TestCp.test_noclobber,cp.TestCp.test_streaming".
+.PARAMETER TopLevelFlags
+  Top level flags to pass to gsutil, such as "-o GSUtil:gs_host=...".
+  Accepts a string containing all top level flags.
 #>
 
 param (
   [string]$GsutilRepoDir,
   [string]$PyExe,
-  [string]$Tests
+  [string]$Tests,
+  [string]$TopLevelFlags
 )
 
 $SCRIPT_START_DATE = (Get-Date)  # Used to calculate runtime duration upon completion.
@@ -105,6 +109,7 @@ foreach ($test_group in $Tests) {
     mkdir -Force "$using:state_dirs_path\state_dir_$using:test_group" > $null
     & $using:PyExe "$using:GsutilRepoDir\gsutil.py" `
         -o "GSUtil:state_dir=$using:state_dirs_path\state_dir_$using:test_group" `
+        $using:TopLevelFlags `
         test -p 1 $using:test_group 2>&1 |
             ForEach-Object ToString |
             Tee-Object "$using:log_dir_path\$using:test_group.log"


### PR DESCRIPTION
Confirms custom endpoints are maintained through sliced downloads and parallel composite uploads by testing compatibility with private service connect (PSC).