### PR TITLE
Fix shim tests for windows

### DIFF
--- a/gslib/tests/test_cp.py
+++ b/gslib/tests/test_cp.py
@@ -4686,6 +4686,7 @@ class TestCpUnitTests(testcase.GsUtilUnitTestCase):
             return_log_handler=True)
         info_lines = '\n'.join(mock_log_handler.messages['info'])
         self.assertIn(
-            'Gcloud Storage Command: fake_dir/bin/gcloud alpha storage cp'
-            ' -r -r --ignore-symlinks {} {}'.format(fpath, suri(bucket_uri)),
-            info_lines)
+            'Gcloud Storage Command: {} alpha storage cp'
+            ' -r -r --ignore-symlinks {} {}'.format(
+                os.path.join('fake_dir', 'bin', 'gcloud'), fpath,
+                suri(bucket_uri)), info_lines)

--- a/gslib/tests/test_ls.py
+++ b/gslib/tests/test_ls.py
@@ -199,8 +199,9 @@ class TestLsUnit(testcase.GsUtilUnitTestCase):
         mock_log_handler = self.RunCommand('ls', ['-rRlLbeah', '-p foo'],
                                            return_log_handler=True)
         self.assertIn(
-            'Gcloud Storage Command: fake_dir/bin/gcloud alpha storage ls'
-            ' -r -r -l -L -b -e -a --readable-sizes --project  foo',
+            'Gcloud Storage Command: {} alpha storage ls'
+            ' -r -r -l -L -b -e -a --readable-sizes --project  foo'.format(
+                os.path.join('fake_dir', 'bin', 'gcloud')),
             mock_log_handler.messages['info'])
 
 


### PR DESCRIPTION
A couple of tests introduced in https://github.com/GoogleCloudPlatform/gsutil/pull/1448 are breaking on windows. This PR fixes them.