### PR TITLE
Onboard mTLS support with AIP-4114 for gsutil

### DIFF
--- a/gslib/context_config.py
+++ b/gslib/context_config.py
@@ -36,9 +36,11 @@ _CONTEXT_AWARE_METADATA_PATH = "~/.secureConnect/context_aware_metadata.json"
 _CERT_PROVIDER_COMMAND = "cert_provider_command"
 _CERT_PROVIDER_COMMAND_PASSPHRASE_OPTION = "--with_passphrase"
 
+
 class CertProvisionError(Exception):
   """Represents errors when provisioning a client certificate."""
   pass
+
 
 class ContextConfigSingletonAlreadyExistsError(Exception):
   """Error for when create_context_config is called multiple times."""
@@ -191,7 +193,6 @@ class _ContextConfig(object):
     except CertProvisionError as e:
       self.logger.error('Failed to provision client certificate: %s' % e)
 
-
   def _ProvisionClientCert(self, cert_path):
     """Executes certificate provider to obtain client certificate and keys."""
     cert_command = config.get('Credentials', 'cert_provider_command', None)
@@ -220,7 +221,6 @@ class _ContextConfig(object):
     except KeyError as e:
       raise CertProvisionError(
           'Invalid output format from certificate provider, no %s' % e)
-
 
   def _UnprovisionClientCert(self):
     """Cleans up any files or resources provisioned during config init."""

--- a/gslib/context_config.py
+++ b/gslib/context_config.py
@@ -23,7 +23,6 @@ import atexit
 import json
 import os
 import subprocess
-import six
 
 from boto import config
 
@@ -39,9 +38,11 @@ _CERT_PROVIDER_COMMAND_PASSPHRASE_OPTION = "--with_passphrase"
 
 class CertProvisionError(Exception):
   """Represents errors when provisioning a client certificate."""
+  pass
 
 class ContextConfigSingletonAlreadyExistsError(Exception):
   """Error for when create_context_config is called multiple times."""
+  pass
 
 
 def _IsPemSectionMarker(line):
@@ -127,37 +128,36 @@ def _read_metadata_file(metadata_path):
   Returns:
       Dict[str, str]: The metadata.
   Raises:
-      google.auth.CertProvisionError: If failed to parse metadata as JSON.
+      CertProvisionError: If failed to parse metadata as JSON.
   """
   try:
     with open(metadata_path) as f:
       metadata = json.load(f)
-  except ValueError as caught_exc:
-    new_exc = CertProvisionError(caught_exc)
-    six.raise_from(new_exc, caught_exc)
+  except ValueError as e:
+    raise CertProvisionError(e)
   return metadata
 
 
 def _default_command():
-  """Loads default cert provider command
+  """Loads default cert provider command.
   Returns:
-      str: The default command
+      str: The default command.
   Raises:
-      google.auth.CertProvisionError: If command cannot be found
+      CertProvisionError: If command cannot be found.
   """
   metadata_path = _check_path()
   if metadata_path:
     metadata_json = _read_metadata_file(metadata_path)
 
     if _CERT_PROVIDER_COMMAND not in metadata_json:
-      raise CertProvisionError("Client certificate provider is not found")
+      raise CertProvisionError("Client certificate provider is not found.")
 
     command = metadata_json[_CERT_PROVIDER_COMMAND]
     if (_CERT_PROVIDER_COMMAND_PASSPHRASE_OPTION not in command):
       command.append(_CERT_PROVIDER_COMMAND_PASSPHRASE_OPTION)
     return command
 
-  raise CertProvisionError("Client certificate provider is not found")
+  raise CertProvisionError("Client certificate provider is not found.")
 
 
 class _ContextConfig(object):

--- a/gslib/context_config.py
+++ b/gslib/context_config.py
@@ -32,7 +32,8 @@ import gslib
 _singleton_config = None
 
 # Metadata JSON that stores information about the default certificate provider.
-_DEFAULT_METADATA_PATH = "~/.secureConnect/context_aware_metadata.json"
+_DEFAULT_METADATA_PATH = os.path.expanduser(
+    os.path.join('~', '.secureConnect', 'context_aware_metadata.json'))
 _CERT_PROVIDER_COMMAND = "cert_provider_command"
 _CERT_PROVIDER_COMMAND_PASSPHRASE_OPTION = "--with_passphrase"
 

--- a/gslib/context_config.py
+++ b/gslib/context_config.py
@@ -202,8 +202,11 @@ class _ContextConfig(object):
 
   def _ProvisionClientCert(self, cert_path):
     """Executes certificate provider to obtain client certificate and keys."""
-    cert_command = config.get('Credentials', 'cert_provider_command', None)
-    if not cert_command:
+    cert_command_string = config.get('Credentials', 'cert_provider_command',
+                                     None)
+    if cert_command_string:
+      cert_command = cert_command_string.split(' ')
+    else:
       # Load the default certificate provider if sit is not provided by user.
       cert_command = _default_command()
 

--- a/gslib/context_config.py
+++ b/gslib/context_config.py
@@ -132,7 +132,7 @@ def _read_metadata_file(metadata_path):
   """Loads context aware metadata from the given path.
 
   Returns:
-      Dict[str, str]: The metadata.
+      dict: The metadata JSON.
 
   Raises:
       CertProvisionError: If failed to parse metadata as JSON.
@@ -156,12 +156,12 @@ def _default_command():
   metadata_path = _check_path()
 
   if not metadata_path:
-    raise CertProvisionError("Client certificate provider is not found.")
+    raise CertProvisionError("Client certificate provider file not found.")
 
   metadata_json = _read_metadata_file(metadata_path)
 
   if _CERT_PROVIDER_COMMAND not in metadata_json:
-    raise CertProvisionError("Client certificate provider is not found.")
+    raise CertProvisionError("Client certificate provider command not found.")
 
   command = metadata_json[_CERT_PROVIDER_COMMAND]
   if (_CERT_PROVIDER_COMMAND_PASSPHRASE_OPTION not in command):

--- a/gslib/context_config.py
+++ b/gslib/context_config.py
@@ -118,7 +118,6 @@ def _check_path():
   """
   metadata_path = os.path.expanduser(_CONTEXT_AWARE_METADATA_PATH)
   if not os.path.exists(metadata_path):
-    _LOGGER.debug("%s is not found, skip client SSL authentication.", metadata_path)
     return None
   return metadata_path
 
@@ -136,7 +135,6 @@ def _read_metadata_file(metadata_path):
   except ValueError as caught_exc:
     new_exc = CertProvisionError(caught_exc)
     six.raise_from(new_exc, caught_exc)
-
   return metadata
 
 

--- a/gslib/tests/test_context_config.py
+++ b/gslib/tests/test_context_config.py
@@ -216,7 +216,7 @@ class TestContextConfig(testcase.GsUtilUnitTestCase):
 
   @mock.patch.object(subprocess, 'Popen')
   @mock.patch(OPEN_TO_PATCH, new_callable=mock.mock_open)
-  def testDefaultProviderExecutesCommandWithSpace(self, mock_Popen, mock_open):
+  def testExecutesProviderCommandWithSpaceFromDefaultFile(self, mock_Popen, mock_open):
     mock_open.return_value = DEFAULT_CERT_PROVIDER_FILE_CONTENTS_WITH_SPACE
     with SetBotoConfigForTest([('Credentials', 'use_client_certificate', 'True')
                               ]):
@@ -246,7 +246,7 @@ class TestContextConfig(testcase.GsUtilUnitTestCase):
             'Client certificate provider command not found.')
 
   @mock.patch.object(subprocess, 'Popen')
-  def testCustomProviderExecutesCommand(self, mock_Popen):
+  def testExecutesCustomProviderCommandFromBotoConfig(self, mock_Popen):
     with SetBotoConfigForTest([
         ('Credentials', 'use_client_certificate', 'True'),
         ('Credentials', 'cert_provider_command', 'some/path')

--- a/gslib/tests/test_context_config.py
+++ b/gslib/tests/test_context_config.py
@@ -246,6 +246,18 @@ class TestContextConfig(testcase.GsUtilUnitTestCase):
         self.mock_logger.error.assert_called_once_with(
             'Client certificate provider command not found.')
 
+  @mock.patch('os.path.exists')
+  def testDefaultProviderNotFoundError(self, mock_path):
+    mock_path.return_value = False
+    with SetBotoConfigForTest([('Credentials', 'use_client_certificate', 'True')
+                              ]):
+      # Purposely end execution here to avoid writing a file.
+      with self.assertRaises(ValueError):
+        context_config.create_context_config(self.mock_logger)
+
+        self.mock_logger.error.assert_called_once_with(
+            'Client certificate provider file not found.')
+
   @mock.patch.object(subprocess, 'Popen')
   def testExecutesCustomProviderCommandFromBotoConfig(self, mock_Popen):
     with SetBotoConfigForTest([

--- a/gslib/tests/test_context_config.py
+++ b/gslib/tests/test_context_config.py
@@ -35,12 +35,14 @@ from gslib.tests.util import SetBotoConfigForTest
 from gslib.tests.util import unittest
 
 DEFAULT_CERT_PROVIDER_FILE_CONTENTS = {
-    "cert_provider_command": [ "some/helper", "--print_certificate" ] }
+    "cert_provider_command": ["some/helper", "--print_certificate"]
+}
 
 DEFAULT_CERT_PROVIDER_FILE_CONTENTS_WITH_SPACE = {
-    "cert_provider_command": [ "/some helper", "--print_certificate" ] }
+    "cert_provider_command": ["/some helper", "--print_certificate"]
+}
 
-DEFAULT_CERT_PROVIDER_FILE_NO_COMMAND = { "foo": "foo" }
+DEFAULT_CERT_PROVIDER_FILE_NO_COMMAND = {"foo": "foo"}
 
 CERT_SECTION = """-----BEGIN CERTIFICATE-----
 LKJHLSDJKFHLEUIORWUYERWEHJHL
@@ -165,7 +167,7 @@ class TestPemFileParser(testcase.GsUtilUnitTestCase):
 
 
 # Setting global context_config singleton causes issues in parallel.
-# @base.NotParallelizable
+@base.NotParallelizable
 @testcase.integration_testcase.SkipForS3('mTLS only runs on GCS JSON API.')
 @testcase.integration_testcase.SkipForXML('mTLS only runs on GCS JSON API.')
 class TestContextConfig(testcase.GsUtilUnitTestCase):
@@ -202,11 +204,11 @@ class TestContextConfig(testcase.GsUtilUnitTestCase):
   @mock.patch.object(os.path, 'exists')
   @mock.patch.object(subprocess, 'Popen')
   @mock.patch(OPEN_TO_PATCH, new_callable=mock.mock_open)
-  def testExecutesProviderCommandFromDefaultFile(
-      self, mock_open, mock_Popen, mock_path, mock_config_bool, mock_json_load):
+  def testExecutesProviderCommandFromDefaultFile(self, mock_open, mock_Popen,
+                                                 mock_path, mock_config_bool,
+                                                 mock_json_load):
     mock_config_bool.return_value = True
-    mock_json_load.side_effect = [
-        DEFAULT_CERT_PROVIDER_FILE_CONTENTS ]
+    mock_json_load.side_effect = [DEFAULT_CERT_PROVIDER_FILE_CONTENTS]
 
     # Purposely end execution here to avoid writing a file.
     with self.assertRaises(ValueError):
@@ -227,7 +229,8 @@ class TestContextConfig(testcase.GsUtilUnitTestCase):
       self, mock_open, mock_Popen, mock_path, mock_config_bool, mock_json_load):
     mock_config_bool.return_value = True
     mock_json_load.side_effect = [
-        DEFAULT_CERT_PROVIDER_FILE_CONTENTS_WITH_SPACE ]
+        DEFAULT_CERT_PROVIDER_FILE_CONTENTS_WITH_SPACE
+    ]
 
     # Purposely end execution here to avoid writing a file.
     with self.assertRaises(ValueError):
@@ -242,8 +245,8 @@ class TestContextConfig(testcase.GsUtilUnitTestCase):
   @mock.patch.object(os.path, 'exists')
   @mock.patch.object(config, 'getbool')
   @mock.patch.object(json, 'load', autospec=True)
-  def testDefaultProviderNoCommandError(
-      self, mock_open, mock_json_load, mock_config_bool, mock_path):
+  def testDefaultProviderNoCommandError(self, mock_open, mock_json_load,
+                                        mock_config_bool, mock_path):
     # Mock the use_client_certificate flag as true
     mock_config_bool.return_value = True
     mock_json_load.return_value = DEFAULT_CERT_PROVIDER_FILE_NO_COMMAND

--- a/gslib/tests/test_context_config.py
+++ b/gslib/tests/test_context_config.py
@@ -34,14 +34,16 @@ from gslib.tests.util import SetBotoConfigForTest
 from gslib.tests.util import unittest
 
 DEFAULT_CERT_PROVIDER_FILE_CONTENTS = {
-    "cert_provider_command": ["some/helper", "--print_certificate"]
+    'cert_provider_command': [
+        os.path.join('some', 'helper'), '--print_certificate'
+    ]
 }
 
 DEFAULT_CERT_PROVIDER_FILE_CONTENTS_WITH_SPACE = {
-    "cert_provider_command": ["/some helper", "--print_certificate"]
+    'cert_provider_command': ['some helper', '--print_certificate']
 }
 
-DEFAULT_CERT_PROVIDER_FILE_NO_COMMAND = {"foo": "foo"}
+DEFAULT_CERT_PROVIDER_FILE_NO_COMMAND = {'foo': 'foo'}
 
 CERT_SECTION = """-----BEGIN CERTIFICATE-----
 LKJHLSDJKFHLEUIORWUYERWEHJHL
@@ -212,9 +214,9 @@ class TestContextConfig(testcase.GsUtilUnitTestCase):
         context_config.create_context_config(self.mock_logger)
 
         mock_open.assert_called_with(context_config._DEFAULT_METADATA_PATH)
-        mock_Popen.assert_called_once_with(os.path.realpath('some/cert'),
-                                           '--print_certificate',
-                                           '--with_passphrase')
+        mock_Popen.assert_called_once_with(
+            os.path.realpath(os.path.join('some', 'helper')),
+            '--print_certificate', '--with_passphrase')
 
   @mock.patch('os.path.exists', new=mock.Mock(return_value=True))
   @mock.patch.object(json, 'load', autospec=True)
@@ -232,7 +234,7 @@ class TestContextConfig(testcase.GsUtilUnitTestCase):
         context_config.create_context_config(self.mock_logger)
 
         mock_open.assert_called_with(context_config._DEFAULT_METADATA_PATH)
-        mock_Popen.assert_called_once_with(os.path.realpath('some/cert helper'),
+        mock_Popen.assert_called_once_with(os.path.realpath('cert helper'),
                                            '--print_certificate',
                                            '--with_passphrase')
 

--- a/gslib/tests/test_context_config.py
+++ b/gslib/tests/test_context_config.py
@@ -216,7 +216,8 @@ class TestContextConfig(testcase.GsUtilUnitTestCase):
 
   @mock.patch.object(subprocess, 'Popen')
   @mock.patch(OPEN_TO_PATCH, new_callable=mock.mock_open)
-  def testExecutesProviderCommandWithSpaceFromDefaultFile(self, mock_Popen, mock_open):
+  def testExecutesProviderCommandWithSpaceFromDefaultFile(
+      self, mock_Popen, mock_open):
     mock_open.return_value = DEFAULT_CERT_PROVIDER_FILE_CONTENTS_WITH_SPACE
     with SetBotoConfigForTest([('Credentials', 'use_client_certificate', 'True')
                               ]):

--- a/gslib/tests/test_context_config.py
+++ b/gslib/tests/test_context_config.py
@@ -264,11 +264,15 @@ class TestContextConfig(testcase.GsUtilUnitTestCase):
           "Client certificate provider file not found.")
 
   @mock.patch.object(json, 'load', autospec=True)
-  def testRaisesCertProvisionErrorOnJsonLoadError(self, mock_json_load):
+  @mock.patch('os.path.exists', new=mock.Mock(return_value=True))
+  @mock.patch(OPEN_TO_PATCH, new_callable=mock.mock_open)
+  def testRaisesCertProvisionErrorOnJsonLoadError(self, mock_open,
+                                                  mock_json_load):
     mock_json_load.side_effect = ValueError('valueError')
     with SetBotoConfigForTest([('Credentials', 'use_client_certificate', 'True')
                               ]):
       context_config.create_context_config(self.mock_logger)
+      mock_open.assert_called_with(context_config._DEFAULT_METADATA_PATH)
       self.mock_logger.error.assert_called_once_with(
           'Failed to provision client certificate: valueError')
 


### PR DESCRIPTION
- The certificate discovery has the following logic:
   - Use the user specified command in `.boto` file if available
   - Otherwise, automatically locate the SecureConnectHelper Metadata JSON

Notes: This PR is backwards-compatible

For more information about the mTLS spec please read: [AIP-4114](https://google.aip.dev/auth/4114)