### PR TITLE
Shim: Make use_gcloud_storage accept boolean values instead of strings

### DIFF
--- a/gslib/tests/test_cp.py
+++ b/gslib/tests/test_cp.py
@@ -4678,7 +4678,8 @@ class TestCpUnitTests(testcase.GsUtilUnitTestCase):
   def test_shim_translates_flags(self):
     bucket_uri = self.CreateBucket()
     fpath = self.CreateTempFile(contents=b'abcd')
-    with SetBotoConfigForTest([('GSUtil', 'use_gcloud_storage', 'dry_run')]):
+    with SetBotoConfigForTest([('GSUtil', 'use_gcloud_storage', 'True'),
+                               ('GSUtil', 'hidden_shim_mode', 'dry_run')]):
       with SetEnvironmentForTest({
           'CLOUDSDK_CORE_PASS_CREDENTIALS_TO_GSUTIL': 'True',
           'CLOUDSDK_ROOT_DIR': 'fake_dir',

--- a/gslib/tests/test_ls.py
+++ b/gslib/tests/test_ls.py
@@ -191,7 +191,8 @@ class TestLsUnit(testcase.GsUtilUnitTestCase):
     self.assertNotRegex(stdout, 'Placement locations:')
 
   def test_shim_translates_flags(self):
-    with SetBotoConfigForTest([('GSUtil', 'use_gcloud_storage', 'dry_run')]):
+    with SetBotoConfigForTest([('GSUtil', 'use_gcloud_storage', 'True'),
+                               ('GSUtil', 'hidden_shim_mode', 'dry_run')]):
       with SetEnvironmentForTest({
           'CLOUDSDK_CORE_PASS_CREDENTIALS_TO_GSUTIL': 'True',
           'CLOUDSDK_ROOT_DIR': 'fake_dir',

--- a/gslib/tests/test_rm.py
+++ b/gslib/tests/test_rm.py
@@ -749,7 +749,8 @@ class TestRmUnitTests(testcase.GsUtilUnitTestCase):
 
   def test_shim_translates_flags(self):
     bucket_uri = self.CreateBucket()
-    with SetBotoConfigForTest([('GSUtil', 'use_gcloud_storage', 'dry_run')]):
+    with SetBotoConfigForTest([('GSUtil', 'use_gcloud_storage', 'True'),
+                               ('GSUtil', 'hidden_shim_mode', 'dry_run')]):
       with SetEnvironmentForTest({
           'CLOUDSDK_CORE_PASS_CREDENTIALS_TO_GSUTIL': 'True',
           'CLOUDSDK_ROOT_DIR': 'fake_dir',
@@ -770,7 +771,8 @@ class TestRmUnitTests(testcase.GsUtilUnitTestCase):
     bucket_uri = self.CreateBucket()
     object_uri = self.CreateObject(bucket_uri, 'foo', 'abcd')
     mock_stdin.__iter__.return_value = [suri(object_uri)]
-    with SetBotoConfigForTest([('GSUtil', 'use_gcloud_storage', 'dry_run')]):
+    with SetBotoConfigForTest([('GSUtil', 'use_gcloud_storage', 'True'),
+                               ('GSUtil', 'hidden_shim_mode', 'dry_run')]):
       with SetEnvironmentForTest({
           'CLOUDSDK_CORE_PASS_CREDENTIALS_TO_GSUTIL': 'True',
           'CLOUDSDK_ROOT_DIR': 'fake_dir',

--- a/gslib/tests/test_shim_util.py
+++ b/gslib/tests/test_shim_util.py
@@ -55,12 +55,10 @@ def _mock_boto_config(boto_config_dict):
     return boto_config_dict.get(section, {}).get(key, default_value)
 
   with mock.patch.object(config, 'get', autospec=True) as mock_get:
-    with mock.patch.object(config, 'getbool', autospec=True) as mock_getbool:
-      with mock.patch.object(config, 'items', autospec=True) as mock_items:
-        mock_get.side_effect = _config_get_side_effect
-        mock_getbool.side_effect = _config_get_side_effect
-        mock_items.return_value = boto_config_dict.items()
-        yield
+    with mock.patch.object(config, 'items', autospec=True) as mock_items:
+      mock_get.side_effect = _config_get_side_effect
+      mock_items.return_value = boto_config_dict.items()
+      yield
 
 
 class FakeCommandWithGcloudStorageMap(command.Command):
@@ -289,15 +287,19 @@ class TestTranslateToGcloudStorageIfRequested(testcase.GsUtilUnitTestCase):
                              '-x', 'arg1', 'arg2'
                          ])
 
-  def test_returns_false_if_invalid_use_gcloud_storage_value(self):
+  def test_raises_error_if_invalid_use_gcloud_storage_value(self):
     with util.SetBotoConfigForTest([('GSUtil', 'use_gcloud_storage', 'invalid')
                                    ]):
-      self.assertFalse(
-          self._fake_command.translate_to_gcloud_storage_if_requested())
+      with self.assertRaisesRegex(
+          exception.CommandException,
+          'CommandException: Invalid option specified for'
+          ' GSUtil:use_gcloud_storage config setting. Should be one of:'
+          ' never | if_available_else_skip | always | dry_run'):
+        self._fake_command.translate_to_gcloud_storage_if_requested()
 
   def test_raises_error_if_cloudsdk_root_dir_is_none(self):
-    with util.SetBotoConfigForTest([('GSUtil', 'use_gcloud_storage', 'True'),
-                                    ('GSUtil', 'shim_no_fallback', 'True')]):
+    with util.SetBotoConfigForTest([('GSUtil', 'use_gcloud_storage', 'always')
+                                   ]):
       with util.SetEnvironmentForTest({
           'CLOUDSDK_ROOT_DIR': None,
       }):
@@ -309,13 +311,13 @@ class TestTranslateToGcloudStorageIfRequested(testcase.GsUtilUnitTestCase):
             ' You can manually set the `CLOUDSDK_ROOT_DIR` environment variable'
             ' to point to the google-cloud-sdk installation directory to'
             ' resolve the issue. Alternatively, you can set'
-            ' `use_gcloud_storage=False` to disable running the command'
+            ' `use_gcloud_storage=never` to disable running the command'
             ' using gcloud storage.'):
           self._fake_command.translate_to_gcloud_storage_if_requested()
 
   def test_raises_error_if_pass_credentials_to_gsutil_is_missing(self):
-    with util.SetBotoConfigForTest([('GSUtil', 'use_gcloud_storage', 'True'),
-                                    ('GSUtil', 'shim_no_fallback', 'True')]):
+    with util.SetBotoConfigForTest([('GSUtil', 'use_gcloud_storage', 'always')
+                                   ]):
       with util.SetEnvironmentForTest({
           'CLOUDSDK_ROOT_DIR': 'fake_dir',
           'CLOUDSDK_CORE_PASS_CREDENTIALS_TO_GSUTIL': None
@@ -331,8 +333,8 @@ class TestTranslateToGcloudStorageIfRequested(testcase.GsUtilUnitTestCase):
 
   def test_raises_error_if_gcloud_storage_map_missing(self):
     self._fake_command.gcloud_storage_map = None
-    with util.SetBotoConfigForTest([('GSUtil', 'use_gcloud_storage', 'True'),
-                                    ('GSUtil', 'shim_no_fallback', 'True')]):
+    with util.SetBotoConfigForTest([('GSUtil', 'use_gcloud_storage', 'always')
+                                   ]):
       with util.SetEnvironmentForTest({
           'CLOUDSDK_CORE_PASS_CREDENTIALS_TO_GSUTIL': 'True',
           'CLOUDSDK_ROOT_DIR': 'fake_dir',
@@ -343,9 +345,10 @@ class TestTranslateToGcloudStorageIfRequested(testcase.GsUtilUnitTestCase):
             ' gcloud storage because the translation mapping is missing.'):
           self._fake_command.translate_to_gcloud_storage_if_requested()
 
-  def test_use_gcloud_storage_without_use_no_fallback(self):
+  def test_use_gcloud_storage_set_to_if_available_else_skip(self):
     """Should not raise error."""
-    with util.SetBotoConfigForTest([('GSUtil', 'use_gcloud_storage', 'True')]):
+    with util.SetBotoConfigForTest([('GSUtil', 'use_gcloud_storage',
+                                     'if_available_else_skip')]):
       with util.SetEnvironmentForTest({
           'CLOUDSDK_CORE_PASS_CREDENTIALS_TO_GSUTIL': 'True',
           'CLOUDSDK_ROOT_DIR': 'fake_dir',
@@ -363,12 +366,24 @@ class TestTranslateToGcloudStorageIfRequested(testcase.GsUtilUnitTestCase):
             mock_log_handler.messages['error'])
         self.assertIn('FakeCommandWithGcloudStorageMap called', stdout)
 
-  def test_translated_command_gets_logged_to_debug_logs(self):
-    with _mock_boto_config(
-        {'GSUtil': {
-            'use_gcloud_storage': 'True',
-            'shim_no_fallback': 'True'
-        }}):
+  def test_dry_run_mode_prints_translated_command(self):
+    """Should print the gcloud command and run gsutil."""
+    with _mock_boto_config({'GSUtil': {'use_gcloud_storage': 'dry_run'}}):
+      with util.SetEnvironmentForTest({'CLOUDSDK_ROOT_DIR': 'fake_dir'}):
+        stdout, mock_log_handler = self.RunCommand('fake_shim',
+                                                   args=['arg1'],
+                                                   return_stdout=True,
+                                                   return_log_handler=True)
+        self.assertIn(
+            'Gcloud Storage Command: {} objects fake arg1'.format(
+                os.path.join('fake_dir', 'bin', 'gcloud')),
+            mock_log_handler.messages['info'])
+        self.assertIn(
+            'FakeCommandWithGcloudStorageMap called'.format(
+                os.path.join('fake_dir', 'bin', 'gcloud')), stdout)
+
+  def test_non_dry_mode_logs_translated_command_to_debug_logs(self):
+    with _mock_boto_config({'GSUtil': {'use_gcloud_storage': 'always'}}):
       with util.SetEnvironmentForTest({
           'CLOUDSDK_CORE_PASS_CREDENTIALS_TO_GSUTIL': 'True',
           'CLOUDSDK_ROOT_DIR': 'fake_dir',
@@ -381,6 +396,19 @@ class TestTranslateToGcloudStorageIfRequested(testcase.GsUtilUnitTestCase):
               'Gcloud Storage Command: {} objects'
               ' fake --zip opt1 -x arg1 arg2'.format(
                   os.path.join('fake_dir', 'bin', 'gcloud')))
+
+  def test_print_gcloud_storage_env_vars_in_dry_run_mode(self):
+    """Should log the command and env vars to logger.info"""
+    with mock.patch.object(self._fake_command, 'logger',
+                           autospec=True) as mock_logger:
+      self._fake_command._print_gcloud_storage_command_info(
+          ['fake', 'gcloud', 'command'], {'fake_env_var': 'val'}, dry_run=True)
+      expected_calls = [
+          mock.call('Gcloud Storage Command: fake gcloud command'),
+          mock.call('Environment variables for Gcloud Storage:'),
+          mock.call('%s=%s', 'fake_env_var', 'val'),
+      ]
+      self.assertEqual(mock_logger.info.mock_calls, expected_calls)
 
   def test_top_level_flags_get_translated(self):
     """Should return True and perform the translation."""
@@ -416,10 +444,8 @@ class TestTranslateToGcloudStorageIfRequested(testcase.GsUtilUnitTestCase):
             })
 
   def test_parallel_operations_true_does_not_add_process_count_env_vars(self):
-    with util.SetBotoConfigForTest([
-        ('GSUtil', 'use_gcloud_storage', 'True'),
-        ('GSUtil', 'shim_no_fallback', 'True'),
-    ]):
+    with util.SetBotoConfigForTest([('GSUtil', 'use_gcloud_storage', 'always')
+                                   ]):
       with util.SetEnvironmentForTest({
           'CLOUDSDK_CORE_PASS_CREDENTIALS_TO_GSUTIL': 'True',
           'CLOUDSDK_ROOT_DIR': 'fake_dir',
@@ -433,11 +459,7 @@ class TestTranslateToGcloudStorageIfRequested(testcase.GsUtilUnitTestCase):
 
   def test_debug_value_4_adds_log_http_flag(self):
     # Debug level 4 represents the -DD option.
-    with _mock_boto_config(
-        {'GSUtil': {
-            'use_gcloud_storage': 'True',
-            'shim_no_fallback': 'True'
-        }}):
+    with _mock_boto_config({'GSUtil': {'use_gcloud_storage': 'always'}}):
       with util.SetEnvironmentForTest({
           'CLOUDSDK_CORE_PASS_CREDENTIALS_TO_GSUTIL': 'True',
           'CLOUDSDK_ROOT_DIR': 'fake_dir',
@@ -456,11 +478,7 @@ class TestTranslateToGcloudStorageIfRequested(testcase.GsUtilUnitTestCase):
                      new='fake_service_account')
   def test_impersonate_service_account_translation(self):
     """Should add the --impersonate-service-account flag."""
-    with _mock_boto_config(
-        {'GSUtil': {
-            'use_gcloud_storage': 'True',
-            'shim_no_fallback': 'True'
-        }}):
+    with _mock_boto_config({'GSUtil': {'use_gcloud_storage': 'always'}}):
       with util.SetEnvironmentForTest({
           'CLOUDSDK_CORE_PASS_CREDENTIALS_TO_GSUTIL': 'True',
           'CLOUDSDK_ROOT_DIR': 'fake_dir',
@@ -474,11 +492,7 @@ class TestTranslateToGcloudStorageIfRequested(testcase.GsUtilUnitTestCase):
             ])
 
   def test_quiet_mode_translation_adds_no_user_output_enabled_flag(self):
-    with _mock_boto_config(
-        {'GSUtil': {
-            'use_gcloud_storage': 'True',
-            'shim_no_fallback': 'True'
-        }}):
+    with _mock_boto_config({'GSUtil': {'use_gcloud_storage': 'always'}}):
       with util.SetEnvironmentForTest({
           'CLOUDSDK_CORE_PASS_CREDENTIALS_TO_GSUTIL': 'True',
           'CLOUDSDK_ROOT_DIR': 'fake_dir',
@@ -543,11 +557,7 @@ class TestHeaderTranslation(testcase.GsUtilUnitTestCase):
 
   @mock.patch.object(shim_util, 'DATA_TRANSFER_COMMANDS', new={'fake_shim'})
   def test_translated_headers_get_added_to_final_command(self):
-    with _mock_boto_config(
-        {'GSUtil': {
-            'use_gcloud_storage': 'True',
-            'shim_no_fallback': 'True'
-        }}):
+    with _mock_boto_config({'GSUtil': {'use_gcloud_storage': 'always'}}):
       with util.SetEnvironmentForTest({
           'CLOUDSDK_CORE_PASS_CREDENTIALS_TO_GSUTIL': 'True',
           'CLOUDSDK_ROOT_DIR': 'fake_dir',
@@ -748,8 +758,7 @@ class TestBotoTranslation(testcase.GsUtilUnitTestCase):
     """Should add translated env vars as well flags."""
     with _mock_boto_config({
         'GSUtil': {
-            'use_gcloud_storage': 'True',
-            'shim_no_fallback': 'True',
+            'use_gcloud_storage': 'always',
             'content_language': 'foo',
             'default_project_id': 'fake_project',
         }
@@ -993,8 +1002,8 @@ class TestRunGcloudStorage(testcase.GsUtilUnitTestCase):
 class TestShimE2E(testcase.GsUtilIntegrationTestCase):
 
   def test_runs_gcloud_storage_if_use_gcloud_storage_true(self):
-    with util.SetBotoConfigForTest([('GSUtil', 'use_gcloud_storage', 'True'),
-                                    ('GSUtil', 'shim_no_fallback', 'True')]):
+    with util.SetBotoConfigForTest([('GSUtil', 'use_gcloud_storage', 'always')
+                                   ]):
       with util.SetEnvironmentForTest({
           'CLOUDSDK_CORE_PASS_CREDENTIALS_TO_GSUTIL': 'True',
           'CLOUDSDK_ROOT_DIR': None,

--- a/gslib/tests/testcase/integration_testcase.py
+++ b/gslib/tests/testcase/integration_testcase.py
@@ -144,9 +144,7 @@ class GsUtilIntegrationTestCase(base.GsUtilTestCase):
 
     self.multiregional_buckets = util.USE_MULTIREGIONAL_BUCKETS
 
-    use_gcloud_storage = config.get('GSUtil', 'use_gcloud_storage', 'never')
-    self._use_gcloud_storage = use_gcloud_storage in ('always',
-                                                      'if_available_else_skip')
+    self._use_gcloud_storage = config.get('GSUtil', 'use_gcloud_storage', False)
 
     if util.RUN_S3_TESTS:
       self.nonexistent_bucket_name = (
@@ -1005,11 +1003,14 @@ class GsUtilIntegrationTestCase(base.GsUtilTestCase):
     # TODO(b/203250512) Remove this once all the commands are supported
     # via gcloud storage.
     if force_gsutil:
-      use_gcloud_storage = 'never'
+      use_gcloud_storage = False
     else:
-      use_gcloud_storage = config.get('GSUtil', 'use_gcloud_storage', 'never')
+      use_gcloud_storage = config.getbool('GSUtil', 'use_gcloud_storage', False)
     gcloud_storage_setting = [
-        '-o', 'GSUtil:use_gcloud_storage={}'.format(use_gcloud_storage)
+        '-o',
+        'GSUtil:use_gcloud_storage={}'.format(use_gcloud_storage),
+        '-o',
+        'GSUtil:hidden_shim_mode=no_fallback',
     ]
     cmd = [
         gslib.GSUTIL_PATH, '--testexceptiontraces', '-o',

--- a/gslib/utils/shim_util.py
+++ b/gslib/utils/shim_util.py
@@ -28,6 +28,14 @@ from boto import config
 from gslib import exception
 from gslib.utils import constants
 
+
+class USE_GCLOUD_STORAGE_VALUE(enum.Enum):
+  NEVER = 'never'
+  IF_AVAILABLE_ELSE_SKIP = 'if_available_else_skip'
+  ALWAYS = 'always'
+  DRY_RUN = 'dry_run'
+
+
 DECRYPTION_KEY_REGEX = re.compile(r'^decryption_key([1-9]$|[1-9][0-9]$|100$)')
 
 # Required for headers translation and boto config translation.
@@ -212,7 +220,7 @@ def _get_gcloud_binary_path():
         ' not installed via Cloud SDK. You can manually set the'
         ' `CLOUDSDK_ROOT_DIR` environment variable to point to the'
         ' google-cloud-sdk installation directory to resolve the issue.'
-        ' Alternatively, you can set `use_gcloud_storage=False` to disable'
+        ' Alternatively, you can set `use_gcloud_storage=never` to disable'
         ' running the command using gcloud storage.')
   return os.path.join(cloudsdk_root, 'bin', 'gcloud')
 
@@ -409,13 +417,16 @@ class GcloudStorageCommandMixin(object):
     return self._get_gcloud_storage_args(self.sub_opts, self.args,
                                          self.gcloud_storage_map)
 
-  def _print_gcloud_storage_command_info(self, gcloud_command, env_variables):
-    self.logger.debug('Gcloud Storage Command: {}'.format(
-        ' '.join(gcloud_command)))
+  def _print_gcloud_storage_command_info(self,
+                                         gcloud_command,
+                                         env_variables,
+                                         dry_run=False):
+    logger_func = self.logger.info if dry_run else self.logger.debug
+    logger_func('Gcloud Storage Command: {}'.format(' '.join(gcloud_command)))
     if env_variables:
-      self.logger.debug('Environment variables for Gcloud Storage:')
+      logger_func('Environment variables for Gcloud Storage:')
       for k, v in env_variables.items():
-        self.logger.debug('%s=%s', k, v)
+        logger_func('%s=%s', k, v)
 
   def translate_to_gcloud_storage_if_requested(self):
     """Translates the gsutil command to gcloud storage equivalent.
@@ -435,9 +446,15 @@ class GcloudStorageCommandMixin(object):
 
       # We don't want to run any translation for the "test" command.
       return False
-    use_gcloud_storage = config.getbool('GSUtil', 'use_gcloud_storage', False)
-
-    if use_gcloud_storage:
+    try:
+      use_gcloud_storage = USE_GCLOUD_STORAGE_VALUE(
+          config.get('GSUtil', 'use_gcloud_storage', 'never'))
+    except ValueError:
+      raise exception.CommandException(
+          'Invalid option specified for'
+          ' GSUtil:use_gcloud_storage config setting. Should be one of: {}'.
+          format(' | '.join([x.value for x in USE_GCLOUD_STORAGE_VALUE])))
+    if use_gcloud_storage != USE_GCLOUD_STORAGE_VALUE.NEVER:
       try:
         top_level_flags, env_variables = self._translate_top_level_flags()
         header_flags = self._translate_headers()
@@ -450,7 +467,11 @@ class GcloudStorageCommandMixin(object):
                                   self.get_gcloud_storage_args() +
                                   top_level_flags + header_flags +
                                   flags_from_boto)
-        if not os.environ.get('CLOUDSDK_CORE_PASS_CREDENTIALS_TO_GSUTIL'):
+        if use_gcloud_storage == USE_GCLOUD_STORAGE_VALUE.DRY_RUN:
+          self._print_gcloud_storage_command_info(gcloud_storage_command,
+                                                  env_variables,
+                                                  dry_run=True)
+        elif not os.environ.get('CLOUDSDK_CORE_PASS_CREDENTIALS_TO_GSUTIL'):
           raise exception.GcloudStorageTranslationError(
               'Requested to use "gcloud storage" but gsutil is not using the'
               ' same credentials as gcloud.'
@@ -464,13 +485,7 @@ class GcloudStorageCommandMixin(object):
           self._translated_env_variables = env_variables
           return True
       except exception.GcloudStorageTranslationError as e:
-        # shim_no_fallback is a hidden config option that can be used
-        # for test parity or debugging purposes.
-        # Setting shim_no_fallback=True along with use_gcloud_storage=True
-        # will ensure that an error is raised if a command/flag is not
-        # yet supported via the shim.
-        shim_no_fallback = config.getbool('GSUtil', 'shim_no_fallback', False)
-        if shim_no_fallback:
+        if use_gcloud_storage == USE_GCLOUD_STORAGE_VALUE.ALWAYS:
           raise exception.CommandException(e)
         # For all other cases, we want to run gsutil.
         self.logger.error(


### PR DESCRIPTION
Updating the `use_gcloud_storage` boto config option to just accept either `True` or `False` values.

Before:
```
use_gcloud_storage = if_available_else_skip/never/always/dry_run
```

After:
```
use_gcloud_storage=True/False
```

If you set `use_gcloud_storage=True`, it will try to run `gcloud storage` and will fallback to running gsutil if a command/flag is not yet supported via the shim or gcloud storage. This is equivalent to setting `if_available_else_skip` before.

Introduced a hidden config option `hidden_shim_mode` that should be used only for debugging and testing purposes.

For `always` equivalent, `hidden_shim_mode=no_fallback` can be used, which will raise an error if the requested command/flag is not supported via the shim.

Similarly, to run the command in dry_run mode, `hidden_shim_mode=dry_run` can be used.