### PR TITLE
Fix kokoro failures on linux because of pyenv

### DIFF
--- a/test/ci/kokoro/run_integ_tests.sh
+++ b/test/ci/kokoro/run_integ_tests.sh
@@ -64,7 +64,6 @@ function install_pyenv {
   fi
   pyenv update
   # To address pyenv issue: See b/187701234#comment12
-  echo "Going to update python-build"
   cd /home/kbuilder/.pyenv/plugins/python-build/../.. && git pull && \
     git checkout 783870759566a77d09b426e0305bc0993a522765 && cd -
 }

--- a/test/ci/kokoro/run_integ_tests.sh
+++ b/test/ci/kokoro/run_integ_tests.sh
@@ -63,6 +63,9 @@ function install_pyenv {
     fi
   fi
   pyenv update
+  # To address pyenv issue: See b/187701234#comment12
+  cd /home/kbuilder/.pyenv/plugins/python-build/../.. && git pull && \
+    git checkout 783870759566a77d09b426e0305bc0993a522765 && cd -
 }
 
 function install_python {

--- a/test/ci/kokoro/run_integ_tests.sh
+++ b/test/ci/kokoro/run_integ_tests.sh
@@ -64,6 +64,7 @@ function install_pyenv {
   fi
   pyenv update
   # To address pyenv issue: See b/187701234#comment12
+  echo "Going to update python-build"
   cd /home/kbuilder/.pyenv/plugins/python-build/../.. && git pull && \
     git checkout 783870759566a77d09b426e0305bc0993a522765 && cd -
 }


### PR DESCRIPTION
Our Kokoro job has been failing for Linux only.
This started happening since May 07

https://fusion.corp.google.com/projectanalysis/summary/KOKORO/prod:cloud_storage_gsutil%2Flinux%2Fcontinuous

Looking at the log, it seems it is running all the tests but in the end failing because of errors like these:
```
protocol version mismatch -- is your shell clean?
(see the rsync man page for an explanation)
rsync error: protocol incompatibility (code 2) at compat.c(178) [Receiver=3.1.3]
Warning: Permanently added 'localhost' (ECDSA) to the list of known hosts.
```

Check b/187701234#comment12 for more info.

