### PR TITLE
Fix flaky test for rm using preconditions

### DIFF
--- a/gslib/tests/test_rm.py
+++ b/gslib/tests/test_rm.py
@@ -611,8 +611,7 @@ class TestRm(testcase.GsUtilIntegrationTestCase):
          suri(object_uri)],
         return_stderr=True,
         expected_status=1)
-    self.assertRegex(
-        stderr, r'PreconditionException: 412 (Precondition)?\s*(Failed|None)')
+    self.assertRegex(stderr, r'PreconditionException: 412')
 
   def test_stdin_args(self):
     """Tests rm with the -I option."""


### PR DESCRIPTION
Rm tests are occasionally failing because the backend gives two different messages.

```
gsutil -h x-goog-if-generation-match:12345 rm gs://gsutil_test_bucket-4/t
est.txt
Removing gs://gsutil_test_bucket-4/test.txt...
PreconditionException: 412 At least one of the pre-conditions you specified did not hold.
```
and
```
$ gsutil -h x-goog-if-generation-match:12345 rm gs://gsutil_test_bucket-4/test.txt
Removing gs://gsutil_test_bucket-4/test.txt...
PreconditionException: 412 Precondition Failed
```

Making the test less strict so that it can work for both the messages.