### PR TITLE
Minor documentation fixes

### DIFF
--- a/gslib/commands/cp.py
+++ b/gslib/commands/cp.py
@@ -95,7 +95,7 @@ _DESCRIPTION_TEXT = """
   You can use the ``-n`` option to prevent overwriting the content of
   existing files. The following example downloads text files from a bucket
   without clobbering the data in your directory:
-  
+
     gsutil cp -n gs://my-bucket/*.txt .
 
   Use the ``-r`` option to copy an entire directory tree.
@@ -407,13 +407,10 @@ _SLICED_OBJECT_DOWNLOADS_TEXT = """
   of slices is set small to avoid this problem, you can disable sliced object
   download if necessary by setting the "sliced_object_download_threshold"
   variable in the ``.boto`` config file to 0.
-
-
 """
 
 _PARALLEL_COMPOSITE_UPLOADS_TEXT = """
 <B>PARALLEL COMPOSITE UPLOADS</B>
-
   gsutil can automatically use
   `object composition <https://cloud.google.com/storage/docs/composite-objects>`_
   to perform uploads in parallel for large, local files being uploaded to

--- a/gslib/commands/hmac.py
+++ b/gslib/commands/hmac.py
@@ -81,9 +81,9 @@ _DELETE_DESCRIPTION = """
   deleted.
 
 <B>DELETE OPTIONS</B>
-  The "delete" sub-command has the following option
+  The ``delete`` sub-command has the following option
 
-  -p <project>.               Specify the ID or number of the project from which to
+  -p <project>                Specify the ID or number of the project from which to
                               delete a key.
 """
 
@@ -144,7 +144,7 @@ _UPDATE_DESCRIPTION = """
                               if the specified etag matches the etag of the
                               stored key.
 
-  -p <project>                Specify ther ID or number of the project in
+  -p <project>                Specify the ID or number of the project in
                               which to update a key.
 """
 

--- a/gslib/commands/rm.py
+++ b/gslib/commands/rm.py
@@ -75,7 +75,7 @@ _DETAILED_HELP_TEXT = ("""
   When working with versioning-enabled buckets, note that the -r option removes
   all object versions in the subdirectory. To remove only the live version of
   each object in the subdirectory, use the `** wildcard
-  <https://cloud.google.com//storage/docs/gsutil/addlhelp/WildcardNames>`_.
+  <https://cloud.google.com/storage/docs/gsutil/addlhelp/WildcardNames>`_.
 
   The following command removes all versions of all objects in a bucket, and
   then deletes the bucket:
@@ -129,7 +129,7 @@ _DETAILED_HELP_TEXT = ("""
               gsutil deletes the bucket. This option implies the -a option and
               deletes all object versions. If you only want to delete live
               object versions, use the `** wildcard
-              <https://cloud.google.com//storage/docs/gsutil/addlhelp/WildcardNames>`_
+              <https://cloud.google.com/storage/docs/gsutil/addlhelp/WildcardNames>`_
               instead of -r.
 
   -a          Delete all versions of an object.


### PR DESCRIPTION
Attempting to fix typo and syntax issues that cropped up in the latest doc generation run (preparing for the 5.4 gsutil release)