### PR TITLE
Support skipping integrity checks in daisy chain transfers.

### DIFF
--- a/gslib/tests/test_copy_helper_funcs.py
+++ b/gslib/tests/test_copy_helper_funcs.py
@@ -19,6 +19,7 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import unicode_literals
 
+import collections
 import datetime
 import logging
 import os
@@ -47,6 +48,7 @@ from gslib.utils import parallelism_framework_util
 from gslib.utils import posix_util
 from gslib.utils import system_util
 from gslib.utils import hashing_helper
+from gslib.utils.copy_helper import _CheckCloudHashes
 from gslib.utils.copy_helper import _DelegateUploadFileToObject
 from gslib.utils.copy_helper import _GetPartitionInfo
 from gslib.utils.copy_helper import _SelectUploadCompressionStrategy
@@ -750,3 +752,14 @@ class TestExpandUrlToSingleBlr(GsUtilUnitTestCase):
 
     self.assertTrue(have_existing_dst_container)
     self.assertEqual(exp_url, StorageUrlFromString('gs://test/folder/'))
+
+  def testCheckCloudHashesIsSkippedCorrectly(self):
+    FakeObject = collections.namedtuple('FakeObject', ['md5Hash'])
+
+    with SetBotoConfigForTest([('GSUtil', 'check_hashes', 'never')]):
+      # Should not raise a hash mismatch error:
+      _CheckCloudHashes(logger=None,
+                        src_url=None,
+                        dst_url=None,
+                        src_obj_metadata=FakeObject(md5Hash='a'),
+                        dst_obj_metadata=FakeObject(md5Hash='b'))

--- a/gslib/utils/copy_helper.py
+++ b/gslib/utils/copy_helper.py
@@ -798,6 +798,15 @@ def _CheckCloudHashes(logger, src_url, dst_url, src_obj_metadata,
     CommandException: if cloud digests don't match local digests.
   """
   # See hack comment in _CheckHashes.
+
+  # Sometimes (e.g. when kms is enabled for s3) the values we check below are
+  # not actually content hashes. The early exit here provides users a workaround
+  # for this case and any others we've missed.
+  check_hashes_config = config.get('GSUtil', 'check_hashes',
+                                   CHECK_HASH_IF_FAST_ELSE_FAIL)
+  if check_hashes_config == CHECK_HASH_NEVER:
+    return
+
   checked_one = False
   download_hashes = {}
   upload_hashes = {}


### PR DESCRIPTION
Along with a [boto PR](https://github.com/gsutil-mirrors/boto/commit/fe0a6a99a7e2a89714c91ce91e827a9d85e3acc9), this provides a workaround for #1249.