### PR TITLE
Do not perform hash validation if check_hashes=never even if Content-MD5 is set

### DIFF
--- a/gslib/tests/test_cp.py
+++ b/gslib/tests/test_cp.py
@@ -2348,6 +2348,16 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
     self.assertIn('Copying file:', stderr)
     self.AssertNObjectsInBucket(bucket_uri, 1)
 
+  def test_upload_does_not_raise_with_content_md5_and_check_hashes_never(self):
+    fpath1 = self.CreateTempFile(file_name=('foo'))
+    bucket_uri = self.CreateBucket()
+    with SetBotoConfigForTest([('GSUtil', 'check_hashes', 'never')]):
+      stderr = self.RunGsUtil(
+          ['-h', 'Content-MD5: invalid-md5',  'cp', fpath1, suri(bucket_uri)],
+          return_stderr=True)
+      self.assertIn('Copying file:', stderr)
+    self.AssertNObjectsInBucket(bucket_uri, 1)
+
   @SequentialAndParallelTransfer
   def test_cp_object_ending_with_slash(self):
     """Tests that cp works with object names ending with slash."""

--- a/gslib/utils/copy_helper.py
+++ b/gslib/utils/copy_helper.py
@@ -3830,6 +3830,11 @@ def PerformCopy(logger,
   if global_copy_helper_opts.dest_storage_class:
     dst_obj_metadata.storageClass = global_copy_helper_opts.dest_storage_class
 
+  if config.get('GSUtil', 'check_hashes') == CHECK_HASH_NEVER:
+    # GCS server will perform MD5 validation if the md5 hash is present.
+    # Remove md5_hash if check_hashes=never.
+    dst_obj_metadata.md5Hash = None
+
   _LogCopyOperation(logger, src_url, dst_url, dst_obj_metadata)
 
   if src_url.IsCloudUrl():


### PR DESCRIPTION
Currently, hash validation is performed for GCS uploads if someone `-h Content-MD5` is present along with `check_hashes=never`.

```
gsutil  -o "GSUtil:check_hashes=never"  -h "Content-MD5: VgyllJgiiaRAbyUUIqDMmw=="  cp ~/temp/junk/test.txt gs://gs
util_test_bucket-4/
...
BadRequestException: 400 Provided MD5 hash "VgyllJgiiaRAbyUUIqDMmw==" doesn't match calculated MD5 hash "iuPXG/eB0vLil6O2Rt2Dqw==".
```

Similarly for S3 to GCS copy, since the MD5 hash from the source gets copied to destination metadata before the upload, the server will through a hash mismatch error.

```
gsutil -o "GSUtil:check_hashes=never" cp s3://bucket/test2.txt gs://bucket/
...
ResumableUploadAbortException: 400 Provided MD5 hash "3QCu8Pz90+Aiek7XuT0NbQ==" doesn't match calculated MD5 hash "iuPXG/eB0vLil6O2Rt2Dqw==".
```


After the fix both the above copies work and MD5 validation is ignored.
