### PR TITLE
Fixes broken import in test_storage_url

### DIFF
--- a/gslib/tests/test_storage_url.py
+++ b/gslib/tests/test_storage_url.py
@@ -26,7 +26,7 @@ from gslib import storage_url
 from gslib.exception import InvalidUrlError
 from gslib.tests.testcase import base
 
-import mock
+from unittest import mock
 
 _UNSUPPORTED_DOUBLE_WILDCARD_WARNING_TEXT = (
     '** behavior is undefined if directly preceeded or followed by'


### PR DESCRIPTION
Previously some environments were coming back with a rather obscure error:

```
======================================================================
ERROR: FailedTest (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: FailedTest
Traceback (most recent call last):
File "/usr/lib/python3.9/unittest/loader.py", line 154, in loadTestsFromName
module = __import__(module_name)
ModuleNotFoundError: No module named 'FailedTest'
```