### PR TITLE
Replace deprecated threading.currentThread with current_thread

### DIFF
--- a/gslib/tests/test_parallelism_framework.py
+++ b/gslib/tests/test_parallelism_framework.py
@@ -98,7 +98,7 @@ def _ReturnOneValue(cls, args, thread_state=None):
 
 
 def _ReturnProcAndThreadId(cls, args, thread_state=None):
-  return (os.getpid(), threading.currentThread().ident)
+  return os.getpid(), threading.current_thread().ident
 
 
 def _SleepThenReturnProcAndThreadId(cls, args, thread_state=None):


### PR DESCRIPTION
`threading.currentThread` was deprecated in Python 3.10 (October 2021).

Replace with `threading.current_thread`, added in Python 2.6 (October 2008).

* https://docs.python.org/3.12/whatsnew/3.10.html#deprecated
* https://github.com/python/cpython/pull/25174

(Also remove the redundant parentheses.)