### PR TITLE
Eliminate the multiprocessing warning

### DIFF
--- a/gslib/command.py
+++ b/gslib/command.py
@@ -1349,15 +1349,6 @@ class Command(HelpProvider, GcloudStorageCommandMixin):
                'update your config file(s) (located at %s) and set '
                '"parallel_process_count = 1".') %
               (os_name, ', '.join(GetFriendlyConfigFilePaths())))))
-    is_main_thread = self.recursive_apply_level == 0
-    if os_name == 'macOS' and process_count > 1 and is_main_thread:
-      self.logger.info(
-          'If you experience problems with multiprocessing on MacOS, they '
-          'might be related to https://bugs.python.org/issue33725. You can '
-          'disable multiprocessing by editing your .boto config or by adding '
-          'the following flag to your command: '
-          '`-o "GSUtil:parallel_process_count=1"`. Note that multithreading is '
-          'still available even if you disable multiprocessing.\n')
 
     self.logger.debug('process count: %d', process_count)
     self.logger.debug('thread count: %d', thread_count)


### PR DESCRIPTION
This is super annoying and should've been made opt-outable. Ethier way, not a major concern anymore, as the linked issue is closed long time ago.