### PR TITLE
Fix AttributeError when running without stdin

### DIFF
--- a/gslib/utils/system_util.py
+++ b/gslib/utils/system_util.py
@@ -244,7 +244,8 @@ def IsRunningInCiEnvironment():
 
 def IsRunningInteractively():
   """Returns True if currently running interactively on a TTY."""
-  return sys.stdout.isatty() and sys.stderr.isatty() and sys.stdin.isatty()
+  return sys.stdout.isatty() and sys.stderr.isatty() and \
+         sys.stdin and sys.stdin.isatty()
 
 
 def MonkeyPatchHttp():


### PR DESCRIPTION
With a closed stdin, that is without any means to accept input from the user,
the session cannot be interactive. sys.stdin is NoneType in that case, and
NoneType knows no `isatty()`. The error will occur with any command, but
the fastest way to trigger it is:

    gsutil version <&-