### PR TITLE
Replace invalid import mock statements

### DIFF
--- a/gslib/tests/test_context_config.py
+++ b/gslib/tests/test_context_config.py
@@ -20,9 +20,9 @@ from __future__ import division
 from __future__ import unicode_literals
 
 import json
-import mock
 import os
 import subprocess
+from unittest import mock
 
 import six
 

--- a/gslib/tests/test_execution_util.py
+++ b/gslib/tests/test_execution_util.py
@@ -19,8 +19,8 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import unicode_literals
 
-import mock
 import subprocess
+from unittest import mock
 
 from gslib import exception
 from gslib.tests import testcase

--- a/gslib/tests/test_hashing_helper.py
+++ b/gslib/tests/test_hashing_helper.py
@@ -22,6 +22,7 @@ from __future__ import unicode_literals
 import hashlib
 import os
 import pkgutil
+from unittest import mock
 
 from gslib.exception import CommandException
 from gslib.storage_url import StorageUrlFromString
@@ -31,7 +32,6 @@ from gslib.utils.hashing_helper import CalculateMd5FromContents
 from gslib.utils.hashing_helper import GetMd5
 from gslib.utils.hashing_helper import HashingFileUploadWrapper
 
-import mock
 
 _TEST_FILE = 'test.txt'
 

--- a/gslib/tests/test_hashing_helper.py
+++ b/gslib/tests/test_hashing_helper.py
@@ -32,7 +32,6 @@ from gslib.utils.hashing_helper import CalculateMd5FromContents
 from gslib.utils.hashing_helper import GetMd5
 from gslib.utils.hashing_helper import HashingFileUploadWrapper
 
-
 _TEST_FILE = 'test.txt'
 
 

--- a/gslib/tests/test_kms.py
+++ b/gslib/tests/test_kms.py
@@ -208,7 +208,7 @@ class TestKmsUnitTests(testcase.GsUtilUnitTestCase):
                 suri(bucket_uri)],
         return_stdout=True)
     self.assertIn('Setting default KMS key for bucket', stdout)
-    mock_patch_bucket.assert_called()
+    self.assertTrue(mock_patch_bucket.called)
 
   @mock.patch(
       'gslib.cloud_api_delegator.CloudApiDelegator.GetProjectServiceAccount')
@@ -228,7 +228,7 @@ class TestKmsUnitTests(testcase.GsUtilUnitTestCase):
                 suri(bucket_uri)],
         return_stdout=True)
     self.assertIn('Setting default KMS key for bucket', stdout)
-    mock_patch_bucket.assert_called()
+    self.assertTrue(mock_patch_bucket.called)
 
   @mock.patch(
       'gslib.cloud_api_delegator.CloudApiDelegator.GetProjectServiceAccount')

--- a/gslib/tests/test_kms.py
+++ b/gslib/tests/test_kms.py
@@ -20,8 +20,7 @@ from __future__ import division
 from __future__ import unicode_literals
 
 from random import randint
-import mock
-import unittest
+from unittest import mock
 
 from gslib.cloud_api import AccessDeniedException
 from gslib.project_id import PopulateProjectId

--- a/gslib/tests/test_parallelism_framework.py
+++ b/gslib/tests/test_parallelism_framework.py
@@ -27,13 +27,13 @@ from __future__ import division
 from __future__ import unicode_literals
 
 import functools
-import mock
 import os
 import signal
 import six
 import threading
 import textwrap
 import time
+from unittest import mock
 
 import boto
 from boto.storage_uri import BucketStorageUri

--- a/gslib/tests/test_stet_util.py
+++ b/gslib/tests/test_stet_util.py
@@ -29,7 +29,7 @@ from gslib.tests.util import unittest
 from gslib.utils import execution_util
 from gslib.utils import stet_util
 
-import mock
+from unittest import mock
 
 
 class TestStetUtil(testcase.GsUtilUnitTestCase):


### PR DESCRIPTION
Pipinstall tests for the release process started to fail because a change was introduced where mock library gets installed conditionally only for python2 https://github.com/GoogleCloudPlatform/gsutil/commit/043abe9b58ff2aff52325abeebde54cd056c0c3f  but some tests were still importing mock directly.

Not using six because this branch is meant to only support python3 going forward.