### PR TITLE
Support generation querying for ls command.

### DIFF
--- a/gslib/commands/ls.py
+++ b/gslib/commands/ls.py
@@ -67,7 +67,7 @@ _DETAILED_HELP_TEXT = ("""
   listed provider:
 
     gsutil ls gs://
-    
+
   gsutil currently supports ``gs://`` and ``s3://`` as valid providers
 
   If you specify bucket URLs, gsutil ls lists objects at the top level of
@@ -243,7 +243,7 @@ _DETAILED_HELP_TEXT = ("""
   -l          Prints long listing (owner, length).
 
   -L          Prints even more detail than -l.
-  
+
               Note: If you use this option with the (non-default) XML API it
               generates an additional request per object being listed, which
               makes the -L option run much more slowly and cost more than the

--- a/gslib/tests/test_ls.py
+++ b/gslib/tests/test_ls.py
@@ -420,6 +420,25 @@ class TestLs(testcase.GsUtilIntegrationTestCase):
       time_updated = time.strptime(time_updated, '%a, %d %b %Y %H:%M:%S %Z')
       self.assertGreater(time_updated, time_created)
 
+  @SkipForS3('Integration test utils only support GCS JSON for versioning.')
+  @SkipForXML('Integration test utils only support GCS JSON for versioning.')
+  def test_one_object_with_generation(self):
+    """Tests listing one object by generation when multiple versions exist."""
+    bucket = self.CreateBucketJson(versioning_enabled=True)
+    object1 = self.CreateObjectJson(bucket_name=bucket.name, contents=b'1')
+    object2 = self.CreateObjectJson(bucket_name=bucket.name,
+                                    object_name=object1.name,
+                                    contents=b'2')
+    object_url_string1 = 'gs://{}/{}#{}'.format(object1.bucket, object1.name,
+                                                object1.generation)
+    object_url_string2 = 'gs://{}/{}#{}'.format(object2.bucket, object2.name,
+                                                object2.generation)
+
+    stdout = self.RunGsUtil(['ls', object_url_string2], return_stdout=True)
+
+    self.assertNotIn(object_url_string1, stdout)
+    self.assertIn(object_url_string2, stdout)
+
   def test_subdir(self):
     """Tests listing a bucket subdirectory."""
     bucket_uri = self.CreateBucket(test_objects=1)

--- a/gslib/utils/ls_helper.py
+++ b/gslib/utils/ls_helper.py
@@ -371,12 +371,15 @@ class LsHelper(object):
       return self._RecurseExpandUrlAndPrint(url.url_string,
                                             print_initial_newline=False)
     else:
-      # User provided a prefix or object URL, but it's impossible to tell
-      # which until we do a listing and see what matches.
+      # User provided a prefix or object URL, but can't tell which unless there
+      # is a generation or we do a listing to see what matches.
+      if url.HasGeneration():
+        iteration_url = url.url_string
+      else:
+        iteration_url = url.CreatePrefixUrl()
       top_level_iterator = PluralityCheckableIterator(
           self._iterator_func(
-              url.CreatePrefixUrl(wildcard_suffix=None),
-              all_versions=self.all_versions).IterAll(
+              iteration_url, all_versions=self.all_versions).IterAll(
                   expand_top_level_buckets=True,
                   bucket_listing_fields=self.bucket_listing_fields))
       plurality = top_level_iterator.HasPlurality()


### PR DESCRIPTION
Manually tested S3 since unit test covers GCS JSON:
```
$ python3 ./gsutil mb s3://12versiontest34
Creating s3://12versiontest34/...
$ python3 ./gsutil versioning set on s3://12versiontest34
$ python3 ./gsutil cp ~/Desktop/foo1 s3://12versiontest34                                           
$ python3 ./gsutil cp ~/Desktop/foo1 s3://12versiontest34                                            
$ python3 ./gsutil ls -a s3://12versiontest34
s3://12versiontest34/foo1#t3kEY8Yx8mu8xp4PAJB00_HfFZg16Rso
s3://12versiontest34/foo1#S7jkzG1up8Ory1Cdkv8SDzfpe2tImBL3
$ python3 ./gsutil ls -a s3://12versiontest34/foo1#S7jkzG1up8Ory1Cdkv8SDzfpe2tImBL3
s3://12versiontest34/foo1#S7jkzG1up8Ory1Cdkv8SDzfpe2tImBL3
```

Before:
```
$ python3 ./gsutil ls -a s3://12versiontest34/foo1#S7jkzG1up8Ory1Cdkv8SDzfpe2tImBL3
s3://12versiontest34/foo1#t3kEY8Yx8mu8xp4PAJB00_HfFZg16Rso
s3://12versiontest34/foo1#S7jkzG1up8Ory1Cdkv8SDzfpe2tImBL3
```
After:
```
$ python3 ./gsutil ls -a s3://12versiontest34/foo1#S7jkzG1up8Ory1Cdkv8SDzfpe2tImBL3
s3://12versiontest34/foo1#S7jkzG1up8Ory1Cdkv8SDzfpe2tImBL3
```