### PR TITLE
Adds a message encouraging py3 upgrade

### DIFF
--- a/gslib/__main__.py
+++ b/gslib/__main__.py
@@ -264,10 +264,6 @@ def main():
   if not supported:
     raise CommandException(err)
     sys.exit(1)
-  if sys.version_info.major is 2:
-    sys.stderr.write(
-        'Gsutil 5 will drop Python 2 support. Please install Python 3 to '
-        'continue using the latest version of Gsutil. https://goo.gle/py3\n')
 
   boto_util.MonkeyPatchBoto()
   system_util.MonkeyPatchHttp()

--- a/gslib/__main__.py
+++ b/gslib/__main__.py
@@ -264,6 +264,10 @@ def main():
   if not supported:
     raise CommandException(err)
     sys.exit(1)
+  if sys.version_info.major is 2:
+    sys.stderr.write(
+        'Gsutil 5 will drop Python 2 support. Please install Python 3 to '
+        'continue using the latest version of Gsutil. https://goo.gle/py3\n')
 
   boto_util.MonkeyPatchBoto()
   system_util.MonkeyPatchHttp()

--- a/gslib/command_runner.py
+++ b/gslib/command_runner.py
@@ -341,7 +341,8 @@ class CommandRunner(object):
       if system_util.IsRunningInteractively() and collect_analytics:
         metrics.CheckAndMaybePromptForAnalyticsEnabling()
 
-    if not do_shutdown:
+    # This will skip the Python update prompt for tests.
+    if do_shutdown:
       self.MaybePromptForPythonUpdate(command_name)
 
     if not args:

--- a/gslib/command_runner.py
+++ b/gslib/command_runner.py
@@ -341,7 +341,8 @@ class CommandRunner(object):
       if system_util.IsRunningInteractively() and collect_analytics:
         metrics.CheckAndMaybePromptForAnalyticsEnabling()
 
-    self.MaybePromptForPythonUpdate(command_name)
+    if not do_shutdown:
+      self.MaybePromptForPythonUpdate(command_name)
 
     if not args:
       args = []

--- a/gslib/command_runner.py
+++ b/gslib/command_runner.py
@@ -466,18 +466,19 @@ class CommandRunner(object):
       command_name: The name of the command being run.
 
     Returns:
-      True if the user decides to update.
+      True if a prompt was output.
     """
     logger = logging.getLogger()
     if (self.SkipUpdateCheck(command_name) or
-        boto.config.getbool('GSUtil', 'skip_python_update_prompt', False)):
+        boto.config.getbool('GSUtil', 'skip_python_update_prompt', False) or
+        sys.version_info.major != 2):
       return False
 
     # Notify the user about Python 2 deprecation.
-    if sys.version_info.major == 2:
-      print_to_fd(
-          'Gsutil 5 will drop Python 2 support. Please install Python 3 to '
-          'continue using the latest version of Gsutil. https://goo.gle/py3\n')
+    print_to_fd(
+        'Gsutil 5 will drop Python 2 support. Please install Python 3 to '
+        'continue using the latest version of Gsutil. https://goo.gle/py3\n')
+    return True
 
   def MaybeCheckForAndOfferSoftwareUpdate(self, command_name, debug):
     """Checks the last time we checked for an update and offers one if needed.

--- a/gslib/command_runner.py
+++ b/gslib/command_runner.py
@@ -538,8 +538,7 @@ class CommandRunner(object):
 
       cur_ver = gslib.VERSION
       try:
-        tarball = GsutilPubTarball()
-        cur_ver = LookUpGsutilVersion(gsutil_api, tarball)
+        cur_ver = LookUpGsutilVersion(gsutil_api, GsutilPubTarball())
       except Exception:
         return False
 

--- a/gslib/command_runner.py
+++ b/gslib/command_runner.py
@@ -454,7 +454,7 @@ class CommandRunner(object):
         command_name in ('config', 'update', 'ver', 'version') or
         not logger.isEnabledFor(logging.INFO) or
         boto_util.HasUserSpecifiedGsHost()):
-        return True
+      return True
     return False
 
   def MaybePromptForPythonUpdate(self, command_name):
@@ -468,7 +468,7 @@ class CommandRunner(object):
     """
     logger = logging.getLogger()
     if (self.SkipUpdateCheck(command_name) or
-      boto.config.getbool('GSUtil', 'skip_python_update_prompt', False)):
+        boto.config.getbool('GSUtil', 'skip_python_update_prompt', False)):
       return False
 
     # Notify the user about Python 2 deprecation.

--- a/gslib/command_runner.py
+++ b/gslib/command_runner.py
@@ -426,7 +426,7 @@ class CommandRunner(object):
           )))
     return return_code
 
-  def SkipUpdateCheck(self, command_name):
+  def SkipUpdateCheck(self):
     """Helper function that will determine if update checks should be skipped.
 
     Args:
@@ -455,11 +455,9 @@ class CommandRunner(object):
     Returns:
       True if a prompt was output.
     """
-    logger = logging.getLogger()
-    if (self.SkipUpdateCheck(command_name) or
+    if (sys.version_info.major != 2 or self.SkipUpdateCheck() or
         command_name not in ('update', 'ver', 'version') or
-        boto.config.getbool('GSUtil', 'skip_python_update_prompt', False) or
-        sys.version_info.major != 2):
+        boto.config.getbool('GSUtil', 'skip_python_update_prompt', False)):
       return False
 
     # Notify the user about Python 2 deprecation.
@@ -496,7 +494,7 @@ class CommandRunner(object):
     # - user is using a Cloud SDK install (which should only be updated via
     #   gcloud components update)
     logger = logging.getLogger()
-    if (self.SkipUpdateCheck(command_name) or
+    if (self.SkipUpdateCheck() or
         command_name in ('config', 'update', 'ver', 'version') or
         system_util.InvokedViaCloudSdk()):
       return False

--- a/gslib/command_runner.py
+++ b/gslib/command_runner.py
@@ -462,6 +462,12 @@ class CommandRunner(object):
         boto_util.HasUserSpecifiedGsHost() or system_util.InvokedViaCloudSdk()):
       return False
 
+    # Notify the user about Python 2 deprecation.
+    if sys.version_info.major == 2:
+      print_to_fd(
+          'Gsutil 5 will drop Python 2 support. Please install Python 3 to '
+          'continue using the latest version of Gsutil. https://goo.gle/py3\n')
+
     software_update_check_period = boto.config.getint(
         'GSUtil', 'software_update_check_period', 30)
     # Setting software_update_check_period to 0 means periodic software

--- a/gslib/command_runner.py
+++ b/gslib/command_runner.py
@@ -476,8 +476,8 @@ class CommandRunner(object):
 
     # Notify the user about Python 2 deprecation.
     print_to_fd(
-        'Gsutil 5 will drop Python 2 support. Please install Python 3 to '
-        'continue using the latest version of Gsutil. https://goo.gle/py3\n')
+        'Gsutil 5 drops Python 2 support. Please install Python 3 to continue '
+        'using the latest version of gsutil. https://goo.gle/py3\n')
     return True
 
   def MaybeCheckForAndOfferSoftwareUpdate(self, command_name, debug):

--- a/gslib/commands/update.py
+++ b/gslib/commands/update.py
@@ -23,6 +23,7 @@ import os
 import shutil
 import signal
 import stat
+import sys
 import tarfile
 import tempfile
 import textwrap
@@ -37,11 +38,11 @@ from gslib.sig_handling import RegisterSignalHandler
 from gslib.utils import system_util
 from gslib.utils.boto_util import GetConfigFilePaths
 from gslib.utils.boto_util import CERTIFICATE_VALIDATION_ENABLED
-from gslib.utils.constants import GSUTIL_PUB_TARBALL
 from gslib.utils.constants import RELEASE_NOTES_URL
 from gslib.utils.text_util import CompareVersions
 from gslib.utils.update_util import DisallowUpdateIfDataInGsutilDir
 from gslib.utils.update_util import LookUpGsutilVersion
+from gslib.utils.update_util import GsutilPubTarball
 
 _SYNOPSIS = """
   gsutil update [-f] [-n] [url]
@@ -95,7 +96,7 @@ _DETAILED_HELP_TEXT = ("""
 
   -n          Causes update command to run without prompting [Y/n] whether to
               continue if an update is available.
-""" % GSUTIL_PUB_TARBALL)
+""" % GsutilPubTarball())
 
 
 class UpdateCommand(Command):
@@ -336,7 +337,7 @@ class UpdateCommand(Command):
           raise CommandException(
               'Invalid update object URL. Must name a single .tar.gz file.')
     else:
-      update_from_url_str = GSUTIL_PUB_TARBALL
+      update_from_url_str = GsutilPubTarball()
 
     # Try to retrieve version info from tarball metadata; failing that; download
     # the tarball and extract the VERSION file. The version lookup will fail

--- a/gslib/tests/test_command_runner.py
+++ b/gslib/tests/test_command_runner.py
@@ -226,37 +226,34 @@ class TestCommandRunnerUnitTests(testcase.unit_testcase.GsUtilUnitTestCase):
     with mock.patch.object(sys, 'version_info') as v_info:
       v_info.major = 2
       self.running_interactively = False
-      self.assertEqual(
-          False,
-          self.command_runner.MaybePromptForPythonUpdate('ls'))
+      self.assertEqual(False,
+                       self.command_runner.MaybePromptForPythonUpdate('ls'))
 
   @unittest.skipIf(util.HAS_NON_DEFAULT_GS_HOST, SKIP_BECAUSE_RETRIES_ARE_SLOW)
   def test_py3_skipped_in_boto(self):
     """Tests that py3 prompt is not triggered if not running skipped in boto."""
-    with SetBotoConfigForTest([('GSUtil', 'skip_python_update_prompt', 'True')]):
+    with SetBotoConfigForTest([('GSUtil', 'skip_python_update_prompt', 'True')
+                              ]):
       with mock.patch.object(sys, 'version_info') as v_info:
         v_info.major = 2
-        self.assertEqual(
-            False,
-            self.command_runner.MaybePromptForPythonUpdate('ls'))
+        self.assertEqual(False,
+                         self.command_runner.MaybePromptForPythonUpdate('ls'))
 
   @unittest.skipIf(util.HAS_NON_DEFAULT_GS_HOST, SKIP_BECAUSE_RETRIES_ARE_SLOW)
   def test_py3_prompt_on_py2(self):
     """Tests that py3 prompt is not triggered if not running skipped in boto."""
     with mock.patch.object(sys, 'version_info') as v_info:
       v_info.major = 2
-      self.assertEqual(
-          True,
-          self.command_runner.MaybePromptForPythonUpdate('ls'))
-  
+      self.assertEqual(True,
+                       self.command_runner.MaybePromptForPythonUpdate('ls'))
+
   @unittest.skipIf(util.HAS_NON_DEFAULT_GS_HOST, SKIP_BECAUSE_RETRIES_ARE_SLOW)
   def test_py3_prompt_on_py3(self):
     """Tests that py3 prompt is not triggered if on py3."""
     with mock.patch.object(sys, 'version_info') as v_info:
       v_info.major = 3
-      self.assertEqual(
-          False,
-          self.command_runner.MaybePromptForPythonUpdate('ls'))
+      self.assertEqual(False,
+                       self.command_runner.MaybePromptForPythonUpdate('ls'))
 
   @unittest.skipIf(util.HAS_NON_DEFAULT_GS_HOST, SKIP_BECAUSE_RETRIES_ARE_SLOW)
   def test_not_interactive(self):

--- a/gslib/tests/test_command_runner.py
+++ b/gslib/tests/test_command_runner.py
@@ -223,37 +223,35 @@ class TestCommandRunnerUnitTests(testcase.unit_testcase.GsUtilUnitTestCase):
   @unittest.skipIf(util.HAS_NON_DEFAULT_GS_HOST, SKIP_BECAUSE_RETRIES_ARE_SLOW)
   def test_py3_not_interactive(self):
     """Tests that py3 prompt is not triggered if not running interactively."""
-    with mock.patch.object(sys, 'version_info') as v_info:
-      v_info.major = 2
+    with mock.patch.object(sys, 'version_info') as version_info:
+      version_info.major = 2
       self.running_interactively = False
-      self.assertEqual(False,
-                       self.command_runner.MaybePromptForPythonUpdate('ls'))
+      self.assertFalse(self.command_runner.MaybePromptForPythonUpdate('ver'))
 
   @unittest.skipIf(util.HAS_NON_DEFAULT_GS_HOST, SKIP_BECAUSE_RETRIES_ARE_SLOW)
   def test_py3_skipped_in_boto(self):
     """Tests that py3 prompt is not triggered if skipped in boto config."""
     with SetBotoConfigForTest([('GSUtil', 'skip_python_update_prompt', 'True')
                               ]):
-      with mock.patch.object(sys, 'version_info') as v_info:
-        v_info.major = 2
-        self.assertEqual(False,
-                         self.command_runner.MaybePromptForPythonUpdate('ls'))
+      with mock.patch.object(sys, 'version_info') as version_info:
+        version_info.major = 2
+        self.assertFalse(self.command_runner.MaybePromptForPythonUpdate('ver'))
 
   @unittest.skipIf(util.HAS_NON_DEFAULT_GS_HOST, SKIP_BECAUSE_RETRIES_ARE_SLOW)
   def test_py3_prompt_on_py2(self):
     """Tests that py3 prompt is triggered on Python 2."""
-    with mock.patch.object(sys, 'version_info') as v_info:
-      v_info.major = 2
+    with mock.patch.object(sys, 'version_info') as version_info:
+      version_info.major = 2
       self.assertEqual(True,
-                       self.command_runner.MaybePromptForPythonUpdate('ls'))
+                       self.command_runner.MaybePromptForPythonUpdate('ver'))
 
   @unittest.skipIf(util.HAS_NON_DEFAULT_GS_HOST, SKIP_BECAUSE_RETRIES_ARE_SLOW)
   def test_py3_prompt_on_py3(self):
     """Tests that py3 prompt is not triggered on Python 3."""
-    with mock.patch.object(sys, 'version_info') as v_info:
-      v_info.major = 3
+    with mock.patch.object(sys, 'version_info') as version_info:
+      version_info.major = 3
       self.assertEqual(False,
-                       self.command_runner.MaybePromptForPythonUpdate('ls'))
+                       self.command_runner.MaybePromptForPythonUpdate('ver'))
 
   @unittest.skipIf(util.HAS_NON_DEFAULT_GS_HOST, SKIP_BECAUSE_RETRIES_ARE_SLOW)
   def test_not_interactive(self):

--- a/gslib/tests/test_command_runner.py
+++ b/gslib/tests/test_command_runner.py
@@ -231,7 +231,7 @@ class TestCommandRunnerUnitTests(testcase.unit_testcase.GsUtilUnitTestCase):
 
   @unittest.skipIf(util.HAS_NON_DEFAULT_GS_HOST, SKIP_BECAUSE_RETRIES_ARE_SLOW)
   def test_py3_skipped_in_boto(self):
-    """Tests that py3 prompt is not triggered if not running skipped in boto."""
+    """Tests that py3 prompt is not triggered if skipped in boto config."""
     with SetBotoConfigForTest([('GSUtil', 'skip_python_update_prompt', 'True')
                               ]):
       with mock.patch.object(sys, 'version_info') as v_info:
@@ -241,7 +241,7 @@ class TestCommandRunnerUnitTests(testcase.unit_testcase.GsUtilUnitTestCase):
 
   @unittest.skipIf(util.HAS_NON_DEFAULT_GS_HOST, SKIP_BECAUSE_RETRIES_ARE_SLOW)
   def test_py3_prompt_on_py2(self):
-    """Tests that py3 prompt is not triggered if not running skipped in boto."""
+    """Tests that py3 prompt is triggered on Python 2."""
     with mock.patch.object(sys, 'version_info') as v_info:
       v_info.major = 2
       self.assertEqual(True,
@@ -249,7 +249,7 @@ class TestCommandRunnerUnitTests(testcase.unit_testcase.GsUtilUnitTestCase):
 
   @unittest.skipIf(util.HAS_NON_DEFAULT_GS_HOST, SKIP_BECAUSE_RETRIES_ARE_SLOW)
   def test_py3_prompt_on_py3(self):
-    """Tests that py3 prompt is not triggered if on py3."""
+    """Tests that py3 prompt is not triggered on Python 3."""
     with mock.patch.object(sys, 'version_info') as v_info:
       v_info.major = 3
       self.assertEqual(False,

--- a/gslib/tests/test_update.py
+++ b/gslib/tests/test_update.py
@@ -42,6 +42,12 @@ from gslib.utils import system_util
 from gslib.utils.boto_util import CERTIFICATE_VALIDATION_ENABLED
 from gslib.utils.constants import UTF8
 from gslib.utils.update_util import DisallowUpdateIfDataInGsutilDir
+from gslib.utils.update_util import GsutilPubTarball
+
+from six import add_move, MovedModule
+
+add_move(MovedModule('mock', 'mock', 'unittest.mock'))
+from six.moves import mock
 
 TESTS_DIR = os.path.abspath(os.path.dirname(__file__))
 GSUTIL_DIR = os.path.join(TESTS_DIR, '..', '..')
@@ -253,3 +259,11 @@ class UpdateUnitTest(testcase.GsUtilUnitTestCase):
         func = shutil.copyfile
       func(os.path.join(GSUTIL_DIR, comp), os.path.join(gsutil_src, comp))
     DisallowUpdateIfDataInGsutilDir(directory=gsutil_src)
+
+  def test_pub_tarball(self):
+    """Ensure that the correct URI is returned based on the Python version."""
+    with mock.patch.object(sys, 'version_info') as version_info:
+      version_info.major = 3
+      self.assertIn('gsutil.tar.gz', GsutilPubTarball())
+      version_info.major = 2
+      self.assertIn('gsutil4.tar.gz', GsutilPubTarball())

--- a/gslib/utils/constants.py
+++ b/gslib/utils/constants.py
@@ -49,6 +49,7 @@ DEFAULT_GCS_JSON_API_VERSION = 'v1'
 DEFAULT_GSUTIL_STATE_DIR = os.path.expanduser(os.path.join('~', '.gsutil'))
 
 GSUTIL_PUB_TARBALL = 'gs://pub/gsutil.tar.gz'
+GSUTIL_PUB_TARBALL_PY2 = 'gs://pub/gsutil4.tar.gz'
 
 IAM_POLICY_VERSION = 3
 

--- a/gslib/utils/update_util.py
+++ b/gslib/utils/update_util.py
@@ -23,11 +23,14 @@ import logging
 import os
 import re
 import textwrap
+import sys
 
 import gslib
 from gslib.utils.system_util import IS_OSX
 from gslib.exception import CommandException
 from gslib.storage_url import StorageUrlFromString
+from gslib.utils.constants import GSUTIL_PUB_TARBALL
+from gslib.utils.constants import GSUTIL_PUB_TARBALL_PY2
 
 
 # This function used to belong inside of update.py. However, it needed to be
@@ -118,3 +121,14 @@ def LookUpGsutilVersion(gsutil_api, url_str):
       for prop in obj.metadata.additionalProperties:
         if prop.key == 'gsutil_version':
           return prop.value
+
+
+def GsutilPubTarball():
+  """Returns the appropriate gsutil pub tarball based on the Python version.
+
+  Returns:
+    The storage_uri of the appropriate pub tarball.
+  """
+  if sys.version_info.major == 2:
+    return GSUTIL_PUB_TARBALL_PY2
+  return GSUTIL_PUB_TARBALL


### PR DESCRIPTION
This PR does the following:
- Alerts users running the `upgrade` or `version` command that they should install Py3 to stay up to date with the latest code. This way if you can't use the `upgrade` command, there will still be messaging.
- Python 2 gets a different upgrade tarball, leaving the door open for releasing bug fixes later on.