### PR TITLE
Fixes an issue with setting user when preserve POSIX is enabled.

### DIFF
--- a/gslib/utils/posix_util.py
+++ b/gslib/utils/posix_util.py
@@ -451,7 +451,8 @@ def ParseAndSetPOSIXAttributes(path,
       # Windows doesn't use POSIX uid/gid/mode unlike other systems. So there's
       # no point continuing.
       return
-    if found_uid:
+    # Only root can change ownership.
+    if found_uid and os.geteuid() == 0:
       uid = int(uid)
     if found_gid:
       gid = int(gid)


### PR DESCRIPTION
Note that this does not have any tests associated with it given the fact this file is uncovered and currently lacks a mechanism for mocking user IDs.