### PR TITLE
Updating link to cp Options docs

### DIFF
--- a/gslib/commands/mv.py
+++ b/gslib/commands/mv.py
@@ -87,7 +87,8 @@ _DETAILED_HELP_TEXT = ("""
 <B>OPTIONS</B>
   All options that are available for the gsutil cp command are also available
   for the gsutil mv command (except for the -R flag, which is implied by the
-  ``gsutil mv`` command). Please see the OPTIONS sections of "gsutil help cp"
+  ``gsutil mv`` command). Please see the
+  <a href="/storage/docs/gsutil/commands/cp#options">Options section for cp</a>
   for more information.
 
 """)


### PR DESCRIPTION
Docs work described in here: https://b.corp.google.com/issues/202778546, https://critique-ng.corp.google.com/cl/403993699