### PR TITLE
PAP: Replace unspecified with inherited

### DIFF
--- a/gslib/commands/mb.py
+++ b/gslib/commands/mb.py
@@ -152,9 +152,9 @@ _DETAILED_HELP_TEXT = ("""
                          retention policy see "gsutil help retention"
 
   --pap setting          Specifies the public access prevention setting. Valid
-                         values are "enforced" or "unspecified". When
+                         values are "enforced" or "inherited". When
                          "enforced", objects in this bucket cannot be made
-                         publicly accessible. Default is "unspecified".
+                         publicly accessible. Default is "inherited".
 
   --placement reg1,reg2  Two regions that form the cutom dual-region.
                          Only regions within the same continent are or will ever

--- a/gslib/commands/pap.py
+++ b/gslib/commands/pap.py
@@ -100,8 +100,7 @@ class PapCommand(Command):
       argparse_arguments={
           'get': [CommandArgument.MakeNCloudURLsArgument(1),],
           'set': [
-              CommandArgument('mode',
-                              choices=['enforced', 'inherited']),
+              CommandArgument('mode', choices=['enforced', 'inherited']),
               CommandArgument.MakeZeroOrMoreCloudBucketURLsArgument()
           ],
       })

--- a/gslib/commands/pap.py
+++ b/gslib/commands/pap.py
@@ -30,7 +30,7 @@ from gslib.third_party.storage_apitools import storage_v1_messages as apitools_m
 from gslib.utils.constants import NO_MAX
 
 _SET_SYNOPSIS = """
-  gsutil pap set (enforced|unspecified) gs://<bucket_name>...
+  gsutil pap set (enforced|inherited) gs://<bucket_name>...
 """
 
 _GET_SYNOPSIS = """
@@ -43,7 +43,7 @@ _SET_DESCRIPTION = """
 <B>SET</B>
   The ``pap set`` command configures public access prevention
   for Cloud Storage buckets. If you set a bucket to be
-  ``unspecified``, it uses public access prevention only if
+  ``inherited``, it uses public access prevention only if
   the bucket is subject to the `public access prevention
   <https://cloud.google.com/storage/docs/org-policy-constraints#public-access-prevention>`_
   organization policy.
@@ -101,7 +101,7 @@ class PapCommand(Command):
           'get': [CommandArgument.MakeNCloudURLsArgument(1),],
           'set': [
               CommandArgument('mode',
-                              choices=['enforced', 'unspecified', 'inherited']),
+                              choices=['enforced', 'inherited']),
               CommandArgument.MakeZeroOrMoreCloudBucketURLsArgument()
           ],
       })
@@ -132,12 +132,12 @@ class PapCommand(Command):
                                                 fields=['iamConfiguration'],
                                                 provider=bucket_url.scheme)
     iam_config = bucket_metadata.iamConfiguration
-    public_access_prevention = iam_config.publicAccessPrevention or 'unspecified'
+    public_access_prevention = iam_config.publicAccessPrevention or 'inherited'
     bucket = str(bucket_url).rstrip('/')
     print('%s: %s' % (bucket, public_access_prevention))
 
   def _SetPublicAccessPrevention(self, blr, setting_arg):
-    """Sets the Public Access Prevention setting for a bucket enforced or unspecified."""
+    """Sets the Public Access Prevention setting for a bucket enforced or inherited."""
     bucket_url = blr.storage_url
 
     iam_config = IamConfigurationValue()

--- a/gslib/tests/test_mb.py
+++ b/gslib/tests/test_mb.py
@@ -145,19 +145,15 @@ class TestMb(testcase.GsUtilIntegrationTestCase):
     self.VerifyPublicAccessPreventionValue(bucket_uri, 'enforced')
 
   @SkipForXML('Public access prevention only runs on GCS JSON API.')
-  def test_create_with_pap_unspecified(self):
+  def test_create_with_pap_inherited(self):
     bucket_name = self.MakeTempName('bucket')
     bucket_uri = boto.storage_uri('gs://%s' % (bucket_name.lower()),
                                   suppress_consec_slashes=False)
-    self.RunGsUtil(['mb', '--pap', 'unspecified', suri(bucket_uri)])
-    # TODO(b/201683262) Replace all calls to this method
-    # with self.VerifyPublicAccessPreventionValue(bucket_uri, 'inherited')
-    # once the backend rollout is completed.
+    self.RunGsUtil(['mb', '--pap', 'inherited', suri(bucket_uri)])
     stdout = self.RunGsUtil(['publicaccessprevention', 'get',
                              suri(bucket_uri)],
                             return_stdout=True)
-    self.assertRegex(stdout,
-                     r'%s:\s+(unspecified|inherited)' % suri(bucket_uri))
+    self.assertRegex(stdout, r'%s:\s+inherited' % suri(bucket_uri))
 
   @SkipForXML('Public access prevention only runs on GCS JSON API.')
   def test_create_with_pap_invalid_arg(self):

--- a/gslib/tests/test_pap.py
+++ b/gslib/tests/test_pap.py
@@ -30,20 +30,10 @@ class TestPublicAccessPrevention(testcase.GsUtilIntegrationTestCase):
   _set_pap_cmd = ['pap', 'set']
   _get_pap_cmd = ['pap', 'get']
 
-  def _verify_public_access_prevention_unspecified(self, bucket_uri):
-    # TODO(b/201683262) Replace all calls to this method
-    # with self.VerifyPublicAccessPreventionValue(bucket_uri, 'inherited')
-    # once the backend rollout is completed.
-    stdout = self.RunGsUtil(['publicaccessprevention', 'get',
-                             suri(bucket_uri)],
-                            return_stdout=True)
-    self.assertRegex(stdout,
-                     r'%s:\s+(unspecified|inherited)' % suri(bucket_uri))
-
   @SkipForXML('Public access prevention only runs on GCS JSON API')
   def test_off_on_default_buckets(self):
     bucket_uri = self.CreateBucket()
-    self._verify_public_access_prevention_unspecified(bucket_uri)
+    self.VerifyPublicAccessPreventionValue(bucket_uri, 'inherited')
 
   @SkipForXML('Public access prevention only runs on GCS JSON API')
   def test_turning_off_on_enabled_buckets(self):
@@ -51,14 +41,13 @@ class TestPublicAccessPrevention(testcase.GsUtilIntegrationTestCase):
                                    prefer_json_api=True)
     self.VerifyPublicAccessPreventionValue(bucket_uri, 'enforced')
 
-    self.RunGsUtil(self._set_pap_cmd + ['unspecified', suri(bucket_uri)])
-    self._verify_public_access_prevention_unspecified(bucket_uri)
+    self.RunGsUtil(self._set_pap_cmd + ['inherited', suri(bucket_uri)])
+    self.VerifyPublicAccessPreventionValue(bucket_uri, 'inherited')
 
   @SkipForXML('Public access prevention only runs on GCS JSON API')
   def test_turning_on(self):
     bucket_uri = self.CreateBucket()
     self.RunGsUtil(self._set_pap_cmd + ['enforced', suri(bucket_uri)])
-
     self.VerifyPublicAccessPreventionValue(bucket_uri, 'enforced')
 
   @SkipForXML('Public access prevention only runs on GCS JSON API')
@@ -68,8 +57,8 @@ class TestPublicAccessPrevention(testcase.GsUtilIntegrationTestCase):
     self.RunGsUtil(self._set_pap_cmd + ['enforced', suri(bucket_uri)])
     self.VerifyPublicAccessPreventionValue(bucket_uri, 'enforced')
 
-    self.RunGsUtil(self._set_pap_cmd + ['unspecified', suri(bucket_uri)])
-    self._verify_public_access_prevention_unspecified(bucket_uri)
+    self.RunGsUtil(self._set_pap_cmd + ['inherited', suri(bucket_uri)])
+    self.VerifyPublicAccessPreventionValue(bucket_uri, 'inherited')
 
   @SkipForXML('Public access prevention only runs on GCS JSON API')
   def test_multiple_buckets(self):
@@ -79,10 +68,8 @@ class TestPublicAccessPrevention(testcase.GsUtilIntegrationTestCase):
         self._get_pap_cmd +
         [suri(bucket_uri1), suri(bucket_uri2)],
         return_stdout=True)
-    self.assertRegex(stdout,
-                     r'%s:\s+(unspecified|inherited)' % suri(bucket_uri1))
-    self.assertRegex(stdout,
-                     r'%s:\s+(unspecified|inherited)' % suri(bucket_uri2))
+    self.assertRegex(stdout, r'%s:\s+inherited' % suri(bucket_uri1))
+    self.assertRegex(stdout, r'%s:\s+inherited' % suri(bucket_uri2))
 
   @SkipForJSON('Testing XML only behavior')
   def test_xml_fails(self):
@@ -99,7 +86,7 @@ class TestPublicAccessPrevention(testcase.GsUtilIntegrationTestCase):
     ]
     with SetBotoConfigForTest(boto_config_hmac_auth_only):
       bucket_uri = 'gs://any-bucket-name'
-      stderr = self.RunGsUtil(self._set_pap_cmd + ['unspecified', bucket_uri],
+      stderr = self.RunGsUtil(self._set_pap_cmd + ['inherited', bucket_uri],
                               return_stderr=True,
                               expected_status=1)
       self.assertIn('command can only be with the Cloud Storage JSON API',
@@ -115,7 +102,7 @@ class TestPublicAccessPrevention(testcase.GsUtilIntegrationTestCase):
   def test_s3_fails(self):
     bucket_uri = self.CreateBucket()
     stderr = self.RunGsUtil(self._set_pap_cmd +
-                            ['unspecified', suri(bucket_uri)],
+                            ['inherited', suri(bucket_uri)],
                             return_stderr=True,
                             expected_status=1)
     self.assertIn('command can only be used for GCS Buckets', stderr)


### PR DESCRIPTION
Now that inherited is supported and public, we can replace unspecified with inherited.