### PR TITLE
STET Util

### DIFF
--- a/gslib/commands/config.py
+++ b/gslib/commands/config.py
@@ -528,6 +528,14 @@ content_language = en
 # If this option is not supplied, those tests will be skipped.
 #test_notification_url = https://yourdomain.url/notification-endpoint
 
+# Used in conjunction with --stet flag on cp command for end-to-end encryption.
+# STET binary path. If not specified, gsutil checks PATH for "stet".
+#stet_binary_path = <Path to binary "/usr/local/bin/stet">
+
+# STET config path. If not specified, gsutil checks the default config location:
+# "~/.config/stet.yaml"
+#stet_config_path = <Path to config file "~/.config/my_config.yaml">
+
 """ % {
     'hash_fast_else_fail': CHECK_HASH_IF_FAST_ELSE_FAIL,
     'hash_fast_else_skip': CHECK_HASH_IF_FAST_ELSE_SKIP,

--- a/gslib/commands/config.py
+++ b/gslib/commands/config.py
@@ -45,6 +45,7 @@ from gslib.exception import CommandException
 from gslib.metrics import CheckAndMaybePromptForAnalyticsEnabling
 from gslib.sig_handling import RegisterSignalHandler
 from gslib.utils import constants
+from gslib.utils import stet_util
 from gslib.utils import system_util
 from gslib.utils.hashing_helper import CHECK_HASH_ALWAYS
 from gslib.utils.hashing_helper import CHECK_HASH_IF_FAST_ELSE_FAIL
@@ -533,7 +534,7 @@ content_language = en
 #stet_binary_path = <Path to binary "/usr/local/bin/stet">
 
 # STET config path. If not specified, gsutil checks the default config location:
-# "~/.config/stet.yaml"
+# "{default_stet_config_path}"
 #stet_config_path = <Path to config file "~/.config/my_config.yaml">
 
 """ % {
@@ -559,6 +560,7 @@ content_language = en
     'max_upload_compression_buffer_size':
         (DEFAULT_MAX_UPLOAD_COMPRESSION_BUFFER_SIZE),
     'gzip_compression_level': DEFAULT_GZIP_COMPRESSION_LEVEL,
+    'default_stet_config_path': stet_util.DEFAULT_STET_CONFIG_PATH,
 }
 
 CONFIG_OAUTH2_CONFIG_CONTENT = """

--- a/gslib/tests/test_stet_util.py
+++ b/gslib/tests/test_stet_util.py
@@ -1,0 +1,199 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for stet_util.py."""
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import division
+from __future__ import unicode_literals
+
+import os
+import shutil
+
+from gslib import storage_url
+from gslib.tests import testcase
+from gslib.tests import util
+from gslib.tests.util import unittest
+from gslib.utils import execution_util
+from gslib.utils import stet_util
+
+import mock
+
+
+class TestStetUtil(testcase.GsUtilUnitTestCase):
+  """Test STET utils."""
+
+  @mock.patch.object(execution_util, 'ExecuteExternalCommand')
+  def test_stet_upload_uses_binary_and_config_from_boto(
+      self, mock_execute_external_command):
+    fake_config_path = self.CreateTempFile()
+    mock_execute_external_command.return_value = ('stdout', 'stderr')
+    mock_logger = mock.Mock()
+
+    source_url = storage_url.StorageUrlFromString('in')
+    destination_url = storage_url.StorageUrlFromString('gs://bucket/obj')
+    with util.SetBotoConfigForTest([
+        ('GSUtil', 'stet_binary_path', 'fake_binary_path'),
+        ('GSUtil', 'stet_config_path', fake_config_path),
+    ]):
+      out_file_url = stet_util.encrypt_upload(source_url, destination_url,
+                                              mock_logger)
+
+    self.assertEqual(out_file_url,
+                     storage_url.StorageUrlFromString('in_.stet_tmp'))
+    mock_execute_external_command.assert_called_once_with([
+        'fake_binary_path',
+        'encrypt',
+        '--config-file={}'.format(fake_config_path),
+        '--blob-id=gs://bucket/obj',
+        'in',
+        'in_.stet_tmp',
+    ])
+    mock_logger.debug.assert_called_once_with('stderr')
+
+  @mock.patch.object(execution_util, 'ExecuteExternalCommand')
+  def test_stet_upload_runs_with_binary_from_path_with_correct_settings(
+      self, mock_execute_external_command):
+    fake_config_path = self.CreateTempFile()
+    temporary_path_directory = self.CreateTempDir()
+    fake_stet_binary_path = self.CreateTempFile(tmpdir=temporary_path_directory,
+                                                file_name='stet')
+    previous_path = os.getenv('PATH')
+    os.environ['PATH'] += os.path.pathsep + temporary_path_directory
+
+    mock_execute_external_command.return_value = ('stdout', 'stderr')
+    mock_logger = mock.Mock()
+
+    source_url = storage_url.StorageUrlFromString('in')
+    destination_url = storage_url.StorageUrlFromString('gs://bucket/obj')
+    with util.SetBotoConfigForTest([
+        ('GSUtil', 'stet_binary_path', None),
+        ('GSUtil', 'stet_config_path', fake_config_path),
+    ]):
+      out_file_url = stet_util.encrypt_upload(source_url, destination_url,
+                                              mock_logger)
+
+    self.assertEqual(out_file_url,
+                     storage_url.StorageUrlFromString('in_.stet_tmp'))
+    mock_execute_external_command.assert_called_once_with([
+        fake_stet_binary_path,
+        'encrypt',
+        '--config-file={}'.format(fake_config_path),
+        '--blob-id=gs://bucket/obj',
+        'in',
+        'in_.stet_tmp',
+    ])
+    mock_logger.debug.assert_called_once_with('stderr')
+
+    os.environ['PATH'] = previous_path
+
+  @mock.patch.object(execution_util, 'ExecuteExternalCommand')
+  def test_stet_upload_uses_config_from_default_path_with_correct_settings(
+      self, mock_execute_external_command):
+    mock_execute_external_command.return_value = ('stdout', 'stderr')
+    mock_logger = mock.Mock()
+
+    source_url = storage_url.StorageUrlFromString('in')
+    destination_url = storage_url.StorageUrlFromString('gs://bucket/obj')
+    with util.SetBotoConfigForTest([
+        ('GSUtil', 'stet_binary_path', 'fake_binary_path'),
+        ('GSUtil', 'stet_config_path', None),
+    ]):
+      with mock.patch.object(os.path,
+                             'exists',
+                             new=mock.Mock(return_value=True)):
+        out_file_url = stet_util.encrypt_upload(source_url, destination_url,
+                                                mock_logger)
+
+    self.assertEqual(out_file_url,
+                     storage_url.StorageUrlFromString('in_.stet_tmp'))
+    mock_execute_external_command.assert_called_once_with([
+        'fake_binary_path',
+        'encrypt',
+        '--config-file={}'.format(
+            os.path.expanduser(stet_util.DEFAULT_STET_CONFIG_PATH)),
+        '--blob-id=gs://bucket/obj',
+        'in',
+        'in_.stet_tmp',
+    ])
+    mock_logger.debug.assert_called_once_with('stderr')
+
+  @mock.patch.object(shutil, 'move')
+  @mock.patch.object(execution_util, 'ExecuteExternalCommand')
+  def test_stet_download_runs_binary_and_replaces_temp_file(
+      self, mock_execute_external_command, mock_move):
+    fake_config_path = self.CreateTempFile()
+    mock_execute_external_command.return_value = ('stdout', 'stderr')
+    mock_logger = mock.Mock()
+
+    source_url = storage_url.StorageUrlFromString('gs://bucket/obj')
+    destination_url = storage_url.StorageUrlFromString('out')
+    with util.SetBotoConfigForTest([
+        ('GSUtil', 'stet_binary_path', 'fake_binary_path'),
+        ('GSUtil', 'stet_config_path', fake_config_path),
+    ]):
+      stet_util.decrypt_download(source_url, destination_url, mock_logger)
+
+    mock_execute_external_command.assert_called_once_with([
+        'fake_binary_path', 'decrypt',
+        '--config-file={}'.format(fake_config_path),
+        '--blob-id=gs://bucket/obj', 'out', 'out_.stet_tmp'
+    ])
+    mock_logger.debug.assert_called_once_with('stderr')
+    mock_move.assert_called_once_with('out_.stet_tmp', 'out')
+
+  @mock.patch.object(stet_util,
+                     '_get_stet_binary_from_path',
+                     new=mock.Mock(return_value=None))
+  def test_stet_util_errors_if_no_binary(self):
+    fake_config_path = self.CreateTempFile()
+    source_url = storage_url.StorageUrlFromString('in')
+    destination_url = storage_url.StorageUrlFromString('gs://bucket/obj')
+    with util.SetBotoConfigForTest([
+        ('GSUtil', 'stet_binary_path', None),
+        ('GSUtil', 'stet_config_path', fake_config_path),
+    ]):
+      with self.assertRaises(KeyError):
+        stet_util.encrypt_upload(source_url, destination_url, None)
+
+  def test_stet_util_errors_if_no_config(self):
+    source_url = storage_url.StorageUrlFromString('in')
+    destination_url = storage_url.StorageUrlFromString('gs://bucket/obj')
+    with util.SetBotoConfigForTest([
+        ('GSUtil', 'stet_binary_path', 'fake_binary_path'),
+        ('GSUtil', 'stet_config_path', None),
+    ]):
+      with mock.patch.object(os.path,
+                             'exists',
+                             new=mock.Mock(return_value=False)):
+        with self.assertRaises(KeyError):
+          stet_util.encrypt_upload(source_url, destination_url, None)
+
+  @mock.patch.object(os.path, 'expanduser', autospec=True)
+  @mock.patch.object(execution_util,
+                     'ExecuteExternalCommand',
+                     new=mock.Mock(return_value=('stdout', 'stderr')))
+  def test_stet_util_expands_home_directory_symbol(self, mock_expanduser):
+    fake_config_path = self.CreateTempFile()
+    source_url = storage_url.StorageUrlFromString('in')
+    destination_url = storage_url.StorageUrlFromString('gs://bucket/obj')
+    with util.SetBotoConfigForTest([
+        ('GSUtil', 'stet_binary_path', 'fake_binary_path'),
+        ('GSUtil', 'stet_config_path', fake_config_path),
+    ]):
+      stet_util.encrypt_upload(source_url, destination_url, mock.Mock())
+    mock_expanduser.assert_has_calls(
+        [mock.call('fake_binary_path'),
+         mock.call(fake_config_path)])

--- a/gslib/tests/test_temporary_file_util.py
+++ b/gslib/tests/test_temporary_file_util.py
@@ -36,3 +36,8 @@ class TestTemporaryUtil(testcase.GsUtilUnitTestCase):
     self.assertEqual(
         temporary_file_util.GetTempZipFileName(
             storage_url.StorageUrlFromString('file.txt')), 'file.txt_.gztmp')
+
+  def testGetsStetTemporaryFileName(self):
+    self.assertEqual(
+        temporary_file_util.GetStetTempFileName(
+            storage_url.StorageUrlFromString('file.txt')), 'file.txt_.stet_tmp')

--- a/gslib/utils/stet_util.py
+++ b/gslib/utils/stet_util.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Helper functions for Split Trust Encryption Tool integration."""
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import division
+from __future__ import unicode_literals
+
+import os
+import shutil
+
+from gslib import storage_url
+from gslib.utils import execution_util
+from gslib.utils import temporary_file_util
+
+from boto import config
+
+DEFAULT_STET_CONFIG_PATH = '~/.config/stet.yaml'
+
+
+class StetSubcommandName(object):
+  """Enum class for available STET subcommands."""
+  ENCRYPT = 'encrypt'
+  DECRYPT = 'decrypt'
+
+
+def _get_stet_binary_from_path():
+  """Retrieves STET binary from path if available. Python 2 compatible."""
+  for path_directory in os.getenv('PATH').split(os.path.pathsep):
+    binary_path = os.path.join(path_directory, 'stet')
+    if os.path.exists(binary_path):
+      return binary_path
+
+
+def _stet_transform(subcommand, blob_id, in_file_path, out_file_path, logger):
+  """Runs a STET transform on a file.
+
+  Encrypts for uploads. Decrypts for downloads. Automatically populates
+  flags for the STET binary.
+
+  Args:
+    subcommand (StetSubcommandName): Subcommand to call on STET binary.
+    blob_id (str): Cloud URL that binary uses for validation.
+    in_file_path (str): File to be transformed source.
+    out_file_path (str): Where to write result of transform.
+    logger (logging.Logger): For logging STET binary output.
+
+  Raises:
+    KeyError: STET binary or config could not be found.
+  """
+  binary_path = config.get('GSUtil', 'stet_binary_path',
+                           _get_stet_binary_from_path())
+  if not binary_path:
+    raise KeyError('Could not find STET binary in boto config or PATH.')
+
+  config_path = config.get('GSUtil', 'stet_config_path',
+                           DEFAULT_STET_CONFIG_PATH)
+  if not os.path.exists(config_path):
+    raise KeyError(
+        'Could not find STET config in boto config or at default {}'.format(
+            DEFAULT_STET_CONFIG_PATH))
+
+  _, stderr = execution_util.ExecuteExternalCommand([
+      os.path.expanduser(binary_path), subcommand,
+      '--config-file=' + os.path.expanduser(config_path),
+      '--blob-id=' + blob_id, in_file_path, out_file_path
+  ])
+  logger.debug(stderr)
+
+
+def encrypt_upload(source_url, destination_url, logger):
+  """Encrypts a file with STET binary before upload.
+
+  Args:
+    source_url (StorageUrl): Copy source.
+    destination_url (StorageUrl): Copy destination.
+    logger (logging.Logger): For logging STET binary output.
+
+  Returns:
+    stet_temporary_file_url (StorageUrl): Path to STET-encrypted file.
+  """
+  in_file = source_url.object_name
+  out_file = temporary_file_util.GetStetTempFileName(source_url)
+  blob_id = destination_url.url_string
+
+  _stet_transform(StetSubcommandName.ENCRYPT, blob_id, in_file, out_file,
+                  logger)
+  return storage_url.StorageUrlFromString(out_file)
+
+
+def decrypt_download(source_url, destination_url, logger):
+  """STET-decrypts downloaded file.
+
+  Args:
+    source_url (StorageUrl): Copy source.
+    destination_url (StorageUrl): Copy destination.
+    logger (logging.Logger): For logging STET binary output.
+  """
+  in_file = destination_url.object_name
+  out_file = temporary_file_util.GetStetTempFileName(destination_url)
+  blob_id = source_url.url_string
+
+  _stet_transform(StetSubcommandName.DECRYPT, blob_id, in_file, out_file,
+                  logger)
+  shutil.move(out_file, in_file)

--- a/gslib/utils/temporary_file_util.py
+++ b/gslib/utils/temporary_file_util.py
@@ -28,3 +28,8 @@ def GetTempFileName(storage_url):
 def GetTempZipFileName(storage_url):
   """Returns temporary name for a temporarily compressed file."""
   return '%s_.gztmp' % storage_url.object_name
+
+
+def GetStetTempFileName(storage_url):
+  """Returns temporary file name for result of STET transform."""
+  return '%s_.stet_tmp' % storage_url.object_name


### PR DESCRIPTION
STET util for running binary.

Earlier commits include STET .boto config setting and temporary file type.
"[GSUtil]" isn't the best fit for the STET config setting, but everything else is less related, and it's probably not worth making a new section in the file. Briefly chatted with @thomasmaclean  about this.