### PR TITLE
PAP: Temporarily handle unspecified as well as inherited

### DIFF
--- a/gslib/commands/pap.py
+++ b/gslib/commands/pap.py
@@ -100,7 +100,8 @@ class PapCommand(Command):
       argparse_arguments={
           'get': [CommandArgument.MakeNCloudURLsArgument(1),],
           'set': [
-              CommandArgument('mode', choices=['enforced', 'unspecified']),
+              CommandArgument('mode',
+                              choices=['enforced', 'unspecified', 'inherited']),
               CommandArgument.MakeZeroOrMoreCloudBucketURLsArgument()
           ],
       })

--- a/gslib/tests/test_ls.py
+++ b/gslib/tests/test_ls.py
@@ -1103,7 +1103,8 @@ class TestLs(testcase.GsUtilIntegrationTestCase):
   def test_list_public_access_prevention(self):
     bucket_uri = self.CreateBucket()
     stdout = self.RunGsUtil(['ls', '-Lb', suri(bucket_uri)], return_stdout=True)
-    self.assertRegex(stdout, r'Public access prevention:\t*unspecified')
+    self.assertRegex(stdout,
+                     r'Public access prevention:\t*(unspecified|inherited)')
     # Enforce public access prevention.
     self.RunGsUtil(['pap', 'set', 'enforced', suri(bucket_uri)])
     stdout = self.RunGsUtil(['ls', '-Lb', suri(bucket_uri)], return_stdout=True)

--- a/gslib/tests/test_mb.py
+++ b/gslib/tests/test_mb.py
@@ -122,12 +122,14 @@ class TestMb(testcase.GsUtilIntegrationTestCase):
     bucket_uri = boto.storage_uri('gs://%s' % (bucket_name.lower()),
                                   suppress_consec_slashes=False)
     self.RunGsUtil(['mb', '--pap', 'unspecified', suri(bucket_uri)])
-    # TODO(b/201683262) Change this to only check for inherited we have
-    # consitent behavior from the backend
-    try:
-      self.VerifyPublicAccessPreventionValue(bucket_uri, 'unspecified')
-    except AssertionError:
-      self.VerifyPublicAccessPreventionValue(bucket_uri, 'inherited')
+    # TODO(b/201683262) Replace all calls to this method
+    # with self.VerifyPublicAccessPreventionValue(bucket_uri, 'inherited')
+    # once the backend rollout is completed.
+    stdout = self.RunGsUtil(['publicaccessprevention', 'get',
+                             suri(bucket_uri)],
+                            return_stdout=True)
+    self.assertRegex(stdout,
+                     r'%s:\s+(unspecified|inherited)' % suri(bucket_uri))
 
   @SkipForXML('Public access prevention only runs on GCS JSON API.')
   def test_create_with_pap_invalid_arg(self):

--- a/gslib/tests/test_mb.py
+++ b/gslib/tests/test_mb.py
@@ -122,7 +122,12 @@ class TestMb(testcase.GsUtilIntegrationTestCase):
     bucket_uri = boto.storage_uri('gs://%s' % (bucket_name.lower()),
                                   suppress_consec_slashes=False)
     self.RunGsUtil(['mb', '--pap', 'unspecified', suri(bucket_uri)])
-    self.VerifyPublicAccessPreventionValue(bucket_uri, 'unspecified')
+    # TODO(b/201683262) Change this to only check for inherited we have
+    # consitent behavior from the backend
+    try:
+      self.VerifyPublicAccessPreventionValue(bucket_uri, 'unspecified')
+    except AssertionError:
+      self.VerifyPublicAccessPreventionValue(bucket_uri, 'inherited')
 
   @SkipForXML('Public access prevention only runs on GCS JSON API.')
   def test_create_with_pap_invalid_arg(self):

--- a/gslib/tests/test_pap.py
+++ b/gslib/tests/test_pap.py
@@ -31,14 +31,14 @@ class TestPublicAccessPrevention(testcase.GsUtilIntegrationTestCase):
   _get_pap_cmd = ['pap', 'get']
 
   def _verify_public_access_prevention_unspecified(self, bucket_uri):
-    # TODO(b/201683262) Remove this one backend rollout is completed.
-    try:
-      self.VerifyPublicAccessPreventionValue(bucket_uri, 'unspecified')
-    except AssertionError:
-      # For a brief period, the backend might support either unspecified
-      # or inherited. Until the full rollout is done, we will have to
-      # check for both the value.
-      self.VerifyPublicAccessPreventionValue(bucket_uri, 'inherited')
+    # TODO(b/201683262) Replace all calls to this method
+    # with self.VerifyPublicAccessPreventionValue(bucket_uri, 'inherited')
+    # once the backend rollout is completed.
+    stdout = self.RunGsUtil(['publicaccessprevention', 'get',
+                             suri(bucket_uri)],
+                            return_stdout=True)
+    self.assertRegex(stdout,
+                     r'%s:\s+(unspecified|inherited)' % suri(bucket_uri))
 
   @SkipForXML('Public access prevention only runs on GCS JSON API')
   def test_off_on_default_buckets(self):

--- a/gslib/tests/test_pap.py
+++ b/gslib/tests/test_pap.py
@@ -30,10 +30,20 @@ class TestPublicAccessPrevention(testcase.GsUtilIntegrationTestCase):
   _set_pap_cmd = ['pap', 'set']
   _get_pap_cmd = ['pap', 'get']
 
+  def _verify_public_access_prevention_unspecified(self, bucket_uri):
+    # TODO(b/201683262) Remove this one backend rollout is completed.
+    try:
+      self.VerifyPublicAccessPreventionValue(bucket_uri, 'unspecified')
+    except AssertionError:
+      # For a brief period, the backend might support either unspecified
+      # or inherited. Until the full rollout is done, we will have to
+      # check for both the value.
+      self.VerifyPublicAccessPreventionValue(bucket_uri, 'inherited')
+
   @SkipForXML('Public access prevention only runs on GCS JSON API')
   def test_off_on_default_buckets(self):
     bucket_uri = self.CreateBucket()
-    self.VerifyPublicAccessPreventionValue(bucket_uri, 'unspecified')
+    self._verify_public_access_prevention_unspecified(bucket_uri)
 
   @SkipForXML('Public access prevention only runs on GCS JSON API')
   def test_turning_off_on_enabled_buckets(self):
@@ -42,7 +52,7 @@ class TestPublicAccessPrevention(testcase.GsUtilIntegrationTestCase):
     self.VerifyPublicAccessPreventionValue(bucket_uri, 'enforced')
 
     self.RunGsUtil(self._set_pap_cmd + ['unspecified', suri(bucket_uri)])
-    self.VerifyPublicAccessPreventionValue(bucket_uri, 'unspecified')
+    self._verify_public_access_prevention_unspecified(bucket_uri)
 
   @SkipForXML('Public access prevention only runs on GCS JSON API')
   def test_turning_on(self):
@@ -59,7 +69,7 @@ class TestPublicAccessPrevention(testcase.GsUtilIntegrationTestCase):
     self.VerifyPublicAccessPreventionValue(bucket_uri, 'enforced')
 
     self.RunGsUtil(self._set_pap_cmd + ['unspecified', suri(bucket_uri)])
-    self.VerifyPublicAccessPreventionValue(bucket_uri, 'unspecified')
+    self._verify_public_access_prevention_unspecified(bucket_uri)
 
   @SkipForXML('Public access prevention only runs on GCS JSON API')
   def test_multiple_buckets(self):
@@ -69,8 +79,10 @@ class TestPublicAccessPrevention(testcase.GsUtilIntegrationTestCase):
         self._get_pap_cmd +
         [suri(bucket_uri1), suri(bucket_uri2)],
         return_stdout=True)
-    self.assertRegex(stdout, r'%s:\s+unspecified' % suri(bucket_uri1))
-    self.assertRegex(stdout, r'%s:\s+unspecified' % suri(bucket_uri2))
+    self.assertRegex(stdout,
+                     r'%s:\s+(unspecified|inherited)' % suri(bucket_uri1))
+    self.assertRegex(stdout,
+                     r'%s:\s+(unspecified|inherited)' % suri(bucket_uri2))
 
   @SkipForJSON('Testing XML only behavior')
   def test_xml_fails(self):


### PR DESCRIPTION
For some time the backend might return `unspecified` or `inherited` for the test project. We will change everything to inherited once the backend rollout is done.