### PR TITLE
Specify the purpose of -p option for -D example

### DIFF
--- a/gslib/commands/cp.py
+++ b/gslib/commands/cp.py
@@ -492,7 +492,9 @@ _OPTIONS_TEXT = """
 
                  NOTE: "Daisy chain" mode is automatically used when copying
                  between providers: for example, when copying data from Cloud Storage
-                 to another provider.
+                 to another provider. The combiation with -p option should be used to 
+                 preserve ACLs when copying, omit -p if not required  (e.g. for bucket with 
+                 uniform bucket-level access)
 
   -e             Exclude symlinks. When specified, symbolic links are not copied.
 

--- a/gslib/commands/cp.py
+++ b/gslib/commands/cp.py
@@ -487,14 +487,12 @@ _OPTIONS_TEXT = """
                  at its destination. However, you can use "daisy chain" mode to change a
                  composite object into a non-composite object. For example:
 
-                     gsutil cp -D -p gs://bucket/obj gs://bucket/obj_tmp
-                     gsutil mv -p gs://bucket/obj_tmp gs://bucket/obj
+                     gsutil cp -D gs://bucket/obj gs://bucket/obj_tmp
+                     gsutil mv gs://bucket/obj_tmp gs://bucket/obj
 
                  NOTE: "Daisy chain" mode is automatically used when copying
                  between providers: for example, when copying data from Cloud Storage
-                 to another provider. The combiation with -p option should be used to 
-                 preserve ACLs when copying, omit -p if not required  (e.g. for bucket with 
-                 uniform bucket-level access)
+                 to another provider.
 
   -e             Exclude symlinks. When specified, symbolic links are not copied.
 


### PR DESCRIPTION
The examples for -D option is confusing, as -p option is also specified. 

Some users end up thinking that these two options should be used together. This is not always the case (e.g. for bucket with uniform bucket-level access),  and an error will be returned in case OWNER permission is missing as OWNER permission is required for preserving ACLs. 
This cl provides additional clarifications to avoid further support tickets.