### PR TITLE
Backfill some changes to the help docs

### DIFF
--- a/gslib/addlhelp/crc32c.py
+++ b/gslib/addlhelp/crc32c.py
@@ -134,11 +134,6 @@ _DETAILED_HELP_TEXT = ("""
 
   https://pypi.python.org/pypi/crcmod/1.7
 
-  MSI installers are available for the 32-bit versions of Python 2.7.
-  Make sure to install to a 32-bit Python directory. If you're using 64-bit
-  Python it won't work with 32-bit crcmod, and instead you'll need to install
-  32-bit Python in order to use crcmod.
-
   NOTE: If you have installed crcmod and gsutil hasn't detected it, it may have
   been installed to the wrong directory. It should be located at
   <python_dir>\\files\\Lib\\site-packages\\crcmod\\

--- a/gslib/commands/pap.py
+++ b/gslib/commands/pap.py
@@ -34,7 +34,7 @@ _SET_SYNOPSIS = """
 """
 
 _GET_SYNOPSIS = """
-  gsutil pap get bucket_url...
+  gsutil pap get gs://<bucket_name>...
 """
 
 _SYNOPSIS = _SET_SYNOPSIS + _GET_SYNOPSIS.lstrip('\n')
@@ -42,25 +42,27 @@ _SYNOPSIS = _SET_SYNOPSIS + _GET_SYNOPSIS.lstrip('\n')
 _SET_DESCRIPTION = """
 <B>SET</B>
   The ``pap set`` command configures public access prevention
-  for Google Cloud Storage buckets.
+  for Cloud Storage buckets. If you set a bucket to be
+  ``unspecified``, it uses public access prevention only if
+  the bucket is subject to the `public access prevention
+  <https://cloud.google.com/storage/docs/org-policy-constraints#public-access-prevention>`_
+  organization policy.
 
 <B>SET EXAMPLES</B>
-  Configure your buckets to use public access prevention:
+  Configure ``redbucket`` and ``bluebucket`` to use public
+  access prevention:
 
     gsutil pap set enforced gs://redbucket gs://bluebucket
-
-  Configure your buckets to NOT use public access prevention:
-
-    gsutil pap set unspecified gs://redbucket gs://bluebucket
 """
 
 _GET_DESCRIPTION = """
 <B>GET</B>
   The ``pap get`` command returns public access prevention
-  value for the specified Cloud Storage buckets.
+  values for the specified Cloud Storage buckets.
 
 <B>GET EXAMPLES</B>
-  Check if your buckets are using public access prevention:
+  Check if ``redbucket`` and ``bluebucket`` are using public
+  access prevention:
 
     gsutil pap get gs://redbucket gs://bluebucket
 """


### PR DESCRIPTION
* Update text for `gsutil pap`.
* Remove some text from the Windows instructions for crcmod.