### PR TITLE
Raise error for invalid destination.

### DIFF
--- a/gslib/tests/test_cp.py
+++ b/gslib/tests/test_cp.py
@@ -4607,9 +4607,9 @@ class TestCpUnitTests(testcase.GsUtilUnitTestCase):
     object_uri = self.CreateObject(bucket_uri=bucket_uri, contents=b'foo')
     destination_path = 'random_dir' + os.path.sep
 
-    with self.assertRaisesRegex(InvalidUrlError,
-                                'Invalid destination path: random_dir/'):
+    with self.assertRaises(InvalidUrlError) as error:
       self.RunCommand('cp', [suri(object_uri), destination_path])
+      self.assertEqual(str(error), 'Invalid destination path: random_dir/')
 
   def test_object_and_prefix_same_name(self):
     bucket_uri = self.CreateBucket()

--- a/gslib/utils/copy_helper.py
+++ b/gslib/utils/copy_helper.py
@@ -2969,7 +2969,7 @@ def _DownloadObjectToFile(src_url,
             'typically happens when using gsutil to download from a subdirectory '
             'created by the Cloud Console (https://cloud.google.com/console)' %
             dst_url.object_name)))
-    # The warning above is needed because before this error might get ignored
+    # The warning above is needed because errors might get ignored
     # for parallel processing.
     raise InvalidUrlError('Invalid destination path: %s' % dst_url.object_name)
 

--- a/gslib/utils/copy_helper.py
+++ b/gslib/utils/copy_helper.py
@@ -2969,6 +2969,8 @@ def _DownloadObjectToFile(src_url,
             'typically happens when using gsutil to download from a subdirectory '
             'created by the Cloud Console (https://cloud.google.com/console)' %
             dst_url.object_name)))
+    # The warning above is needed because before this error might get ignored
+    # for parallel processing.
     raise InvalidUrlError('Invalid destination path: %s' % dst_url.object_name)
 
   api_selector = gsutil_api.GetApiSelector(provider=src_url.scheme)

--- a/gslib/utils/copy_helper.py
+++ b/gslib/utils/copy_helper.py
@@ -77,6 +77,7 @@ from gslib.cs_api_map import ApiSelector
 from gslib.daisy_chain_wrapper import DaisyChainWrapper
 from gslib.exception import CommandException
 from gslib.exception import HashMismatchException
+from gslib.exception import InvalidUrlError
 from gslib.file_part import FilePart
 from gslib.parallel_tracker_file import GenerateComponentObjectPrefix
 from gslib.parallel_tracker_file import ReadParallelUploadTrackerFile
@@ -2968,7 +2969,7 @@ def _DownloadObjectToFile(src_url,
             'typically happens when using gsutil to download from a subdirectory '
             'created by the Cloud Console (https://cloud.google.com/console)' %
             dst_url.object_name)))
-    return (0, 0, dst_url, '')
+    raise InvalidUrlError('Invalid destination path: %s' % dst_url.object_name)
 
   api_selector = gsutil_api.GetApiSelector(provider=src_url.scheme)
   download_strategy = _SelectDownloadStrategy(dst_url)


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/gsutil/issues/800

Raising an error now if destination ends with a delimiter.