### PR TITLE
Import shim before multiprocessing manager is activated

### DIFF
--- a/gslib/__main__.py
+++ b/gslib/__main__.py
@@ -44,6 +44,12 @@ from gslib.utils.version_check import check_python_version_support
 from gslib.utils.arg_helper import GetArgumentsAndOptions
 from gslib.utils.user_agent_helper import GetUserAgent
 
+# This module is actually used by gslib/command.py, but we noticed that certain
+# tests timeout in Python 3.5 because the multiprocessing manager process gets
+# stuck. We do not know the root cause here, but we believe that this might
+# be because of the import lock and loading the module before the
+# multiprocessing Manager instance is create seems to resolve the issue.
+# See b/208418444#comment7
 from gslib.utils.shim_util import GcloudStorageCommandMixin
 
 # Load the gsutil version number and append it to boto.UserAgent so the value is

--- a/gslib/__main__.py
+++ b/gslib/__main__.py
@@ -47,8 +47,8 @@ from gslib.utils.user_agent_helper import GetUserAgent
 # This module is actually used by gslib/command.py, but we noticed that certain
 # tests timeout in Python 3.5 because the multiprocessing manager process gets
 # stuck. We do not know the root cause here, but we believe that this might
-# be because of the import lock and loading the module before the
-# multiprocessing Manager instance is create seems to resolve the issue.
+# be because of the import lock, and loading the module before the
+# multiprocessing Manager instance is created seems to resolve the issue.
 # See b/208418444#comment7
 from gslib.utils.shim_util import GcloudStorageCommandMixin
 

--- a/gslib/__main__.py
+++ b/gslib/__main__.py
@@ -44,6 +44,8 @@ from gslib.utils.version_check import check_python_version_support
 from gslib.utils.arg_helper import GetArgumentsAndOptions
 from gslib.utils.user_agent_helper import GetUserAgent
 
+from gslib.utils.shim_util import GcloudStorageCommandMixin
+
 # Load the gsutil version number and append it to boto.UserAgent so the value is
 # set before anything instantiates boto. This has to run after THIRD_PARTY_DIR
 # is modified (done in gsutil.py) but before any calls are made that would cause


### PR DESCRIPTION
See b/208418444#comment7 for details.
We are adding a dummy import so that the module gets loaded before the any multiprocessing steps are executed.