### PR TITLE
Backfill changes made in cl/397806013

### DIFF
--- a/gslib/commands/hash.py
+++ b/gslib/commands/hash.py
@@ -53,23 +53,23 @@ _DETAILED_HELP_TEXT = ("""
 
 
 <B>DESCRIPTION</B>
-  The hash command calculates hashes on a local file that can be used to compare
-  with gsutil ls -L output. If a specific hash option is not provided, this
-  command calculates all gsutil-supported hashes for the file.
+  Calculate hashes on local files, which can be used to compare with
+  ``gsutil ls -L`` output. If a specific hash option is not provided, this
+  command calculates all gsutil-supported hashes for the files.
 
   Note that gsutil automatically performs hash validation when uploading or
   downloading files, so this command is only needed if you want to write a
-  script that separately checks the hash for some reason.
+  script that separately checks the hash.
 
-  If you calculate a CRC32c hash for the file without a precompiled crcmod
+  If you calculate a CRC32c hash for files without a precompiled crcmod
   installation, hashing will be very slow. See "gsutil help crcmod" for details.
 
 <B>OPTIONS</B>
-  -c          Calculate a CRC32c hash for the file.
+  -c          Calculate a CRC32c hash for the specified files.
 
   -h          Output hashes in hex format. By default, gsutil uses base64.
 
-  -m          Calculate a MD5 hash for the file.
+  -m          Calculate a MD5 hash for the specified files.
 """)
 
 

--- a/gslib/commands/mb.py
+++ b/gslib/commands/mb.py
@@ -48,31 +48,19 @@ _DETAILED_HELP_TEXT = ("""
 
 
 <B>DESCRIPTION</B>
-  The mb command creates a new bucket. Google Cloud Storage has a single
-  namespace, so you are not allowed to create a bucket with a name already
-  in use by another user. You can, however, carve out parts of the bucket name
-  space corresponding to your company's domain name (see "gsutil help naming").
+  Create one or more new buckets. Google Cloud Storage has a single namespace,
+  so you are not allowed to create a bucket with a name already in use by
+  another user. You can, however, carve out parts of the bucket name space
+  corresponding to your company's domain name (see "gsutil help naming").
 
-  If you don't specify a project ID using the -p option, the bucket is created
+  If you don't specify a project ID using the -p option, the buckets are created
   using the default project ID specified in your `gsutil configuration file
   <https://cloud.google.com/storage/docs/boto-gsutil>`_.
 
-  The -c and -l options specify the storage class and location, respectively,
-  for the bucket. Once a bucket is created in a given location and with a
-  given storage class, it cannot be moved to a different location, and the
-  storage class cannot be changed. Instead, you would need to create a new
-  bucket and move the data over and then delete the original bucket.
-
-  The --retention option specifies the retention period for the bucket. For more
-  details about retention policy see "gsutil help retention".
-
-  The -b option specifies the uniform bucket-level access setting of the bucket.
-  ACLs assigned to objects are not evaluated in buckets with uniform bucket-
-  level access enabled. Consequently, only IAM policies grant access to objects
-  in these buckets.
-
-  The --pap option specifies the public access prevention setting of the bucket.
-  When enforced, objects in this bucket cannot be made publicly accessible.
+  The -l option specifies the location for the buckets. Once a bucket is created
+  in a given location, it cannot be moved to a different location. Instead, you
+  need to create a new bucket, move the data over, and then delete the original
+  bucket.
 
 <B>BUCKET STORAGE CLASSES</B>
   You can specify one of the `storage classes
@@ -128,19 +116,11 @@ _DETAILED_HELP_TEXT = ("""
   If you don't specify a --retention option, the bucket is created with no
   retention policy.
 
-<B>UNIFORM BUCKET-LEVEL ACCESS</B>
-  You can enable or disable uniform bucket-level access for a bucket
-  with the -b option.
-
-  Examples:
-
-    gsutil mb -b off gs://bucket-with-acls
-
-    gsutil mb -b on gs://bucket-with-no-acls
-
 <B>OPTIONS</B>
   -b <on|off>            Specifies the uniform bucket-level access setting.
-                         Default is "off"
+                         When "on", ACLs assigned to objects in the bucket are
+                         not evaluated. Consequently, only IAM policies grant
+                         access to objects in these buckets. Default is "off".
 
   -c class               Specifies the default storage class.
                          Default is "Standard".
@@ -157,11 +137,13 @@ _DETAILED_HELP_TEXT = ("""
 
   --retention time       Specifies the retention policy. Default is no retention
                          policy. This can only be set on gs:// buckets and
-                         requires using the JSON API.
+                         requires using the JSON API. For more details about
+                         retention policy see "gsutil help retention"
 
-  --pap setting          Specifies the public access prevention setting.
-                         Valid values are "enforced" or "unspecified".
-                         Default is "unspecified".
+  --pap setting          Specifies the public access prevention setting. Valid
+                         values are "enforced" or "unspecified". When
+                         "enforced", objects in this bucket cannot be made
+                         publicly accessible. Default is "unspecified".
 
 """)
 

--- a/gslib/commands/rb.py
+++ b/gslib/commands/rb.py
@@ -38,8 +38,7 @@ _DETAILED_HELP_TEXT = ("""
 
 
 <B>DESCRIPTION</B>
-  The rb command deletes a bucket. Buckets must be empty before you can delete
-  them.
+  Delete one or more buckets. Buckets must be empty before you can delete them.
 
   Be certain you want to delete a bucket before you do so, as once it is
   deleted the name becomes available and another user may create a bucket with


### PR DESCRIPTION
Small updates to gsutil help docs

-- Make it clearer that `hash`, `mb`, and `rb` commands can apply to more than one resource.
-- Cut out excessive text from the `mb` command, and move useful information into the "options" section.