### PR TITLE
Make certain utils generic for future projects

### DIFF
--- a/gslib/context_config.py
+++ b/gslib/context_config.py
@@ -22,11 +22,11 @@ from __future__ import unicode_literals
 import atexit
 import json
 import os
-import subprocess
 
 from boto import config
 
 import gslib
+from gslib.utils import execution_util
 
 # Maintain a single context configuration.
 _singleton_config = None
@@ -212,15 +212,8 @@ class _ContextConfig(object):
       cert_command = _default_command()
 
     try:
-      command_process = subprocess.Popen(cert_command,
-                                         stdout=subprocess.PIPE,
-                                         stderr=subprocess.PIPE)
-      command_stdout, command_stderr = command_process.communicate()
-      if command_process.returncode != 0:
-        raise CertProvisionError(command_stderr)
-
-      # Python 3 outputs bytes from communicate() by default.
-      command_stdout_string = command_stdout.decode()
+      command_stdout_string, _ = execution_util.ExecuteExternalCommand(
+          cert_command)
 
       sections = _SplitPemIntoSections(command_stdout_string, self.logger)
       with open(cert_path, 'w+') as f:

--- a/gslib/tests/test_context_config.py
+++ b/gslib/tests/test_context_config.py
@@ -227,8 +227,9 @@ class TestContextConfig(testcase.GsUtilUnitTestCase):
     mock_json_load.side_effect = [
         DEFAULT_CERT_PROVIDER_FILE_CONTENTS_WITH_SPACE
     ]
-    with SetBotoConfigForTest([('Credentials', 'use_client_certificate', 'True')
-                              ]):
+    with SetBotoConfigForTest([('Credentials', 'use_client_certificate',
+                                'True'),
+                               ('Credentials', 'cert_provider_command', None)]):
       # Purposely end execution here to avoid writing a file.
       with self.assertRaises(ValueError):
         context_config.create_context_config(self.mock_logger)
@@ -244,8 +245,9 @@ class TestContextConfig(testcase.GsUtilUnitTestCase):
   def testDefaultProviderNoCommandError(self, mock_open, mock_json_load):
     mock_json_load.return_value = DEFAULT_CERT_PROVIDER_FILE_NO_COMMAND
 
-    with SetBotoConfigForTest([('Credentials', 'use_client_certificate', 'True')
-                              ]):
+    with SetBotoConfigForTest([('Credentials', 'use_client_certificate',
+                                'True'),
+                               ('Credentials', 'cert_provider_command', None)]):
       context_config.create_context_config(self.mock_logger)
 
       mock_open.assert_called_with(context_config._DEFAULT_METADATA_PATH)
@@ -255,8 +257,9 @@ class TestContextConfig(testcase.GsUtilUnitTestCase):
 
   @mock.patch('os.path.exists', new=mock.Mock(return_value=False))
   def testDefaultProviderNotFoundError(self):
-    with SetBotoConfigForTest([('Credentials', 'use_client_certificate', 'True')
-                              ]):
+    with SetBotoConfigForTest([('Credentials', 'use_client_certificate',
+                                'True'),
+                               ('Credentials', 'cert_provider_command', None)]):
       context_config.create_context_config(self.mock_logger)
 
       self.mock_logger.error.assert_called_once_with(
@@ -269,8 +272,9 @@ class TestContextConfig(testcase.GsUtilUnitTestCase):
   def testRaisesCertProvisionErrorOnJsonLoadError(self, mock_open,
                                                   mock_json_load):
     mock_json_load.side_effect = ValueError('valueError')
-    with SetBotoConfigForTest([('Credentials', 'use_client_certificate', 'True')
-                              ]):
+    with SetBotoConfigForTest([('Credentials', 'use_client_certificate',
+                                'True'),
+                               ('Credentials', 'cert_provider_command', None)]):
       context_config.create_context_config(self.mock_logger)
       mock_open.assert_called_with(context_config._DEFAULT_METADATA_PATH)
       self.mock_logger.error.assert_called_once_with(

--- a/gslib/tests/test_execution_util.py
+++ b/gslib/tests/test_execution_util.py
@@ -30,8 +30,7 @@ class TestExecutionUtil(testcase.GsUtilUnitTestCase):
   """Test execution utils."""
 
   @mock.patch.object(subprocess, 'Popen')
-  def testExternalCommandReturnsNoOutput(
-      self, mock_Popen):
+  def testExternalCommandReturnsNoOutput(self, mock_Popen):
     mock_command_process = mock.Mock()
     mock_command_process.returncode = 0
     mock_command_process.communicate.return_value = (None, None)
@@ -41,12 +40,12 @@ class TestExecutionUtil(testcase.GsUtilUnitTestCase):
     self.assertIsNone(stdout)
     self.assertIsNone(stderr)
 
-    mock_Popen.assert_called_once_with(
-        ['fake-command'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    mock_Popen.assert_called_once_with(['fake-command'],
+                                       stdout=subprocess.PIPE,
+                                       stderr=subprocess.PIPE)
 
   @mock.patch.object(subprocess, 'Popen')
-  def testExternalCommandReturnsStringOutput(
-      self, mock_Popen):
+  def testExternalCommandReturnsStringOutput(self, mock_Popen):
     mock_command_process = mock.Mock()
     mock_command_process.returncode = 0
     mock_command_process.communicate.return_value = ('a', 'b')
@@ -56,12 +55,12 @@ class TestExecutionUtil(testcase.GsUtilUnitTestCase):
     self.assertEqual(stdout, 'a')
     self.assertEqual(stderr, 'b')
 
-    mock_Popen.assert_called_once_with(
-        ['fake-command'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    mock_Popen.assert_called_once_with(['fake-command'],
+                                       stdout=subprocess.PIPE,
+                                       stderr=subprocess.PIPE)
 
   @mock.patch.object(subprocess, 'Popen')
-  def testExternalCommandReturnsBytesOutput(
-      self, mock_Popen):
+  def testExternalCommandReturnsBytesOutput(self, mock_Popen):
     mock_command_process = mock.Mock()
     mock_command_process.returncode = 0
     mock_command_process.communicate.return_value = (b'a', b'b')
@@ -71,12 +70,12 @@ class TestExecutionUtil(testcase.GsUtilUnitTestCase):
     self.assertEqual(stdout, 'a')
     self.assertEqual(stderr, 'b')
 
-    mock_Popen.assert_called_once_with(
-        ['fake-command'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    mock_Popen.assert_called_once_with(['fake-command'],
+                                       stdout=subprocess.PIPE,
+                                       stderr=subprocess.PIPE)
 
   @mock.patch.object(subprocess, 'Popen')
-  def testExternalCommandReturnsNoOutput(
-      self, mock_Popen):
+  def testExternalCommandReturnsNoOutput(self, mock_Popen):
     mock_command_process = mock.Mock()
     mock_command_process.returncode = 1
     mock_command_process.communicate.return_value = (None, b'error')
@@ -85,5 +84,6 @@ class TestExecutionUtil(testcase.GsUtilUnitTestCase):
     with self.assertRaises(OSError):
       execution_util.ExecuteExternalCommand(['fake-command'])
 
-    mock_Popen.assert_called_once_with(
-        ['fake-command'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    mock_Popen.assert_called_once_with(['fake-command'],
+                                       stdout=subprocess.PIPE,
+                                       stderr=subprocess.PIPE)

--- a/gslib/tests/test_execution_util.py
+++ b/gslib/tests/test_execution_util.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for execution_util.py."""
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import division
+from __future__ import unicode_literals
+
+import mock
+import subprocess
+
+from gslib.tests import testcase
+from gslib.utils import execution_util
+
+
+class TestExecutionUtil(testcase.GsUtilUnitTestCase):
+  """Test execution utils."""
+
+  @mock.patch.object(subprocess, 'Popen')
+  def testExternalCommandReturnsNoOutput(
+      self, mock_Popen):
+    mock_command_process = mock.Mock()
+    mock_command_process.returncode = 0
+    mock_command_process.communicate.return_value = (None, None)
+    mock_Popen.return_value = mock_command_process
+
+    stdout, stderr = execution_util.ExecuteExternalCommand(['fake-command'])
+    self.assertIsNone(stdout)
+    self.assertIsNone(stderr)
+
+    mock_Popen.assert_called_once_with(
+        ['fake-command'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+  @mock.patch.object(subprocess, 'Popen')
+  def testExternalCommandReturnsStringOutput(
+      self, mock_Popen):
+    mock_command_process = mock.Mock()
+    mock_command_process.returncode = 0
+    mock_command_process.communicate.return_value = ('a', 'b')
+    mock_Popen.return_value = mock_command_process
+
+    stdout, stderr = execution_util.ExecuteExternalCommand(['fake-command'])
+    self.assertEqual(stdout, 'a')
+    self.assertEqual(stderr, 'b')
+
+    mock_Popen.assert_called_once_with(
+        ['fake-command'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+  @mock.patch.object(subprocess, 'Popen')
+  def testExternalCommandReturnsBytesOutput(
+      self, mock_Popen):
+    mock_command_process = mock.Mock()
+    mock_command_process.returncode = 0
+    mock_command_process.communicate.return_value = (b'a', b'b')
+    mock_Popen.return_value = mock_command_process
+
+    stdout, stderr = execution_util.ExecuteExternalCommand(['fake-command'])
+    self.assertEqual(stdout, 'a')
+    self.assertEqual(stderr, 'b')
+
+    mock_Popen.assert_called_once_with(
+        ['fake-command'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+  @mock.patch.object(subprocess, 'Popen')
+  def testExternalCommandReturnsNoOutput(
+      self, mock_Popen):
+    mock_command_process = mock.Mock()
+    mock_command_process.returncode = 1
+    mock_command_process.communicate.return_value = (None, b'error')
+    mock_Popen.return_value = mock_command_process
+
+    with self.assertRaises(OSError):
+      execution_util.ExecuteExternalCommand(['fake-command'])
+
+    mock_Popen.assert_called_once_with(
+        ['fake-command'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/gslib/tests/test_temporary_file_util.py
+++ b/gslib/tests/test_temporary_file_util.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for temporary_file_util.py."""
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import division
+from __future__ import unicode_literals
+
+from gslib import storage_url
+from gslib.tests import testcase
+from gslib.utils import temporary_file_util
+
+
+class TestTemporaryUtil(testcase.GsUtilUnitTestCase):
+  """Test temporary file utils."""
+
+  def testGetsTemporaryFileName(self):
+    self.assertEqual(
+        temporary_file_util.GetTempFileName(
+            storage_url.StorageUrlFromString('file.txt')), 'file.txt_.gstmp')
+
+  def testGetsTemporaryZipFileName(self):
+    self.assertEqual(
+        temporary_file_util.GetTempZipFileName(
+            storage_url.StorageUrlFromString('file.txt')), 'file.txt_.gztmp')

--- a/gslib/utils/copy_helper.py
+++ b/gslib/utils/copy_helper.py
@@ -107,6 +107,7 @@ from gslib.tracker_file import TrackerFileType
 from gslib.tracker_file import WriteDownloadComponentTrackerFile
 from gslib.tracker_file import WriteJsonDataToTrackerFile
 from gslib.utils import parallelism_framework_util
+from gslib.utils import temporary_file_util
 from gslib.utils import text_util
 from gslib.utils.boto_util import GetJsonResumableChunkSize
 from gslib.utils.boto_util import GetMaxRetryDelay
@@ -2254,10 +2255,10 @@ def _GetDownloadFile(dst_url, src_obj_metadata, logger):
   # we will fail our hash check for the object.
   if ObjectIsGzipEncoded(src_obj_metadata):
     need_to_unzip = True
-    download_file_name = _GetDownloadTempZipFileName(dst_url)
+    download_file_name = temporary_file_util.GetTempZipFileName(dst_url)
     logger.info('Downloading to temp gzip filename %s', download_file_name)
   else:
-    download_file_name = _GetDownloadTempFileName(dst_url)
+    download_file_name = temporary_file_util.GetTempFileName(dst_url)
 
   # If a file exists at the permanent destination (where the file will be moved
   # after the download is completed), delete it here to reduce disk space
@@ -3071,16 +3072,6 @@ def _DownloadObjectToFile(src_url,
                   finished=True))
 
   return (end_time - start_time, bytes_transferred, dst_url, local_md5)
-
-
-def _GetDownloadTempZipFileName(dst_url):
-  """Returns temporary file name for a temporarily compressed download."""
-  return '%s_.gztmp' % dst_url.object_name
-
-
-def _GetDownloadTempFileName(dst_url):
-  """Returns temporary download file name for uncompressed downloads."""
-  return '%s_.gstmp' % dst_url.object_name
 
 
 def _ValidateAndCompleteDownload(logger,

--- a/gslib/utils/execution_util.py
+++ b/gslib/utils/execution_util.py
@@ -22,7 +22,7 @@ from __future__ import unicode_literals
 import subprocess
 
 
-def execute_external_command(command_and_flags):
+def ExecuteExternalCommand(command_and_flags):
   """Runs external terminal command.
 
   Args:
@@ -40,12 +40,12 @@ def execute_external_command(command_and_flags):
   command_stdout, command_stderr = command_process.communicate()
 
   # Python 3 outputs bytes from communicate() by default.
-  if command_stdout is not None:
-    command_stdout = str(command_stdout)
-  if command_stderr is not None:
-    command_stderr = str(command_stderr)
+  if command_stdout is not None and not isinstance(command_stdout, str):
+    command_stdout = command_stdout.decode()
+  if command_stderr is not None and not isinstance(command_stderr, str):
+    command_stderr = command_stderr.decode()
 
   if command_process.returncode != 0:
     raise OSError(command_stderr)
 
-  return (command_stdout, command_stderr)
+  return command_stdout, command_stderr

--- a/gslib/utils/execution_util.py
+++ b/gslib/utils/execution_util.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Helper functions for executing binaries."""
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import division
+from __future__ import unicode_literals
+
+import subprocess
+
+
+def execute_external_command(command_and_flags):
+  """Runs external terminal command.
+
+  Args:
+    command_and_flags (List[str]): Ordered command and flag strings.
+
+  Returns:
+    (stdout (str|None), stderr (str|None)) from running command.
+
+  Raises:
+    OSError for any issues running the command.
+  """
+  command_process = subprocess.Popen(command_and_flags,
+                                     stdout=subprocess.PIPE,
+                                     stderr=subprocess.PIPE)
+  command_stdout, command_stderr = command_process.communicate()
+
+  # Python 3 outputs bytes from communicate() by default.
+  if command_stdout is not None:
+    command_stdout = str(command_stdout)
+  if command_stderr is not None:
+    command_stderr = str(command_stderr)
+
+  if command_process.returncode != 0:
+    raise OSError(command_stderr)
+
+  return (command_stdout, command_stderr)

--- a/gslib/utils/temporary_file_util.py
+++ b/gslib/utils/temporary_file_util.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Utils for temporary files."""
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import division
+from __future__ import unicode_literals
+
+
+def GetTempFileName(storage_url):
+  """Returns temporary file name for uncompressed file."""
+  return '%s_.gstmp' % storage_url.object_name
+
+
+def GetTempZipFileName(storage_url):
+  """Returns temporary name for a temporarily compressed file."""
+  return '%s_.gztmp' % storage_url.object_name


### PR DESCRIPTION
Make temporary file naming utils generic.
Make binary running logic generic.
Fix an issue where unit tests fail if `cert_provider_command` is present in `.boto`.