### PR TITLE
Added flush to cat_helper.py

### DIFF
--- a/gslib/tests/test_cat.py
+++ b/gslib/tests/test_cat.py
@@ -19,6 +19,8 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import unicode_literals
 
+import sys
+
 from gslib.cs_api_map import ApiSelector
 from gslib.exception import NO_URLS_MATCHED_TARGET
 import gslib.tests.testcase as testcase
@@ -29,6 +31,9 @@ from gslib.tests.util import RUN_S3_TESTS
 from gslib.tests.util import SetBotoConfigForTest
 from gslib.tests.util import TEST_ENCRYPTION_KEY1
 from gslib.tests.util import unittest
+from gslib.utils import cat_helper
+
+from unittest import mock
 
 
 class TestCat(testcase.GsUtilIntegrationTestCase):
@@ -162,3 +167,57 @@ class TestCat(testcase.GsUtilIntegrationTestCase):
       stdout = self.RunGsUtil(
           ['cat', '-r 1-3', suri(object_uri)], return_stdout=True)
       self.assertEqual(stdout, '123')
+
+
+class TestCatHelper(testcase.GsUtilUnitTestCase):
+  """Unit tests for cat helper."""
+
+  def test_cat_helper_runs_flush(self):
+    command_mock = mock.Mock()
+    cat_helper_mock = cat_helper.CatHelper(command_obj=command_mock)
+
+    object_contents = '0123456789'
+    bucket_uri = self.CreateBucket(bucket_name='bucket',
+                                   provider=self.default_provider)
+    obj = self.CreateObject(bucket_uri=bucket_uri,
+                            object_name='foo',
+                            contents=object_contents)
+    obj1 = self.CreateObject(bucket_uri=bucket_uri,
+                             object_name='foo1',
+                             contents=object_contents)
+    obj.root_object = None
+    command_mock.WildcardIterator.return_value = self._test_wildcard_iterator(
+        'gs://bucket/foo*')
+
+    stdout_mock = mock.mock_open()()
+
+    # Mocks two functions because we need to record the order of the function calls (write, flush, write, flush).
+    write_flush_collector_mock = mock.Mock()
+    command_mock.gsutil_api.GetObjectMedia = write_flush_collector_mock
+    stdout_mock.flush = write_flush_collector_mock
+
+    cat_helper_mock.CatUrlStrings(url_strings=['url'], cat_out_fd=stdout_mock)
+    self.assertEqual(write_flush_collector_mock.call_args_list, [
+        mock.call('bucket',
+                  'foo',
+                  stdout_mock,
+                  compressed_encoding=None,
+                  start_byte=0,
+                  end_byte=None,
+                  object_size=10,
+                  generation=None,
+                  decryption_tuple=None,
+                  provider='gs'),
+        mock.call(),
+        mock.call('bucket',
+                  'foo1',
+                  stdout_mock,
+                  compressed_encoding=None,
+                  start_byte=0,
+                  end_byte=None,
+                  object_size=10,
+                  generation=None,
+                  decryption_tuple=None,
+                  provider='gs'),
+        mock.call()
+    ])

--- a/gslib/tests/test_cat.py
+++ b/gslib/tests/test_cat.py
@@ -19,6 +19,7 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import unicode_literals
 
+import six
 import sys
 
 from gslib.cs_api_map import ApiSelector
@@ -198,7 +199,7 @@ class TestCatHelper(testcase.GsUtilUnitTestCase):
     stdout_mock.flush = write_flush_collector_mock
 
     cat_helper_mock.CatUrlStrings(url_strings=['url'], cat_out_fd=stdout_mock)
-    self.assertEqual(write_flush_collector_mock.call_args_list, [
+    mock_part_one = [
         mock.call('bucket',
                   'foo',
                   stdout_mock,
@@ -209,7 +210,9 @@ class TestCatHelper(testcase.GsUtilUnitTestCase):
                   generation=None,
                   decryption_tuple=None,
                   provider='gs'),
-        mock.call(),
+        mock.call()
+    ]
+    mock_part_two = [
         mock.call('bucket',
                   'foo1',
                   stdout_mock,
@@ -221,4 +224,10 @@ class TestCatHelper(testcase.GsUtilUnitTestCase):
                   decryption_tuple=None,
                   provider='gs'),
         mock.call()
-    ])
+    ]
+    # Needed to do these two checks because the object list order differs
+    # between Windows OS and Python Version 3.5.
+    self.assertIn(write_flush_collector_mock.call_args_list[0:2],
+                  [mock_part_one, mock_part_two])
+    self.assertIn(write_flush_collector_mock.call_args_list[2:4],
+                  [mock_part_one, mock_part_two])

--- a/gslib/tests/test_cat.py
+++ b/gslib/tests/test_cat.py
@@ -19,7 +19,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import unicode_literals
 
-import six
 import sys
 
 from gslib.cs_api_map import ApiSelector

--- a/gslib/tests/test_cat.py
+++ b/gslib/tests/test_cat.py
@@ -185,13 +185,14 @@ class TestCatHelper(testcase.GsUtilUnitTestCase):
     obj1 = self.CreateObject(bucket_uri=bucket_uri,
                              object_name='foo1',
                              contents=object_contents)
-    obj.root_object = None
+
     command_mock.WildcardIterator.return_value = self._test_wildcard_iterator(
         'gs://bucket/foo*')
 
     stdout_mock = mock.mock_open()()
 
-    # Mocks two functions because we need to record the order of the function calls (write, flush, write, flush).
+    # Mocks two functions because we need to record the order of the
+    # function calls (write, flush, write, flush).
     write_flush_collector_mock = mock.Mock()
     command_mock.gsutil_api.GetObjectMedia = write_flush_collector_mock
     stdout_mock.flush = write_flush_collector_mock

--- a/gslib/utils/cat_helper.py
+++ b/gslib/utils/cat_helper.py
@@ -21,6 +21,7 @@ from __future__ import unicode_literals
 
 import io
 import sys
+import time
 
 from boto import config
 
@@ -150,6 +151,8 @@ class CatHelper(object):
                   generation=storage_url.generation,
                   decryption_tuple=decryption_keywrapper,
                   provider=storage_url.scheme)
+              cat_out_fd.flush()
+
             else:
               with open(storage_url.object_name, 'rb') as f:
                 self._WriteBytesBufferedFileToFile(f, cat_out_fd)

--- a/gslib/utils/cat_helper.py
+++ b/gslib/utils/cat_helper.py
@@ -21,7 +21,6 @@ from __future__ import unicode_literals
 
 import io
 import sys
-import time
 
 from boto import config
 


### PR DESCRIPTION
The gsutil cat -h flag when used on multiple objects which are small, first prints the headers of all the objects the user entered and then prints the contents of all the objects the user entered.
The reason the gsutil cat -h command with multiple small files does not work properly is because the headers are written to stderr whereas the object contents are written to stdout. Since stderr does not have a buffer and stdout does, with small files, the buffer is not cleared fast enough and both headers are printed before the first content is printed. By flushing the buffer immediately, the header of the first object is printed followed by the content, header of the second object followed by the content, etc.. 