### PR TITLE
Bump gcs-oauth2-boto-plugin version to 3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [pypy2, 2.7, pypy3, 3.5, 3.6, 3.7, 3.8]
+        python-version: [pypy3, 3.5, 3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/gslib/utils/version_check.py
+++ b/gslib/utils/version_check.py
@@ -19,8 +19,8 @@ from sys import version_info
 
 # Key:   Int, supported Python major version
 # Value: Int, min supported Python minor version
-# We currently support Python ==2.7 and >=3.5
-MIN_SUPPORTED_PYTHON_VERSION = {2: 7, 3: 5}
+# We currently support Python >=3.5
+MIN_SUPPORTED_PYTHON_VERSION = {3: 5}
 
 
 def check_python_version_support():

--- a/gsutil
+++ b/gsutil
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # Copyright 2013 Google Inc. All Rights Reserved.
 #


### PR DESCRIPTION
- Bump gcs-oauth2-boto-plugin version to 3.0
- Remove Python 2.7 from CI
- Remove Python 2.7 from version_check.py
- Set the `gsutil` shebang to pick Python 3