### PR TITLE
Fix copying duplicate file name conflicts.

### DIFF
--- a/gslib/command.py
+++ b/gslib/command.py
@@ -737,7 +737,7 @@ class Command(HelpProvider, GcloudStorageCommandMixin):
       check_args: True to have CheckArguments() called after parsing.
       args: List of args. If None, self.args will be used.
       should_update_sub_opts_and_args: True if self.sub_opts and self.args
-        should be updated with the values returned after parsing. Else return a 
+        should be updated with the values returned after parsing. Else return a
         tuple of sub_opts, args returned by getopt.getopt. This is done
         to allow this method to be called from get_gcloud_storage_args in which
         case we do not want to update self.sub_opts and self.args.
@@ -896,7 +896,12 @@ class Command(HelpProvider, GcloudStorageCommandMixin):
           for blr in self.WildcardIterator(
               url.url_string).IterBuckets(bucket_fields=['id']):
             name_expansion_for_url = NameExpansionResult(
-                url, False, False, blr.storage_url, None)
+                source_storage_url=url,
+                is_multi_source_request=False,
+                is_multi_top_level_source_request=False,
+                names_container=False,
+                expanded_storage_url=blr.storage_url,
+                expanded_result=None)
             acl_func(self, name_expansion_for_url)
       else:
         multi_threaded_url_args.append(url_str)

--- a/gslib/commands/rsync.py
+++ b/gslib/commands/rsync.py
@@ -1220,8 +1220,14 @@ class _DiffIterator(object):
           src_url_str_to_check = _EncodeUrl(
               src_url_str[base_src_url_len:].replace('\\', '/'))
           dst_url_str_would_copy_to = copy_helper.ConstructDstUrl(
-              self.base_src_url, StorageUrlFromString(src_url_str), True, True,
-              self.base_dst_url, False, self.recursion_requested).url_string
+              src_url=self.base_src_url,
+              exp_src_url=StorageUrlFromString(src_url_str),
+              src_url_names_container=True,
+              have_multiple_srcs=True,
+              has_multiple_top_level_srcs=False,
+              exp_dst_url=self.base_dst_url,
+              have_existing_dest_subdir=False,
+              recursion_requested=self.recursion_requested).url_string
       if dst_url_str is None:
         if not self.sorted_dst_urls_it.IsEmpty():
           # We don't need time created at the destination.

--- a/gslib/storage_url.py
+++ b/gslib/storage_url.py
@@ -44,6 +44,8 @@ FILE_OBJECT_REGEX = re.compile(r'([^:]*://)(?P<filepath>.*)')
 # Regex to determine if a string contains any wildcards.
 WILDCARD_REGEX = re.compile(r'[*?\[\]]')
 
+RELATIVE_PATH_SYMBOLS = frozenset(['.', '..'])
+
 
 class StorageUrl(object):
   """Abstract base class for file and Cloud Storage URLs."""

--- a/gslib/tests/test_copy_objects_iterator.py
+++ b/gslib/tests/test_copy_objects_iterator.py
@@ -30,12 +30,12 @@ import gslib.tests.testcase as testcase
 def _ConstructNameExpansionIterator(src_url_strs):
   for src_url_str in src_url_strs:
     storage_url = StorageUrlFromString(src_url_str)
-    yield NameExpansionResult(
-        storage_url,
-        False,  # is_multi_source_request
-        False,  # names_container
-        storage_url,  # expanded_storage_url
-        None)  # expanded_result
+    yield NameExpansionResult(source_storage_url=storage_url,
+                              is_multi_source_request=False,
+                              is_multi_top_level_source_request=False,
+                              names_container=False,
+                              expanded_storage_url=storage_url,
+                              expanded_result=None)
 
 
 def _ConstrcutNameExpansionIteratorDestinationTupleIterator(

--- a/gslib/tests/test_mv.py
+++ b/gslib/tests/test_mv.py
@@ -21,7 +21,6 @@ from __future__ import unicode_literals
 
 import os
 
-import crcmod
 from gslib.cs_api_map import ApiSelector
 from gslib.tests.test_cp import TestCpMvPOSIXBucketToLocalErrors
 from gslib.tests.test_cp import TestCpMvPOSIXBucketToLocalNoErrors
@@ -36,7 +35,77 @@ from gslib.utils.retry_util import Retry
 from gslib.utils.system_util import IS_WINDOWS
 
 
-class TestMv(testcase.GsUtilIntegrationTestCase):
+class TestMvUnitTests(testcase.GsUtilUnitTestCase):
+  """Unit tests for mv command."""
+
+  def test_move_bucket_objects_with_duplicate_names_inter_bucket(self):
+    """Tests moving multiple top-level items between buckets."""
+    bucket1_uri = self.CreateBucket()
+    self.CreateObject(bucket_uri=bucket1_uri,
+                      object_name='dir1/file.txt',
+                      contents=b'data')
+    self.CreateObject(bucket_uri=bucket1_uri,
+                      object_name='dir2/file.txt',
+                      contents=b'data')
+    bucket2_uri = self.CreateBucket()
+
+    self.RunCommand('mv', [suri(bucket1_uri, '*'), suri(bucket2_uri)])
+
+    actual = set(
+        str(u)
+        for u in self._test_wildcard_iterator(suri(bucket2_uri, '**')).IterAll(
+            expand_top_level_buckets=True))
+    expected = set([
+        suri(bucket2_uri, 'dir1', 'file.txt'),
+        suri(bucket2_uri, 'dir2', 'file.txt'),
+    ])
+    self.assertEqual(actual, expected)
+
+  def test_move_bucket_objects_with_duplicate_names_to_bucket_subdir(self):
+    """Tests moving multiple top-level items between buckets."""
+    bucket1_uri = self.CreateBucket()
+    self.CreateObject(bucket_uri=bucket1_uri,
+                      object_name='dir1/file.txt',
+                      contents=b'data')
+    self.CreateObject(bucket_uri=bucket1_uri,
+                      object_name='dir2/file.txt',
+                      contents=b'data')
+    bucket2_uri = self.CreateBucket()
+
+    self.RunCommand('mv', [suri(bucket1_uri, '*'), suri(bucket2_uri, 'dir')])
+
+    actual = set(
+        str(u)
+        for u in self._test_wildcard_iterator(suri(bucket2_uri, '**')).IterAll(
+            expand_top_level_buckets=True))
+    expected = set([
+        suri(bucket2_uri, 'dir', 'dir1', 'file.txt'),
+        suri(bucket2_uri, 'dir', 'dir2', 'file.txt'),
+    ])
+    self.assertEqual(actual, expected)
+
+  def test_move_dirs_with_duplicate_file_names_to_bucket(self):
+    """Tests moving multiple top-level items to a bucket."""
+    bucket_uri = self.CreateBucket()
+    dir_path = self.CreateTempDir(test_files=[
+        ('dir1', 'file.txt'),
+        ('dir2', 'file.txt'),
+    ])
+
+    self.RunCommand('mv', [dir_path + '/*', suri(bucket_uri)])
+
+    actual = set(
+        str(u)
+        for u in self._test_wildcard_iterator(suri(bucket_uri, '**')).IterAll(
+            expand_top_level_buckets=True))
+    expected = set([
+        suri(bucket_uri, 'dir1', 'file.txt'),
+        suri(bucket_uri, 'dir2', 'file.txt'),
+    ])
+    self.assertEqual(actual, expected)
+
+
+class TestMvE2ETests(testcase.GsUtilIntegrationTestCase):
   """Integration tests for mv command."""
 
   def test_moving(self):
@@ -201,3 +270,28 @@ class TestMv(testcase.GsUtilIntegrationTestCase):
         'Warning: moving nearline object %s may incur an early deletion '
         'charge, because the original object is less than 30 days old '
         'according to the local system time.' % suri(object_uri), stderr)
+
+  def test_move_bucket_objects_with_duplicate_names_to_dir(self):
+    """Tests moving multiple top-level items to a bucket."""
+    bucket_uri = self.CreateBucket()
+    self.CreateObject(bucket_uri=bucket_uri,
+                      object_name='dir1/file.txt',
+                      contents=b'data')
+    self.CreateObject(bucket_uri=bucket_uri,
+                      object_name='dir2/file.txt',
+                      contents=b'data')
+    self.AssertNObjectsInBucket(bucket_uri, 2)
+
+    tmpdir = self.CreateTempDir()
+    self.RunGsUtil(['mv', suri(bucket_uri, '*'), tmpdir])
+
+    file_list = []
+    for dirname, _, filenames in os.walk(tmpdir):
+      for filename in filenames:
+        file_list.append(os.path.join(dirname, filename))
+    self.assertEqual(len(file_list), 2)
+    self.assertIn('{}{}dir1{}file.txt'.format(tmpdir, os.sep, os.sep),
+                  file_list)
+    self.assertIn('{}{}dir2{}file.txt'.format(tmpdir, os.sep, os.sep),
+                  file_list)
+    self.AssertNObjectsInBucket(bucket_uri, 0)

--- a/gslib/tests/test_naming.py
+++ b/gslib/tests/test_naming.py
@@ -975,15 +975,75 @@ class GsutilNamingTests(testcase.GsUtilUnitTestCase):
       ])
       self.assertEqual(expected, actual)
 
-  # @SequentialAndParallelTransfer
+  def testRecursiveCopyFileToExistingBucketSubDirInvalidSourceParent(self):
+    """Tests recursive copy of invalid path file to existing bucket subdir."""
+    src_dir = self.CreateTempDir(test_files=[('nested', 'f0')])
+    dst_bucket_uri = self.CreateBucket(test_objects=['dst_subdir/existing_obj'])
+
+    for relative_path_string in ['.', '.' + os.sep]:
+      self.RunCommand('cp', [
+          '-R',
+          src_dir + os.sep + relative_path_string,
+          suri(dst_bucket_uri, 'dst_subdir'),
+      ])
+      actual = set(
+          str(u) for u in self._test_wildcard_iterator(
+              suri(dst_bucket_uri, 'dst_subdir', '**')).IterAll(
+                  expand_top_level_buckets=True))
+      expected = set([
+          suri(dst_bucket_uri, 'dst_subdir', 'nested', 'f0'),
+          suri(dst_bucket_uri, 'dst_subdir', 'existing_obj'),
+      ])
+      self.assertEqual(expected, actual)
+
+  def testRecursiveCopyFilesToExistingBucketSubDirInvalidSourceParent(self):
+    """Tests recursive copy of invalid paths files to existing bucket subdir."""
+    src_dir = self.CreateTempDir(test_files=['f0'])
+    dst_bucket_uri = self.CreateBucket(test_objects=['dst_subdir/existing_obj'])
+
+    for relative_path_string in ['.', '.' + os.sep, '..', '..' + os.sep]:
+      with self.assertRaises(InvalidUrlError):
+        self.RunCommand('cp', [
+            '-R',
+            src_dir,
+            relative_path_string,
+            suri(dst_bucket_uri, 'dst_subdir'),
+        ])
+
   def testRecursiveCopyObjsAndFilesToNonExistentBucketSubDir(self):
     """Tests recursive copy of objs + files to non-existent bucket subdir."""
     src_bucket_uri = self.CreateBucket(test_objects=['f0', 'nested/f1'])
-    src_dir = self.CreateTempDir(test_files=['f2', ('nested', 'f3')])
+    src_dir = self.CreateTempDir(test_files=[
+        ('parent', 'f2'),
+        ('parent', 'nested', 'f3'),
+    ])
     dst_bucket_uri = self.CreateBucket()
     self.RunCommand('cp', [
-        '-R', src_dir,
+        '-R',
+        os.path.join(src_dir, 'parent'),
         suri(src_bucket_uri),
+        suri(dst_bucket_uri, 'dst_subdir')
+    ])
+    actual = set(
+        str(u) for u in self._test_wildcard_iterator(suri(
+            dst_bucket_uri, '**')).IterAll(expand_top_level_buckets=True))
+    expected = set([
+        suri(dst_bucket_uri, 'dst_subdir', src_bucket_uri.bucket_name, 'f0'),
+        suri(dst_bucket_uri, 'dst_subdir', src_bucket_uri.bucket_name, 'nested',
+             'f1'),
+        suri(dst_bucket_uri, 'dst_subdir', 'parent', 'f2'),
+        suri(dst_bucket_uri, 'dst_subdir', 'parent', 'nested', 'f3')
+    ])
+    self.assertEqual(expected, actual)
+
+  def testRecursiveCopyNestedObjsToNonExistentBucketSubDir(self):
+    """Tests recursive copy of objs + files to non-existent bucket subdir."""
+    src_bucket_uri = self.CreateBucket(
+        test_objects=['parent/f0', 'parent/nested/f1'])
+    dst_bucket_uri = self.CreateBucket()
+    self.RunCommand('cp', [
+        '-R',
+        suri(src_bucket_uri, 'parent'),
         suri(dst_bucket_uri, 'dst_subdir')
     ])
     actual = set(
@@ -992,6 +1052,18 @@ class GsutilNamingTests(testcase.GsUtilUnitTestCase):
     expected = set([
         suri(dst_bucket_uri, 'dst_subdir', 'f0'),
         suri(dst_bucket_uri, 'dst_subdir', 'nested', 'f1'),
+    ])
+    self.assertEqual(expected, actual)
+
+  def testRecursiveCopyFilesToNonExistentBucketSubDir(self):
+    """Tests recursive copy of objs + files to non-existent bucket subdir."""
+    src_dir = self.CreateTempDir(test_files=['f2', ('nested', 'f3')])
+    dst_bucket_uri = self.CreateBucket()
+    self.RunCommand('cp', ['-R', src_dir, suri(dst_bucket_uri, 'dst_subdir')])
+    actual = set(
+        str(u) for u in self._test_wildcard_iterator(suri(
+            dst_bucket_uri, '**')).IterAll(expand_top_level_buckets=True))
+    expected = set([
         suri(dst_bucket_uri, 'dst_subdir', 'f2'),
         suri(dst_bucket_uri, 'dst_subdir', 'nested', 'f3')
     ])
@@ -1270,18 +1342,6 @@ class GsutilNamingTests(testcase.GsUtilUnitTestCase):
         str(u) for u in self._test_wildcard_iterator(suri(
             src_bucket_uri, '**')).IterAll(expand_top_level_buckets=True))
     self.assertEqual(actual, set())
-
-  def testWildcardSrcSubDirMoveDisallowed(self):
-    """Tests moving a bucket subdir specified by wildcard is disallowed."""
-    src_bucket_uri = self.CreateBucket(test_objects=['dir/foo1'])
-    dst_bucket_uri = self.CreateBucket(test_objects=['dir/foo2'])
-    try:
-      self.RunCommand(
-          'mv', [suri(src_bucket_uri, 'dir*'),
-                 suri(dst_bucket_uri, 'dir')])
-      self.fail('Did not get expected CommandException')
-    except CommandException as e:
-      self.assertIn('mv command disallows naming', e.reason)
 
   def testMovingBucketSubDirToNonExistentBucketSubDir(self):
     """Tests moving a bucket subdir to a non-existent bucket subdir."""


### PR DESCRIPTION
Applies to mv logic as well. Basically treats destination as an existing
directory if multiple top-level sources are detected.