### PR TITLE
Bring back placement flag for custom dual regions

### DIFF
--- a/gslib/commands/ls.py
+++ b/gslib/commands/ls.py
@@ -396,6 +396,9 @@ class LsCommand(Command):
           bucket.autoclass.toggleTime.strftime('%a, %d %b %Y'))
     if bucket.locationType:
       fields['location_type'] = bucket.locationType
+    if bucket.customPlacementConfig:
+      fields['custom_placement_locations'] = (
+          bucket.customPlacementConfig.dataLocations)
     if bucket.metageneration:
       fields['metageneration'] = bucket.metageneration
     if bucket.timeCreated:
@@ -434,6 +437,7 @@ class LsCommand(Command):
     # returns many fields that the XML API does not).
     autoclass_line = ''
     location_type_line = ''
+    custom_placement_locations_line = ''
     metageneration_line = ''
     time_created_line = ''
     time_updated_line = ''
@@ -447,6 +451,9 @@ class LsCommand(Command):
       autoclass_line = '\tAutoclass:\t\t\tEnabled on {autoclass_enabled_date}\n'
     if 'location_type' in fields:
       location_type_line = '\tLocation type:\t\t\t{location_type}\n'
+    if 'custom_placement_locations' in fields:
+      custom_placement_locations_line = (
+          '\tPlacement locations:\t\t{custom_placement_locations}\n')
     if 'metageneration' in fields:
       metageneration_line = '\tMetageneration:\t\t\t{metageneration}\n'
     if 'time_created' in fields:
@@ -473,6 +480,7 @@ class LsCommand(Command):
         ('{bucket} :\n'
          '\tStorage class:\t\t\t{storage_class}\n' + location_type_line +
          '\tLocation constraint:\t\t{location_constraint}\n' +
+         custom_placement_locations_line +
          '\tVersioning enabled:\t\t{versioning}\n'
          '\tLogging configuration:\t\t{logging_config}\n'
          '\tWebsite configuration:\t\t{website_config}\n'
@@ -592,6 +600,7 @@ class LsCommand(Command):
             'autoclass',
             'billing',
             'cors',
+            'customPlacementConfig',
             'defaultObjectAcl',
             'encryption',
             'iamConfiguration',

--- a/gslib/commands/mb.py
+++ b/gslib/commands/mb.py
@@ -44,6 +44,7 @@ from gslib.utils.encryption_helper import ValidateCMEK
 _SYNOPSIS = """
   gsutil mb [-b (on|off)] [-c <class>] [-k <key>] [-l <location>] [-p <project>]
             [--autoclass] [--retention <time>] [--pap <setting>]
+            [--placement <region1>,<region2>]
             [--rpo {}] gs://<bucket_name>...
 """.format(VALID_RPO_VALUES_STRING)
 
@@ -159,6 +160,12 @@ _DETAILED_HELP_TEXT = ("""
                          "enforced", objects in this bucket cannot be made
                          publicly accessible. Default is "inherited".
 
+  --placement reg1,reg2  Two regions that form the cutom dual-region.
+                         Only regions within the same continent are or will ever
+                         be valid. Invalid location pairs (such as
+                         mixed-continent, or with unsupported regions)
+                         will return an error.
+
   --rpo setting          Specifies the `replication setting <https://cloud.google.com/storage/docs/turbo-replication>`_.
                          This flag is not valid for single-region buckets,
                          and multi-region buckets only accept a value of
@@ -188,7 +195,9 @@ class MbCommand(Command):
       min_args=1,
       max_args=NO_MAX,
       supported_sub_args='b:c:l:p:s:k:',
-      supported_private_args=['autoclass', 'retention=', 'pap=', 'rpo='],
+      supported_private_args=[
+          'autoclass', 'retention=', 'pap=', 'placement=', 'rpo='
+      ],
       file_url_ok=False,
       provider_url_ok=False,
       urls_start_arg=0,
@@ -259,6 +268,7 @@ class MbCommand(Command):
     public_access_prevention = None
     rpo = None
     json_only_flags_in_command = []
+    placements = None
     if self.sub_opts:
       for o, a in self.sub_opts:
         if o == '--autoclass':
@@ -292,6 +302,13 @@ class MbCommand(Command):
         elif o == '--pap':
           public_access_prevention = a
           json_only_flags_in_command.append(o)
+        elif o == '--placement':
+          placements = a.split(',')
+          if len(placements) != 2:
+            raise CommandException(
+                'Please specify two regions separated by comma without space.'
+                ' Specified: {}'.format(a))
+          json_only_flags_in_command.append(o)
 
     bucket_metadata = apitools_messages.Bucket(location=location,
                                                rpo=rpo,
@@ -312,6 +329,11 @@ class MbCommand(Command):
       encryption = apitools_messages.Bucket.EncryptionValue()
       encryption.defaultKmsKeyName = kms_key
       bucket_metadata.encryption = encryption
+
+    if placements:
+      placement_config = apitools_messages.Bucket.CustomPlacementConfigValue()
+      placement_config.dataLocations = placements
+      bucket_metadata.customPlacementConfig = placement_config
 
     for bucket_url_str in self.args:
       bucket_url = StorageUrlFromString(bucket_url_str)

--- a/gslib/tests/test_ls.py
+++ b/gslib/tests/test_ls.py
@@ -1143,13 +1143,15 @@ class TestLs(testcase.GsUtilIntegrationTestCase):
     stdout = self.RunGsUtil(['ls', '-Lb', suri(bucket_uri)], return_stdout=True)
     self.assertRegex(stdout, r'RPO:\t\t\t\tASYNC_TURBO')
 
+  @SkipForXML('Custom Dual Region is not supported for the XML API.')
   @SkipForS3('Custom Dual Region is not supported for S3 buckets.')
-  def test_list_Lb_displays_custom_dual_region_info(self):
+  def test_list_Lb_displays_custom_dual_region_placement_info(self):
     bucket_name = 'gs://' + self.MakeTempName('bucket')
-    self.RunGsUtil(['mb', '-l', 'us-central1+us-west1', bucket_name],
+    self.RunGsUtil(['mb', '--placement', 'us-central1,us-west1', bucket_name],
                    expected_status=0)
     stdout = self.RunGsUtil(['ls', '-Lb', bucket_name], return_stdout=True)
-    self.assertRegex(stdout, r"Location constraint:\t\tUS-CENTRAL1\+US-WEST1")
+    self.assertRegex(stdout,
+                     r"Placement locations:\t\t\['US-CENTRAL1', 'US-WEST1'\]")
 
   @SkipForXML('Autoclass is not supported for the XML API.')
   @SkipForS3('Autoclass is not supported for S3 buckets.')

--- a/gslib/tests/test_mb.py
+++ b/gslib/tests/test_mb.py
@@ -266,6 +266,27 @@ class TestMb(testcase.GsUtilIntegrationTestCase):
     ],
                    expected_status=0)
 
+  @SkipForS3('Custom Dual Region is not supported for S3 buckets.')
+  def test_create_with_custom_dual_regions_via_l_flag(self):
+    bucket_name = self.MakeTempName('bucket')
+    bucket_uri = boto.storage_uri('gs://%s' % (bucket_name.lower()),
+                                  suppress_consec_slashes=False)
+    self.RunGsUtil(['mb', '-l', 'us-central1+us-west1', suri(bucket_uri)])
+    stdout = self.RunGsUtil(['ls', '-Lb', suri(bucket_uri)], return_stdout=True)
+    self.assertRegex(stdout, r"Location constraint:\t\tUS-CENTRAL1\+US-WEST1")
+
+  @SkipForS3('Custom Dual Region is not supported for S3 buckets.')
+  def test_create_with_invalid_dual_regions_via_l_flag_raises_error(self):
+    bucket_name = self.MakeTempName('bucket')
+    bucket_uri = boto.storage_uri('gs://%s' % (bucket_name.lower()),
+                                  suppress_consec_slashes=False)
+    stderr = self.RunGsUtil(
+        ['mb', '-l', 'invalid_reg1+invalid_reg2',
+         suri(bucket_uri)],
+        return_stderr=True,
+        expected_status=1)
+    self.assertIn('The specified location constraint is not valid', stderr)
+
   @SkipForXML('The --placement flag only works for GCS JSON API.')
   def test_create_with_placement_flag(self):
     bucket_name = self.MakeTempName('bucket')

--- a/gslib/tests/test_mb.py
+++ b/gslib/tests/test_mb.py
@@ -266,26 +266,47 @@ class TestMb(testcase.GsUtilIntegrationTestCase):
     ],
                    expected_status=0)
 
-  @SkipForS3('Custom Dual Region is not supported for S3 buckets.')
-  def test_create_with_custom_dual_regions(self):
+  @SkipForXML('The --placement flag only works for GCS JSON API.')
+  def test_create_with_placement_flag(self):
     bucket_name = self.MakeTempName('bucket')
     bucket_uri = boto.storage_uri('gs://%s' % (bucket_name.lower()),
                                   suppress_consec_slashes=False)
-    self.RunGsUtil(['mb', '-l', 'us-central1+us-west1', suri(bucket_uri)])
+    self.RunGsUtil(
+        ['mb', '--placement', 'us-central1,us-west1',
+         suri(bucket_uri)])
     stdout = self.RunGsUtil(['ls', '-Lb', suri(bucket_uri)], return_stdout=True)
-    self.assertRegex(stdout, r"Location constraint:\t\tUS-CENTRAL1\+US-WEST1")
+    self.assertRegex(stdout,
+                     r"Placement locations:\t\t\['US-CENTRAL1', 'US-WEST1'\]")
 
-  @SkipForS3('Custom Dual Region is not supported for S3 buckets.')
-  def test_create_with_invalid_dual_regions_raises_error(self):
+  @SkipForXML('The --placement flag only works for GCS JSON API.')
+  def test_create_with_invalid_placement_flag_raises_error(self):
     bucket_name = self.MakeTempName('bucket')
     bucket_uri = boto.storage_uri('gs://%s' % (bucket_name.lower()),
                                   suppress_consec_slashes=False)
     stderr = self.RunGsUtil(
-        ['mb', '-l', 'invalid_reg1+invalid_reg2',
+        ['mb', '--placement', 'invalid_reg1,invalid_reg2',
          suri(bucket_uri)],
         return_stderr=True,
         expected_status=1)
-    self.assertIn('The specified location constraint is not valid', stderr)
+    self.assertRegex(
+        stderr, r'.*BadRequestException: 400 (Invalid custom placement config|'
+        r'One or more unrecognized regions in dual-region, received:'
+        r' INVALID_REG1, INVALID_REG2).*')
+
+  @SkipForXML('The --placement flag only works for GCS JSON API.')
+  def test_create_with_incorrect_number_of_placement_values_raises_error(self):
+    bucket_name = self.MakeTempName('bucket')
+    bucket_uri = boto.storage_uri('gs://%s' % (bucket_name.lower()),
+                                  suppress_consec_slashes=False)
+    # Location nam4 is used for dual-region.
+    stderr = self.RunGsUtil(
+        ['mb', '--placement', 'val1,val2,val3',
+         suri(bucket_uri)],
+        return_stderr=True,
+        expected_status=1)
+    self.assertIn(
+        'CommandException: Please specify two regions separated by comma'
+        ' without space. Specified: val1,val2,val3', stderr)
 
   @SkipForJSON('Testing XML only behavior.')
   def test_single_json_only_flag_raises_error_with_xml_api(self):
@@ -306,13 +327,13 @@ class TestMb(testcase.GsUtilIntegrationTestCase):
     bucket_uri = boto.storage_uri('gs://%s' % (bucket_name.lower()),
                                   suppress_consec_slashes=False)
     stderr = self.RunGsUtil([
-        'mb', '--autoclass', '--pap', 'enabled', '--rpo', 'ASYNC_TURBO', '-b',
-        'on',
+        'mb', '--autoclass', '--pap', 'enabled', '--placement',
+        'uscentral-1,us-asia1', '--rpo', 'ASYNC_TURBO', '-b', 'on',
         suri(bucket_uri)
     ],
                             return_stderr=True,
                             expected_status=1)
     self.assertIn(
-        'CommandException: The --autoclass, --pap, --rpo,'
+        'CommandException: The --autoclass, --pap, --placement, --rpo,'
         ' -b option(s) can only be used for GCS Buckets with the JSON API',
         stderr)


### PR DESCRIPTION
Reverts GoogleCloudPlatform/gsutil#1480 and keeps some of the modifications to the -l flag for mb.