### PR TITLE
Do not upper case rpo values

### DIFF
--- a/gslib/commands/mb.py
+++ b/gslib/commands/mb.py
@@ -254,7 +254,7 @@ class MbCommand(Command):
         elif o == '--retention':
           seconds = RetentionInSeconds(a)
         elif o == '--rpo':
-          rpo = a.strip().upper()
+          rpo = a.strip()
           if rpo not in VALID_RPO_VALUES:
             raise CommandException(
                 'Invalid value for --rpo. Must be one of: {},'

--- a/gslib/commands/rpo.py
+++ b/gslib/commands/rpo.py
@@ -136,7 +136,7 @@ class RpoCommand(Command):
   def _SetRpo(self, blr, rpo_value):
     """Sets the rpo setting for a bucket."""
     bucket_url = blr.storage_url
-    formatted_rpo_value = rpo_value.upper()
+    formatted_rpo_value = rpo_value
     if formatted_rpo_value not in VALID_RPO_VALUES:
       raise CommandException(
           'Invalid value for rpo set.'

--- a/gslib/tests/test_rpo.py
+++ b/gslib/tests/test_rpo.py
@@ -71,6 +71,13 @@ class TestRpoUnit(testcase.GsUtilUnitTestCase):
     ):
       self.RunCommand('rpo', ['set', 'random', 'gs://boo*'])
 
+  def test_set_called_with_lower_case_value_raises_error(self):
+    with self.assertRaisesRegexp(
+        CommandException,
+        r'Invalid value for rpo set. Should be one of \(ASYNC_TURBO\|DEFAULT\)'
+    ):
+      self.RunCommand('rpo', ['set', 'async_turbo', 'gs://boo*'])
+
   def test_invalid_subcommand_raises_error(self):
     with self.assertRaisesRegexp(
         CommandException, 'Invalid subcommand "blah", use get|set instead'):


### PR DESCRIPTION
Before
```
 python3 gsutil.py rpo set Default gs://dpednekar-rpo-test-1
Setting rpo DEFAULT for gs://dpednekar-rpo-test-1
```

After:
```
$ python3 gsutil.py rpo set Default gs://dpednekar-rpo-test-1
CommandException: Invalid value for rpo set. Should be one of (ASYNC_TURBO|DEFAULT)

$ python3 gsutil.py mb -l nam4 --rpo Default gs://dpednekar-rpo-test-3
CommandException: Invalid value for --rpo. Must be one of: (ASYNC_TURBO|DEFAULT), provided: Default
```