### PR TITLE
Change CDR tests to not use us-central-1 and us-east1 together

### DIFF
--- a/gslib/tests/test_ls.py
+++ b/gslib/tests/test_ls.py
@@ -1127,11 +1127,11 @@ class TestLs(testcase.GsUtilIntegrationTestCase):
   @SkipForS3('Custom Dual Region is not supported for S3 buckets.')
   def test_list_Lb_displays_custom_dual_region_placement_info(self):
     bucket_name = 'gs://' + self.MakeTempName('bucket')
-    self.RunGsUtil(['mb', '--placement', 'us-central1,us-east1', bucket_name],
+    self.RunGsUtil(['mb', '--placement', 'us-central1,us-west1', bucket_name],
                    expected_status=0)
     stdout = self.RunGsUtil(['ls', '-Lb', bucket_name], return_stdout=True)
     self.assertRegex(stdout,
-                     r"Placement locations:\t\t\['US-CENTRAL1', 'US-EAST1'\]")
+                     r"Placement locations:\t\t\['US-CENTRAL1', 'US-WEST1'\]")
 
   @SkipForXML('Autoclass is not supported for the XML API.')
   @SkipForS3('Autoclass is not supported for S3 buckets.')

--- a/gslib/tests/test_mb.py
+++ b/gslib/tests/test_mb.py
@@ -192,11 +192,11 @@ class TestMb(testcase.GsUtilIntegrationTestCase):
     bucket_uri = boto.storage_uri('gs://%s' % (bucket_name.lower()),
                                   suppress_consec_slashes=False)
     self.RunGsUtil(
-        ['mb', '--placement', 'us-central1,us-east1',
+        ['mb', '--placement', 'us-central1,us-west1',
          suri(bucket_uri)])
     stdout = self.RunGsUtil(['ls', '-Lb', suri(bucket_uri)], return_stdout=True)
     self.assertRegex(stdout,
-                     r"Placement locations:\t\t\['US-CENTRAL1', 'US-EAST1'\]")
+                     r"Placement locations:\t\t\['US-CENTRAL1', 'US-WEST1'\]")
 
   @SkipForXML('The --placement flag only works for GCS JSON API.')
   def test_create_with_invalid_placement_flag_raises_error(self):


### PR DESCRIPTION
CDR with predefined dual regions e.g us-central1/us-east1 or europe-north1/europe-west4 will not be allowed. Eventually we want to add a test to ensure this combination errors out.