### PR TITLE
Suppress nslookup debug logs

### DIFF
--- a/gslib/commands/perfdiag.py
+++ b/gslib/commands/perfdiag.py
@@ -1588,7 +1588,8 @@ class PerfDiagCommand(Command):
     # it's routing to.
     cmd = ['nslookup', '-type=CNAME', self.XML_API_HOST]
     try:
-      nslookup_cname_output = self._Exec(cmd, return_output=True)
+      nslookup_cname_output = self._Exec(cmd, return_output=True,
+          mute_stderr=True)
       m = re.search(r' = (?P<googserv>[^.]+)\.', nslookup_cname_output)
       sysinfo['googserv_route'] = m.group('googserv') if m else None
     except (CommandException, OSError):
@@ -1656,7 +1657,8 @@ class PerfDiagCommand(Command):
     # Query o-o to find out what the Google DNS thinks is the user's IP.
     try:
       cmd = ['nslookup', '-type=TXT', 'o-o.myaddr.google.com.']
-      nslookup_txt_output = self._Exec(cmd, return_output=True)
+      nslookup_txt_output = self._Exec(cmd, return_output=True,
+          mute_stderr=True)
       m = re.search(r'text\s+=\s+"(?P<dnsip>[\.\d]+)"', nslookup_txt_output)
       sysinfo['dns_o-o_ip'] = m.group('dnsip') if m else None
     except (CommandException, OSError):


### PR DESCRIPTION
Perfdiag runs `nslookup`. Lately, nslookup has started outputting debug logs (probably not on all platforms) which are not that useful for perfdiag and hence can be suppressed 


This test started showing a lot of unrelated logs 

```
$  python3 gsutil.py test perfdiag.TestPerfDiagUnitTests.test_listing_does_not_list_preexisting_objects
1/1 finished - E[0] F[0] s[0] - TestPerfDiagUnitTests.test_listing_does_ - main parsing o-o.myaddr.google.com.
addlookup()
make_empty_lookup()
make_empty_lookup() = 0x7fb2bdb49000->references = 1
looking up o-o.myaddr.google.com.
lock_lookup dighost.c:4186
success
start_lookup()
setup_lookup(0x7fb2bdb49000)
...
```

I am muting the stderr for these command calls.

This is indirectly tested by seeing a test passing without any garbage displayed on the screen.
```
$  python3 gsutil.py test perfdiag.TestPerfDiagUnitTests.test_listing_does_not_list_preexisting_objects
1/1 finished - E[0] F[0] s[0] - TestPerfDiagUnitTests.test_listing_does_ - .
----------------------------------------------------------------------
Ran 1 test in 0.214s

OK
```