### PR TITLE
Add the shim flags only if requested

### DIFF
--- a/gslib/tests/testcase/integration_testcase.py
+++ b/gslib/tests/testcase/integration_testcase.py
@@ -1006,12 +1006,12 @@ class GsUtilIntegrationTestCase(base.GsUtilTestCase):
       use_gcloud_storage = False
     else:
       use_gcloud_storage = config.getbool('GSUtil', 'use_gcloud_storage', False)
-    gcloud_storage_setting = [
-        '-o',
-        'GSUtil:use_gcloud_storage={}'.format(use_gcloud_storage),
-        '-o',
-        'GSUtil:hidden_shim_mode=no_fallback',
-    ]
+      gcloud_storage_setting = [
+          '-o',
+          'GSUtil:use_gcloud_storage={}'.format(use_gcloud_storage),
+          '-o',
+          'GSUtil:hidden_shim_mode=no_fallback',
+      ]
     cmd = [
         gslib.GSUTIL_PATH, '--testexceptiontraces', '-o',
         'GSUtil:default_project_id=' + PopulateProjectId()


### PR DESCRIPTION
I was adding the use_gcloud_storage=False flag everywhere. Now adding it only if it was requested from the top level. Should not have any effect on the tests, just makes it cleaner.