### PR TITLE
Custom dual region - Drop placement flag as multiple locations can now be provided via -l flag

### DIFF
--- a/gslib/commands/ls.py
+++ b/gslib/commands/ls.py
@@ -396,9 +396,6 @@ class LsCommand(Command):
           bucket.autoclass.toggleTime.strftime('%a, %d %b %Y'))
     if bucket.locationType:
       fields['location_type'] = bucket.locationType
-    if bucket.customPlacementConfig:
-      fields['custom_placement_locations'] = (
-          bucket.customPlacementConfig.dataLocations)
     if bucket.metageneration:
       fields['metageneration'] = bucket.metageneration
     if bucket.timeCreated:
@@ -437,7 +434,6 @@ class LsCommand(Command):
     # returns many fields that the XML API does not).
     autoclass_line = ''
     location_type_line = ''
-    custom_placement_locations_line = ''
     metageneration_line = ''
     time_created_line = ''
     time_updated_line = ''
@@ -451,9 +447,6 @@ class LsCommand(Command):
       autoclass_line = '\tAutoclass:\t\t\tEnabled on {autoclass_enabled_date}\n'
     if 'location_type' in fields:
       location_type_line = '\tLocation type:\t\t\t{location_type}\n'
-    if 'custom_placement_locations' in fields:
-      custom_placement_locations_line = (
-          '\tPlacement locations:\t\t{custom_placement_locations}\n')
     if 'metageneration' in fields:
       metageneration_line = '\tMetageneration:\t\t\t{metageneration}\n'
     if 'time_created' in fields:
@@ -480,7 +473,6 @@ class LsCommand(Command):
         ('{bucket} :\n'
          '\tStorage class:\t\t\t{storage_class}\n' + location_type_line +
          '\tLocation constraint:\t\t{location_constraint}\n' +
-         custom_placement_locations_line +
          '\tVersioning enabled:\t\t{versioning}\n'
          '\tLogging configuration:\t\t{logging_config}\n'
          '\tWebsite configuration:\t\t{website_config}\n'
@@ -600,7 +592,6 @@ class LsCommand(Command):
             'autoclass',
             'billing',
             'cors',
-            'customPlacementConfig',
             'defaultObjectAcl',
             'encryption',
             'iamConfiguration',

--- a/gslib/commands/mb.py
+++ b/gslib/commands/mb.py
@@ -186,9 +186,7 @@ class MbCommand(Command):
       min_args=1,
       max_args=NO_MAX,
       supported_sub_args='b:c:l:p:s:k:',
-      supported_private_args=[
-          'autoclass', 'retention=', 'pap=', 'rpo='
-      ],
+      supported_private_args=['autoclass', 'retention=', 'pap=', 'rpo='],
       file_url_ok=False,
       provider_url_ok=False,
       urls_start_arg=0,

--- a/gslib/tests/test_ls.py
+++ b/gslib/tests/test_ls.py
@@ -1143,15 +1143,13 @@ class TestLs(testcase.GsUtilIntegrationTestCase):
     stdout = self.RunGsUtil(['ls', '-Lb', suri(bucket_uri)], return_stdout=True)
     self.assertRegex(stdout, r'RPO:\t\t\t\tASYNC_TURBO')
 
-  @SkipForXML('Custom Dual Region is not supported for the XML API.')
   @SkipForS3('Custom Dual Region is not supported for S3 buckets.')
-  def test_list_Lb_displays_custom_dual_region_placement_info(self):
+  def test_list_Lb_displays_custom_dual_region_info(self):
     bucket_name = 'gs://' + self.MakeTempName('bucket')
-    self.RunGsUtil(['mb', '--placement', 'us-central1,us-west1', bucket_name],
+    self.RunGsUtil(['mb', '-l', 'us-central1+us-west1', bucket_name],
                    expected_status=0)
     stdout = self.RunGsUtil(['ls', '-Lb', bucket_name], return_stdout=True)
-    self.assertRegex(stdout,
-                     r"Placement locations:\t\t\['US-CENTRAL1', 'US-WEST1'\]")
+    self.assertRegex(stdout, r"Location constraint:\t\tUS-CENTRAL1\+US-WEST1")
 
   @SkipForXML('Autoclass is not supported for the XML API.')
   @SkipForS3('Autoclass is not supported for S3 buckets.')

--- a/gslib/tests/test_mb.py
+++ b/gslib/tests/test_mb.py
@@ -266,47 +266,26 @@ class TestMb(testcase.GsUtilIntegrationTestCase):
     ],
                    expected_status=0)
 
-  @SkipForXML('The --placement flag only works for GCS JSON API.')
-  def test_create_with_placement_flag(self):
+  @SkipForS3('Custom Dual Region is not supported for S3 buckets.')
+  def test_create_with_custom_dual_regions(self):
     bucket_name = self.MakeTempName('bucket')
     bucket_uri = boto.storage_uri('gs://%s' % (bucket_name.lower()),
                                   suppress_consec_slashes=False)
-    self.RunGsUtil(
-        ['mb', '--placement', 'us-central1,us-west1',
-         suri(bucket_uri)])
+    self.RunGsUtil(['mb', '-l', 'us-central1+us-west1', suri(bucket_uri)])
     stdout = self.RunGsUtil(['ls', '-Lb', suri(bucket_uri)], return_stdout=True)
-    self.assertRegex(stdout,
-                     r"Placement locations:\t\t\['US-CENTRAL1', 'US-WEST1'\]")
+    self.assertRegex(stdout, r"Location constraint:\t\tUS-CENTRAL1\+US-WEST1")
 
-  @SkipForXML('The --placement flag only works for GCS JSON API.')
-  def test_create_with_invalid_placement_flag_raises_error(self):
+  @SkipForS3('Custom Dual Region is not supported for S3 buckets.')
+  def test_create_with_invalid_dual_regions_raises_error(self):
     bucket_name = self.MakeTempName('bucket')
     bucket_uri = boto.storage_uri('gs://%s' % (bucket_name.lower()),
                                   suppress_consec_slashes=False)
     stderr = self.RunGsUtil(
-        ['mb', '--placement', 'invalid_reg1,invalid_reg2',
+        ['mb', '-l', 'invalid_reg1+invalid_reg2',
          suri(bucket_uri)],
         return_stderr=True,
         expected_status=1)
-    self.assertRegex(
-        stderr, r'.*BadRequestException: 400 (Invalid custom placement config|'
-        r'One or more unrecognized regions in dual-region, received:'
-        r' INVALID_REG1, INVALID_REG2).*')
-
-  @SkipForXML('The --placement flag only works for GCS JSON API.')
-  def test_create_with_incorrect_number_of_placement_values_raises_error(self):
-    bucket_name = self.MakeTempName('bucket')
-    bucket_uri = boto.storage_uri('gs://%s' % (bucket_name.lower()),
-                                  suppress_consec_slashes=False)
-    # Location nam4 is used for dual-region.
-    stderr = self.RunGsUtil(
-        ['mb', '--placement', 'val1,val2,val3',
-         suri(bucket_uri)],
-        return_stderr=True,
-        expected_status=1)
-    self.assertIn(
-        'CommandException: Please specify two regions separated by comma'
-        ' without space. Specified: val1,val2,val3', stderr)
+    self.assertIn('The specified location constraint is not valid', stderr)
 
   @SkipForJSON('Testing XML only behavior.')
   def test_single_json_only_flag_raises_error_with_xml_api(self):
@@ -327,13 +306,13 @@ class TestMb(testcase.GsUtilIntegrationTestCase):
     bucket_uri = boto.storage_uri('gs://%s' % (bucket_name.lower()),
                                   suppress_consec_slashes=False)
     stderr = self.RunGsUtil([
-        'mb', '--autoclass', '--pap', 'enabled', '--placement',
-        'uscentral-1,us-asia1', '--rpo', 'ASYNC_TURBO', '-b', 'on',
+        'mb', '--autoclass', '--pap', 'enabled', '--rpo', 'ASYNC_TURBO', '-b',
+        'on',
         suri(bucket_uri)
     ],
                             return_stderr=True,
                             expected_status=1)
     self.assertIn(
-        'CommandException: The --autoclass, --pap, --placement, --rpo,'
+        'CommandException: The --autoclass, --pap, --rpo,'
         ' -b option(s) can only be used for GCS Buckets with the JSON API',
         stderr)


### PR DESCRIPTION
The --placement flag  and the PlacementConfig support will be dropped. Dual regions can be now specified via the location `-l` flag.
