### PR TITLE
Fix linking syntax in help docs

### DIFF
--- a/gslib/commands/mv.py
+++ b/gslib/commands/mv.py
@@ -87,8 +87,8 @@ _DETAILED_HELP_TEXT = ("""
 <B>OPTIONS</B>
   All options that are available for the gsutil cp command are also available
   for the gsutil mv command (except for the -R flag, which is implied by the
-  ``gsutil mv`` command). Please see the
-  <a href="/storage/docs/gsutil/commands/cp#options">Options section for cp</a>
+  ``gsutil mv`` command). Please see the `Options section for cp
+  <https://cloud.google.com/storage/docs/gsutil/commands/cp#options>`_
   for more information.
 
 """)

--- a/gslib/commands/perfdiag.py
+++ b/gslib/commands/perfdiag.py
@@ -230,8 +230,8 @@ _DETAILED_HELP_TEXT = ("""
               between 0 and 100 (inclusive), with 0 generating a file with
               uniform data, and 100 generating random data. When you specify
               the ``-j`` option, files being uploaded are compressed in-memory and
-              on-the-wire only. See ``cp -j
-              <https://cloud.google.com/storage/docs/gsutil/commands/cp#options>``_
+              on-the-wire only. See `cp -j
+              <https://cloud.google.com/storage/docs/gsutil/commands/cp#options>`_
               for specific semantics.
 
 

--- a/gslib/commands/rsync.py
+++ b/gslib/commands/rsync.py
@@ -334,9 +334,10 @@ _DETAILED_HELP_TEXT = ("""
 
   Note that by default, the gsutil rsync command does not copy the ACLs of
   objects being synchronized and instead will use the default bucket ACL (see
-  "gsutil help defacl"). You can override this behavior with the -p option. See the
-  <a href="https://cloud.google.com/storage/docs/gsutil/commands/rsync#options">Options section</a>
-  to learn how.
+  "gsutil help defacl"). You can override this behavior with the -p option. See
+  the `Options section
+  <https://cloud.google.com/storage/docs/gsutil/commands/rsync#options>`_ to
+  learn how.
 
 
 <B>SLOW CHECKSUMS</B>


### PR DESCRIPTION
Several links were added with incorrect styling, which affects content generation into cloud.google.com documentation