### PR TITLE
Fix gsutil help for -o

### DIFF
--- a/gslib/commands/help.py
+++ b/gslib/commands/help.py
@@ -74,7 +74,8 @@ _DETAILED_HELP_TEXT = ("""
 
 top_level_usage_string = (
     'Usage: gsutil [-D] [-DD] [-h header]... [-i service_account] '
-    '[-m] [-o section:flag=value]... [-q] [-u user_project] [command [opts...] args...]')
+    '[-m] [-o section:flag=value]... [-q] [-u user_project] [command [opts...] args...]'
+)
 
 
 class HelpCommand(Command):

--- a/gslib/commands/help.py
+++ b/gslib/commands/help.py
@@ -74,7 +74,7 @@ _DETAILED_HELP_TEXT = ("""
 
 top_level_usage_string = (
     'Usage: gsutil [-D] [-DD] [-h header]... [-i service_account] '
-    '[-m] [-o] [-q] [-u user_project] [command [opts...] args...]')
+    '[-m] [-o section:flag=value]... [-q] [-u user_project] [command [opts...] args...]')
 
 
 class HelpCommand(Command):


### PR DESCRIPTION
`-o`/`--option` takes a single mandatory parameter of a fixed form and this should be clear in the help
`-o` flags can be included more than once (as with `-h`).

Fixes #1270 