### PR TITLE
Include TypeError as a valid exception for aws.Credentials construction

### DIFF
--- a/gslib/tests/test_wrapped_credentials.py
+++ b/gslib/tests/test_wrapped_credentials.py
@@ -121,3 +121,24 @@ class TestWrappedCredentials(testcase.GsUtilUnitTestCase):
     self.assertEquals(creds2.client_id, "foo")
     self.assertEquals(creds2.access_token, ACCESS_TOKEN)
     self.assertEquals(creds2.token_expiry, creds.token_expiry)
+
+  def testWrappedCredentialSerializationMissingKeywords(self):
+    """Test logic for creating a Wrapped Credentials using keywords that exist in IdentityPool but not AWS."""
+    creds = WrappedCredentials.from_json(
+        json.dumps({
+            "client_id": "foo",
+            "access_token": ACCESS_TOKEN,
+            "token_expiry": "2001-12-05T00:00:00Z",
+            "_base": {
+                "audience": "foo",
+                "subject_token_type": "bar",
+                "token_url": "baz",
+                "credential_source": {
+                    "url": "www.google.com",
+                    "workforce_pool_user_project": "1234567890"
+                }
+            }
+        }))
+
+    self.assertIsInstance(creds, WrappedCredentials)
+    self.assertIsInstance(creds._base, identity_pool.Credentials)

--- a/gslib/utils/wrapped_credentials.py
+++ b/gslib/utils/wrapped_credentials.py
@@ -143,7 +143,7 @@ def _get_external_account_credentials_from_info(info):
   try:
     # Check if configuration corresponds to an AWS credentials.
     creds = aws.Credentials.from_info(info, scopes=DEFAULT_SCOPES)
-  except (ValueError, exceptions.RefreshError):
+  except (TypeError, ValueError, exceptions.RefreshError):
     try:
       # Check if configuration corresponds to an Identity Pool credentials.
       creds = identity_pool.Credentials.from_info(info, scopes=DEFAULT_SCOPES)


### PR DESCRIPTION
This error gets raised when the credentials are Workforce Pool 
credentials with Service Account Impersonation