### PR TITLE
Updated cat -h with multiple small files behavior

### DIFF
--- a/gslib/tests/test_cat.py
+++ b/gslib/tests/test_cat.py
@@ -19,6 +19,8 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import unicode_literals
 
+import sys
+
 from gslib.cs_api_map import ApiSelector
 from gslib.exception import NO_URLS_MATCHED_TARGET
 import gslib.tests.testcase as testcase
@@ -29,6 +31,9 @@ from gslib.tests.util import RUN_S3_TESTS
 from gslib.tests.util import SetBotoConfigForTest
 from gslib.tests.util import TEST_ENCRYPTION_KEY1
 from gslib.tests.util import unittest
+from gslib.utils import cat_helper
+
+from unittest import mock
 
 
 class TestCat(testcase.GsUtilIntegrationTestCase):
@@ -162,3 +167,66 @@ class TestCat(testcase.GsUtilIntegrationTestCase):
       stdout = self.RunGsUtil(
           ['cat', '-r 1-3', suri(object_uri)], return_stdout=True)
       self.assertEqual(stdout, '123')
+
+
+class TestCatHelper(testcase.GsUtilUnitTestCase):
+  """Unit tests for cat helper."""
+
+  def test_cat_helper_runs_flush(self):
+    command_mock = mock.Mock()
+    cat_helper_mock = cat_helper.CatHelper(command_obj=command_mock)
+
+    object_contents = '0123456789'
+    bucket_uri = self.CreateBucket(bucket_name='bucket',
+                                   provider=self.default_provider)
+    obj = self.CreateObject(bucket_uri=bucket_uri,
+                            object_name='foo',
+                            contents=object_contents)
+    obj1 = self.CreateObject(bucket_uri=bucket_uri,
+                             object_name='foo1',
+                             contents=object_contents)
+
+    command_mock.WildcardIterator.return_value = self._test_wildcard_iterator(
+        'gs://bucket/foo*')
+
+    stdout_mock = mock.mock_open()()
+
+    # Mocks two functions because we need to record the order of the
+    # function calls (write, flush, write, flush).
+    write_flush_collector_mock = mock.Mock()
+    command_mock.gsutil_api.GetObjectMedia = write_flush_collector_mock
+    stdout_mock.flush = write_flush_collector_mock
+
+    cat_helper_mock.CatUrlStrings(url_strings=['url'], cat_out_fd=stdout_mock)
+    mock_part_one = [
+        mock.call('bucket',
+                  'foo',
+                  stdout_mock,
+                  compressed_encoding=None,
+                  start_byte=0,
+                  end_byte=None,
+                  object_size=10,
+                  generation=None,
+                  decryption_tuple=None,
+                  provider='gs'),
+        mock.call()
+    ]
+    mock_part_two = [
+        mock.call('bucket',
+                  'foo1',
+                  stdout_mock,
+                  compressed_encoding=None,
+                  start_byte=0,
+                  end_byte=None,
+                  object_size=10,
+                  generation=None,
+                  decryption_tuple=None,
+                  provider='gs'),
+        mock.call()
+    ]
+    # Needed to do these two checks because the object list order differs
+    # between Windows OS and Python Version 3.5.
+    self.assertIn(write_flush_collector_mock.call_args_list[0:2],
+                  [mock_part_one, mock_part_two])
+    self.assertIn(write_flush_collector_mock.call_args_list[2:4],
+                  [mock_part_one, mock_part_two])

--- a/gslib/utils/cat_helper.py
+++ b/gslib/utils/cat_helper.py
@@ -150,6 +150,8 @@ class CatHelper(object):
                   generation=storage_url.generation,
                   decryption_tuple=decryption_keywrapper,
                   provider=storage_url.scheme)
+              cat_out_fd.flush()
+
             else:
               with open(storage_url.object_name, 'rb') as f:
                 self._WriteBytesBufferedFileToFile(f, cat_out_fd)


### PR DESCRIPTION
Under the old "gsutil cat -h" flag, when used on multiple objects which are small, first prints the headers of all the objects the user entered and then prints the contents of all the objects the user entered. The new code prints the header of the first object followed by its content, then the header of the second object followed by its content, etc.. This is done by flushing the buffer.