### PR TITLE
Part 2 of shim for running gcloud storage: Invoke gcloud storage command

### DIFF
--- a/gslib/command.py
+++ b/gslib/command.py
@@ -612,6 +612,7 @@ class Command(HelpProvider, GcloudStorageCommandMixin):
     because it will make changing the __init__ interface more painful.
     """
     # Save class values from constructor params.
+    super().__init__()
     self.command_runner = command_runner
     self.unparsed_args = args
     self.headers = headers

--- a/gslib/command_runner.py
+++ b/gslib/command_runner.py
@@ -30,6 +30,7 @@ import time
 import six
 from six.moves import input
 import boto
+from boto import config
 from boto.storage_uri import BucketStorageUri
 import gslib
 from gslib import metrics
@@ -49,6 +50,7 @@ from gslib.gcs_json_api import GcsJsonApi
 from gslib.no_op_credentials import NoOpCredentials
 from gslib.tab_complete import MakeCompleter
 from gslib.utils import boto_util
+from gslib.utils import shim_util
 from gslib.utils import system_util
 from gslib.utils.constants import RELEASE_NOTES_URL
 from gslib.utils.constants import UTF8
@@ -409,7 +411,14 @@ class CommandRunner(object):
                                sub_opts=command_inst.sub_opts,
                                command_alias=command_name)
 
-    return_code = command_inst.RunCommand()
+    if command_inst.can_run_gcloud_storage():
+      # This does not mean that the gcloud storage command worked.
+      # It only means that we succesfully attempted running gcloud storage.
+      # The command itself might have failed.
+      return_code = command_inst.run_gcloud_storage()
+    else:
+      # Run gsutil.
+      return_code = command_inst.RunCommand()
 
     if CheckMultiprocessingAvailableAndInit().is_available and do_shutdown:
       ShutDownGsutil()

--- a/gslib/command_runner.py
+++ b/gslib/command_runner.py
@@ -411,7 +411,7 @@ class CommandRunner(object):
                                sub_opts=command_inst.sub_opts,
                                command_alias=command_name)
 
-    if command_inst.can_run_gcloud_storage():
+    if command_inst.translate_to_gcloud_storage_if_requested():
       # This does not mean that the gcloud storage command worked.
       # It only means that we succesfully attempted running gcloud storage.
       # The command itself might have failed.

--- a/gslib/commands/cp.py
+++ b/gslib/commands/cp.py
@@ -755,11 +755,11 @@ class CpCommand(Command):
 
   # TODO(b/206151615) Add mappings for remaining flags.
   gcloud_storage_map = GcloudStorageMap(
-    gcloud_command='alpha storage cp',
-    flag_map={
-      '-r': GcloudStorageFlag('-r'),
-      '-R': GcloudStorageFlag('-r'),
-    }
+      gcloud_command='alpha storage cp',
+      flag_map={
+          '-r': GcloudStorageFlag('-r'),
+          '-R': GcloudStorageFlag('-r'),
+      },
   )
 
   # pylint: disable=too-many-statements

--- a/gslib/commands/cp.py
+++ b/gslib/commands/cp.py
@@ -60,6 +60,8 @@ from gslib.utils.posix_util import InitializeUserGroups
 from gslib.utils.posix_util import POSIXAttributes
 from gslib.utils.posix_util import SerializeFileAttributesToObjectMetadata
 from gslib.utils.posix_util import ValidateFilePermissionAccess
+from gslib.utils.shim_util import GcloudStorageFlag
+from gslib.utils.shim_util import GcloudStorageMap
 from gslib.utils.system_util import GetStreamFromFileUrl
 from gslib.utils.system_util import StdinIterator
 from gslib.utils.system_util import StdinIteratorCls
@@ -749,6 +751,15 @@ class CpCommand(Command):
       help_one_line_summary='Copy files and objects',
       help_text=_DETAILED_HELP_TEXT,
       subcommand_help_text={},
+  )
+
+  # TODO(b/206151615) Add mappings for remaining flags.
+  gcloud_storage_map = GcloudStorageMap(
+    gcloud_command='alpha storage cp',
+    flag_map={
+      '-r': GcloudStorageFlag('-r'),
+      '-R': GcloudStorageFlag('-r'),
+    }
   )
 
   # pylint: disable=too-many-statements

--- a/gslib/tests/test_command.py
+++ b/gslib/tests/test_command.py
@@ -28,7 +28,7 @@ from gslib.utils import constants
 
 class FakeGsutilCommand(command.Command):
   """Implementation of a fake gsutil command."""
-  command_spec = command.Command.CreateCommandSpec('fake',
+  command_spec = command.Command.CreateCommandSpec('fake_gsutil',
                                                    min_args=1,
                                                    max_args=constants.NO_MAX,
                                                    supported_sub_args='rz:',

--- a/gslib/tests/test_shim_util.py
+++ b/gslib/tests/test_shim_util.py
@@ -254,8 +254,8 @@ class TestTranslateToGcloudStorageIfRequested(testcase.GsUtilUnitTestCase):
             exception.CommandException,
             'CommandException: Gsutil is not using the same credentials as'
             ' gcloud. You can make gsutil use the same credentials'
-            ' by running:{}{} config set pass_credentials_to_gsutil True'.
-            format(os.linesep, os.path.join('fake_dir', 'bin', 'gcloud'))):
+            ' by running:\n'
+            'fake_dir.bin.gcloud config set pass_credentials_to_gsutil True'):
           self._fake_command.translate_to_gcloud_storage_if_requested()
 
   def test_raises_error_if_gcloud_storage_map_missing(self):

--- a/gslib/tests/test_shim_util.py
+++ b/gslib/tests/test_shim_util.py
@@ -254,7 +254,7 @@ class TestTranslateToGcloudStorageIfRequested(testcase.GsUtilUnitTestCase):
             exception.CommandException,
             'CommandException: Gsutil is not using the same credentials as'
             ' gcloud. You can make gsutil use the same credentials by running:'
-            '\n{} config set pass_credentials_to_gsutil True'.format(
+            '[\r\n]+{} config set pass_credentials_to_gsutil True'.format(
                 os.path.join('fake_dir', 'bin', 'gcloud'))):
           self._fake_command.translate_to_gcloud_storage_if_requested()
 

--- a/gslib/tests/test_shim_util.py
+++ b/gslib/tests/test_shim_util.py
@@ -330,16 +330,11 @@ class TestTranslateToGcloudStorageIfRequested(testcase.GsUtilUnitTestCase):
     with mock.patch.object(self._fake_command, 'logger',
                            autospec=True) as mock_logger:
       self._fake_command._print_gcloud_storage_command_info(
-          ['fake', 'gcloud', 'command'], {
-              'fake_env_var1': 'val1',
-              'fake_env_var2': 'val2',
-          },
-          dry_run=True)
+          ['fake', 'gcloud', 'command'], {'fake_env_var': 'val'}, dry_run=True)
       expected_calls = [
           mock.call('Gcloud Storage Command: fake gcloud command'),
           mock.call('Enviornment variables for Gcloud Storage:'),
-          mock.call('%s=%s', 'fake_env_var1', 'val1'),
-          mock.call('%s=%s', 'fake_env_var2', 'val2'),
+          mock.call('%s=%s', 'fake_env_var', 'val'),
       ]
       self.assertEqual(mock_logger.info.mock_calls, expected_calls)
 

--- a/gslib/tests/test_shim_util.py
+++ b/gslib/tests/test_shim_util.py
@@ -217,9 +217,10 @@ class TestTranslateToGcloudStorageIfRequested(testcase.GsUtilUnitTestCase):
         self.assertTrue(
             self._fake_command.translate_to_gcloud_storage_if_requested())
         # Verify translation.
+        expected_gcloud_path = os.path.join('fake_dir', 'bin', 'gcloud')
         self.assertEqual(self._fake_command._translated_gcloud_storage_command,
                          [
-                             'fake_dir/bin/gcloud', 'objects', 'fake', '--zip',
+                             expected_gcloud_path, 'objects', 'fake', '--zip',
                              'opt1', '-x', 'arg1', 'arg2'
                          ])
         # TODO(b/206149936) Verify translated boto config.
@@ -253,7 +254,8 @@ class TestTranslateToGcloudStorageIfRequested(testcase.GsUtilUnitTestCase):
             exception.CommandException,
             'CommandException: Gsutil is not using the same credentials as'
             ' gcloud. You can make gsutil use the same credentials by running:'
-            '\nfake_dir/bin/gcloud config set pass_credentials_to_gsutil True'):
+            '\n{} config set pass_credentials_to_gsutil True'.format(
+                os.path.join('fake_dir', 'bin', 'gcloud'))):
           self._fake_command.translate_to_gcloud_storage_if_requested()
 
   def test_raises_error_if_gcloud_storage_map_missing(self):
@@ -298,9 +300,10 @@ class TestTranslateToGcloudStorageIfRequested(testcase.GsUtilUnitTestCase):
       with util.SetEnvironmentForTest({'CLOUDSDK_ROOT_DIR': 'fake_dir'}):
         stdout = self.RunCommand('fake', args=['arg1'], return_stdout=True)
         self.assertIn(
-            'Gcloud Storage Command: fake_dir/bin/gcloud objects fake arg1'
-            '\nEnviornment variables for Gcloud Storage: {}\n'
-            'FakeCommandWithGcloudStorageMap called', stdout)
+            'Gcloud Storage Command: {} objects fake arg1'
+            '\nEnviornment variables for Gcloud Storage: {{}}\n'
+            'FakeCommandWithGcloudStorageMap called'.format(
+                os.path.join('fake_dir', 'bin', 'gcloud')), stdout)
 
 
 class TestRunGcloudStorage(testcase.GsUtilUnitTestCase):

--- a/gslib/tests/test_shim_util.py
+++ b/gslib/tests/test_shim_util.py
@@ -328,7 +328,7 @@ class TestRunGcloudStorage(testcase.GsUtilUnitTestCase):
           'CLOUDSDK_CORE_PASS_CREDENTIALS_TO_GSUTIL': 'True',
           'CLOUDSDK_ROOT_DIR': 'fake_dir',
       }):
-        command_instance._translated_boto_config_to_env_vars = {
+        command_instance._translated_env_variables = {
             'new_key': 'new_value',
         }
         command_instance._translated_gcloud_storage_command = ['gcloud', 'foo']

--- a/gslib/tests/test_shim_util.py
+++ b/gslib/tests/test_shim_util.py
@@ -254,7 +254,7 @@ class TestTranslateToGcloudStorageIfRequested(testcase.GsUtilUnitTestCase):
             exception.CommandException,
             'CommandException: Gsutil is not using the same credentials as'
             ' gcloud. You can make gsutil use the same credentials by running:'
-            '[\r\n]+{} config set pass_credentials_to_gsutil True'.format(
+            r'[\r\n]+{} config set pass_credentials_to_gsutil True'.format(
                 os.path.join('fake_dir', 'bin', 'gcloud'))):
           self._fake_command.translate_to_gcloud_storage_if_requested()
 

--- a/gslib/tests/test_shim_util.py
+++ b/gslib/tests/test_shim_util.py
@@ -19,6 +19,8 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import unicode_literals
 
+import os
+import subprocess
 from unittest import mock
 
 from gslib import command
@@ -298,3 +300,39 @@ class TestTranslateToGcloudStorageIfRequested(testcase.GsUtilUnitTestCase):
         mock_gsutil_run_command.assert_called_once_with(
             mock.ANY  # The command instance.
         )
+
+
+class TestRunGcloudStorage(testcase.GsUtilUnitTestCase):
+  """Test Command.run_gcloud_storage method."""
+
+  @mock.patch.object(os.environ, 'copy', return_value={'old_key': 'old_value'})
+  @mock.patch.object(subprocess, 'run', autospec=True)
+  def test_calls_subprocess_with_translated_command_and_env_vars(
+      self, mock_run, mock_environ_copy):
+    command_instance = FakeCommandWithGcloudStorageMap(
+        command_runner=mock.ANY,
+        args=['-z', 'opt1', '-r', 'arg1', 'arg2'],
+        headers=mock.ANY,
+        debug=mock.ANY,
+        trace_token=mock.ANY,
+        parallel_operations=mock.ANY,
+        bucket_storage_uri_class=mock.ANY,
+        gsutil_api_class_map_factory=mock.MagicMock())
+    with util.SetBotoConfigForTest([('GSUtil', 'use_gcloud_storage', 'always')
+                                   ]):
+      with util.SetEnvironmentForTest({
+          'CLOUDSDK_CORE_PASS_CREDENTIALS_TO_GSUTIL': 'True',
+          'CLOUDSDK_ROOT_DIR': 'fake_dir',
+      }):
+        command_instance._translated_boto_config_to_env_vars = {
+            'new_key': 'new_value',
+        }
+        command_instance._translated_gcloud_storage_command = ['gcloud', 'foo']
+        actual_return_code = command_instance.run_gcloud_storage()
+        mock_run.assert_called_once_with(['gcloud', 'foo'],
+                                         env={
+                                             'old_key': 'old_value',
+                                             'new_key': 'new_value'
+                                         })
+        mock_environ_copy.assert_called_once_with()
+        self.assertEqual(actual_return_code, mock_run.return_value.returncode)

--- a/gslib/tests/test_shim_util.py
+++ b/gslib/tests/test_shim_util.py
@@ -322,8 +322,9 @@ class TestTranslateToGcloudStorageIfRequested(testcase.GsUtilUnitTestCase):
           self._fake_command.translate_to_gcloud_storage_if_requested()
           # Verify translation.
           mock_logger.debug.assert_called_once_with(
-              'Gcloud Storage Command: fake_dir/bin/gcloud objects'
-              ' fake --zip opt1 -x arg1 arg2')
+              'Gcloud Storage Command: {} objects'
+              ' fake --zip opt1 -x arg1 arg2'.format(
+                  os.path.join('fake_dir', 'bin', 'gcloud')))
 
   def test_print_gcloud_storage_env_vars_in_dry_run_mode(self):
     """Should log the command and env vars to logger.info"""

--- a/gslib/tests/test_shim_util.py
+++ b/gslib/tests/test_shim_util.py
@@ -224,6 +224,16 @@ class TestTranslateToGcloudStorageIfRequested(testcase.GsUtilUnitTestCase):
                          ])
         # TODO(b/206149936) Verify translated boto config.
 
+  def test_raises_error_if_invalid_use_gcloud_storage_value(self):
+    with util.SetBotoConfigForTest([('GSUtil', 'use_gcloud_storage', 'invalid')
+                                   ]):
+      with self.assertRaisesRegex(
+          exception.CommandException,
+          'CommandException: Invalid option specified for'
+          ' GSUtil:use_gcloud_storage config setting. Should be one of:'
+          ' never | if_available_else_skip | always | dry_run'):
+        self._fake_command.translate_to_gcloud_storage_if_requested()
+
   def test_raises_error_if_cloudsdk_root_dir_is_none(self):
     with util.SetBotoConfigForTest([('GSUtil', 'use_gcloud_storage', 'always')
                                    ]):

--- a/gslib/tests/test_shim_util.py
+++ b/gslib/tests/test_shim_util.py
@@ -253,9 +253,9 @@ class TestTranslateToGcloudStorageIfRequested(testcase.GsUtilUnitTestCase):
         with self.assertRaisesRegex(
             exception.CommandException,
             'CommandException: Gsutil is not using the same credentials as'
-            ' gcloud. You can make gsutil use the same credentials by running:'
-            r'[\r\n]+{} config set pass_credentials_to_gsutil True'.format(
-                os.path.join('fake_dir', 'bin', 'gcloud'))):
+            ' gcloud. You can make gsutil use the same credentials'
+            ' by running:{}{} config set pass_credentials_to_gsutil True'.
+            format(os.linesep, os.path.join('fake_dir', 'bin', 'gcloud'))):
           self._fake_command.translate_to_gcloud_storage_if_requested()
 
   def test_raises_error_if_gcloud_storage_map_missing(self):

--- a/gslib/tests/test_shim_util.py
+++ b/gslib/tests/test_shim_util.py
@@ -201,7 +201,7 @@ class TestTranslateToGcloudStorageIfRequested(testcase.GsUtilUnitTestCase):
                              autospec=True) as mock_get_gcloud_storage_args:
         self.assertFalse(
             self._fake_command.translate_to_gcloud_storage_if_requested())
-        mock_get_gcloud_storage_args.assert_not_called()
+        self.assertFalse(mock_get_gcloud_storage_args.called)
 
   def test_returns_true_with_valid_gcloud_storage_map(self):
     """Should return True and perform the translation."""

--- a/gslib/tests/test_shim_util.py
+++ b/gslib/tests/test_shim_util.py
@@ -34,7 +34,7 @@ from gslib.tests import util
 
 class FakeCommandWithGcloudStorageMap(command.Command):
   """Implementation of a fake gsutil command."""
-  command_spec = command.Command.CreateCommandSpec('fake',
+  command_spec = command.Command.CreateCommandSpec('fake_shim',
                                                    min_args=1,
                                                    max_args=constants.NO_MAX,
                                                    supported_sub_args='irz:',
@@ -46,7 +46,7 @@ class FakeCommandWithGcloudStorageMap(command.Command):
           '-z': shim_util.GcloudStorageFlag(gcloud_flag='--zip'),
       })
   help_spec = command.Command.HelpSpec(
-      help_name='fake_command',
+      help_name='fake_shim',
       help_name_aliases=[],
       help_type='command_help',
       help_one_line_summary='Fake one line summary for the command.',
@@ -138,15 +138,15 @@ class TestGetGCloudStorageArgs(testcase.GsUtilUnitTestCase):
     self._fake_command.gcloud_storage_map = None
     with self.assertRaisesRegex(
         exception.GcloudStorageTranslationError,
-        'Command "fake" cannot be translated to gcloud storage'
+        'Command "fake_shim" cannot be translated to gcloud storage'
         ' because the translation mapping is missing'):
       self._fake_command.get_gcloud_storage_args()
 
   def test_raises_error_if_gcloud_command_is_of_incorrect_type(self):
     self._fake_command.gcloud_storage_map = shim_util.GcloudStorageMap(
         gcloud_command=['incorrect', 'command'], flag_map={})
-    with self.assertRaisesRegex(ValueError,
-                                'Incorrect mapping found for "fake" command'):
+    with self.assertRaisesRegex(
+        ValueError, 'Incorrect mapping found for "fake_shim" command'):
       self._fake_command.get_gcloud_storage_args()
 
   def test_raises_error_if_command_option_mapping_is_missing(self):
@@ -268,7 +268,7 @@ class TestTranslateToGcloudStorageIfRequested(testcase.GsUtilUnitTestCase):
       }):
         with self.assertRaisesRegex(
             exception.CommandException,
-            'CommandException: Command "fake" cannot be translated to'
+            'CommandException: Command "fake_shim" cannot be translated to'
             ' gcloud storage because the translation mapping is missing.'):
           self._fake_command.translate_to_gcloud_storage_if_requested()
 
@@ -282,7 +282,7 @@ class TestTranslateToGcloudStorageIfRequested(testcase.GsUtilUnitTestCase):
       }):
         # return_stderr does not work here. Probably because we have
         # defined the FakeCommand in the same module.
-        stdout, mock_log_handler = self.RunCommand('fake',
+        stdout, mock_log_handler = self.RunCommand('fake_shim',
                                                    args=['-i', 'arg1'],
                                                    return_stdout=True,
                                                    return_log_handler=True)
@@ -298,7 +298,7 @@ class TestTranslateToGcloudStorageIfRequested(testcase.GsUtilUnitTestCase):
     with util.SetBotoConfigForTest([('GSUtil', 'use_gcloud_storage', 'dry_run')
                                    ]):
       with util.SetEnvironmentForTest({'CLOUDSDK_ROOT_DIR': 'fake_dir'}):
-        stdout = self.RunCommand('fake', args=['arg1'], return_stdout=True)
+        stdout = self.RunCommand('fake_shim', args=['arg1'], return_stdout=True)
         self.assertIn(
             'Gcloud Storage Command: {} objects fake arg1'
             '\nEnviornment variables for Gcloud Storage: {{}}\n'

--- a/gslib/utils/shim_util.py
+++ b/gslib/utils/shim_util.py
@@ -145,8 +145,17 @@ class GcloudStorageCommandMixin(object):
     return self._get_gcloud_storage_args(self.sub_opts, self.args,
                                          self.gcloud_storage_map)
 
-  def can_run_gcloud_storage(self):
-    """Returns True if equivalent gcloud storage command can be executed."""
+  def translate_to_gcloud_storage_if_requested(self):
+    """Translates the gsutil command to gcloud storage equivalent.
+
+    The translated commands get stored at
+    self._translated_gcloud_storage_command.
+    This command also translate the boto config, which gets stored as a dict
+    at self._translated_gcloud_storage_command
+    
+    Returns:
+      True if the command was successfully translated, else False.
+    """
     use_gcloud_storage = config.get('GSUtil', 'use_gcloud_storage', 'never')
     if use_gcloud_storage != 'never':
       try:
@@ -165,10 +174,11 @@ class GcloudStorageCommandMixin(object):
           print('Enviornment variables for Gcloud Storage: {}'.format(
               translated_boto_config_to_env_vars))
         elif not os.environ.get('CLOUDSDK_CORE_PASS_CREDENTIALS_TO_GSUTIL'):
+          print('here')
           raise exception.GcloudStorageTranslationError(
               'Gsutil is not using the same credentials as gcloud.'
               ' You can make gsutil use the same credentials by running:\n'
-              ' {} config set pass_credentials_to_gsutil True'.format(
+              '{} config set pass_credentials_to_gsutil True'.format(
                   gcloud_binary_path))
         else:
           self._translated_gcloud_storage_command = gcloud_storage_command

--- a/gslib/utils/shim_util.py
+++ b/gslib/utils/shim_util.py
@@ -159,14 +159,14 @@ class GcloudStorageCommandMixin(object):
     use_gcloud_storage = config.get('GSUtil', 'use_gcloud_storage', 'never')
     if use_gcloud_storage != 'never':
       try:
-        # TODO Get top level flags
+        # TODO(b/206143429) Get top level flags.
         top_level_flags = []
 
         gcloud_binary_path = _get_gcloud_binary_path()
         gcloud_storage_command = ([gcloud_binary_path] +
                                   self.get_gcloud_storage_args() +
                                   top_level_flags)
-        # TODO: Translate boto config to Gcloud env
+        # TODO(b/206149936): Translate boto config to CLOUDSDK envs.
         translated_boto_config_to_env_vars = {}
         if use_gcloud_storage == 'dry_run':
           print('Gcloud Storage Command: {}'.format(

--- a/gslib/utils/shim_util.py
+++ b/gslib/utils/shim_util.py
@@ -26,6 +26,13 @@ import subprocess
 from boto import config
 from gslib import exception
 
+VALID_USE_GCLOUD_STORAGE_VALUES = (
+    'never',
+    'if_available_else_skip',
+    'always',
+    'dry_run',
+)
+
 
 class GcloudStorageFlag(object):
 
@@ -157,6 +164,11 @@ class GcloudStorageCommandMixin(object):
       True if the command was successfully translated, else False.
     """
     use_gcloud_storage = config.get('GSUtil', 'use_gcloud_storage', 'never')
+    if use_gcloud_storage not in VALID_USE_GCLOUD_STORAGE_VALUES:
+      raise exception.CommandException(
+          'Invalid option specified for'
+          ' GSUtil:use_gcloud_storage config setting. Should be one of: {}'.
+          format(' | '.join(VALID_USE_GCLOUD_STORAGE_VALUES)))
     if use_gcloud_storage != 'never':
       try:
         # TODO(b/206143429) Get top level flags.

--- a/gslib/utils/shim_util.py
+++ b/gslib/utils/shim_util.py
@@ -195,7 +195,6 @@ class GcloudStorageCommandMixin(object):
     return False
 
   def run_gcloud_storage(self):
-    print('command is: ', self._translated_gcloud_storage_command)
     subprocess_envs = os.environ.copy()
     subprocess_envs.update(self._translated_boto_config_to_env_vars)
     process = subprocess.run(self._translated_gcloud_storage_command,

--- a/gslib/utils/shim_util.py
+++ b/gslib/utils/shim_util.py
@@ -158,7 +158,7 @@ class GcloudStorageCommandMixin(object):
     The translated commands get stored at
     self._translated_gcloud_storage_command.
     This command also translate the boto config, which gets stored as a dict
-    at self._translated_gcloud_storage_command
+    at self._translated_env_variables
     
     Returns:
       True if the command was successfully translated, else False.
@@ -179,12 +179,12 @@ class GcloudStorageCommandMixin(object):
                                   self.get_gcloud_storage_args() +
                                   top_level_flags)
         # TODO(b/206149936): Translate boto config to CLOUDSDK envs.
-        translated_boto_config_to_env_vars = {}
+        env_variables = {}
         if use_gcloud_storage == 'dry_run':
           print('Gcloud Storage Command: {}'.format(
               ' '.join(gcloud_storage_command)))
           print('Enviornment variables for Gcloud Storage: {}'.format(
-              translated_boto_config_to_env_vars))
+              env_variables))
         elif not os.environ.get('CLOUDSDK_CORE_PASS_CREDENTIALS_TO_GSUTIL'):
           print('here')
           raise exception.GcloudStorageTranslationError(
@@ -194,8 +194,7 @@ class GcloudStorageCommandMixin(object):
                   gcloud_binary_path))
         else:
           self._translated_gcloud_storage_command = gcloud_storage_command
-          self._translated_boto_config_to_env_vars = (
-              translated_boto_config_to_env_vars)
+          self._translated_env_variables = env_variables
           return True
       except exception.GcloudStorageTranslationError as e:
         if use_gcloud_storage == 'always':
@@ -208,7 +207,7 @@ class GcloudStorageCommandMixin(object):
 
   def run_gcloud_storage(self):
     subprocess_envs = os.environ.copy()
-    subprocess_envs.update(self._translated_boto_config_to_env_vars)
+    subprocess_envs.update(self._translated_env_variables)
     process = subprocess.run(self._translated_gcloud_storage_command,
                              env=subprocess_envs)
     return process.returncode


### PR DESCRIPTION
This PR does the following:
- Translates the gsutil command to it's gcloud storage equivalent if it was requested by the user.
- Runs the gcloud storage command if successfully translated.