### PR TITLE
Updated the cat -r command error behavior

### DIFF
--- a/gslib/commands/cat.py
+++ b/gslib/commands/cat.py
@@ -131,7 +131,7 @@ class CatCommand(Command):
           # This if statement ensures the full object is returned
           # instead of throwing a CommandException.
           if request_range == '-':
-            break
+            continue
           range_matcher = re.compile(
               '^(?P<start>[0-9]+)-(?P<end>[0-9]*)$|^(?P<endslice>-[0-9]+)$')
           range_match = range_matcher.match(request_range)

--- a/gslib/commands/cat.py
+++ b/gslib/commands/cat.py
@@ -131,6 +131,10 @@ class CatCommand(Command):
           range_matcher = re.compile(
               '^(?P<start>[0-9]+)-(?P<end>[0-9]*)$|^(?P<endslice>-[0-9]+)$')
           range_match = range_matcher.match(request_range)
+          # This if statement enures the full object is returned
+          # instead of throwing a CommandException.
+          if request_range == '-':
+            break
           if not range_match:
             raise CommandException('Invalid range (%s)' % request_range)
           if range_match.group('start'):

--- a/gslib/commands/cat.py
+++ b/gslib/commands/cat.py
@@ -128,13 +128,13 @@ class CatCommand(Command):
           show_header = True
         elif o == '-r':
           request_range = a.strip()
-          range_matcher = re.compile(
-              '^(?P<start>[0-9]+)-(?P<end>[0-9]*)$|^(?P<endslice>-[0-9]+)$')
-          range_match = range_matcher.match(request_range)
-          # This if statement enures the full object is returned
+          # This if statement ensures the full object is returned
           # instead of throwing a CommandException.
           if request_range == '-':
             break
+          range_matcher = re.compile(
+              '^(?P<start>[0-9]+)-(?P<end>[0-9]*)$|^(?P<endslice>-[0-9]+)$')
+          range_match = range_matcher.match(request_range)
           if not range_match:
             raise CommandException('Invalid range (%s)' % request_range)
           if range_match.group('start'):

--- a/gslib/tests/test_cat.py
+++ b/gslib/tests/test_cat.py
@@ -43,10 +43,6 @@ class TestCat(testcase.GsUtilIntegrationTestCase):
     """Tests cat command with various range arguments."""
     key_uri = self.CreateObject(contents=b'0123456789')
     # Test various invalid ranges.
-    stderr = self.RunGsUtil(['cat', '-r -', suri(key_uri)],
-                            return_stderr=True,
-                            expected_status=1)
-    self.assertIn('Invalid range', stderr)
     stderr = self.RunGsUtil(['cat', '-r a-b', suri(key_uri)],
                             return_stderr=True,
                             expected_status=1)
@@ -63,6 +59,14 @@ class TestCat(testcase.GsUtilIntegrationTestCase):
     self.assertIn('Invalid range', stderr)
 
     # Test various valid ranges.
+    stdout = self.RunGsUtil(['cat', '-r -', suri(key_uri)], return_stdout=True)
+    self.assertEqual('0123456789', stdout)
+    stdout = self.RunGsUtil(
+        ['cat', '-r 1000-3000', suri(key_uri)], return_stdout=True)
+    self.assertEqual('', stdout)
+    stdout = self.RunGsUtil(
+        ['cat', '-r 1000-', suri(key_uri)], return_stdout=True)
+    self.assertEqual('', stdout)
     stdout = self.RunGsUtil(['cat', '-r 1-3', suri(key_uri)],
                             return_stdout=True)
     self.assertEqual('123', stdout)

--- a/gslib/utils/cat_helper.py
+++ b/gslib/utils/cat_helper.py
@@ -137,6 +137,10 @@ class CatHelper(object):
               printed_one = True
             cat_object = blr.root_object
             storage_url = StorageUrlFromString(blr.url_string)
+            # This if statement ensures nothing is ouputted and no error
+            # is thrown if the user enters an out of bounds range for the object.
+            if start_byte >= cat_object.size:
+              return 0
             if storage_url.IsCloudUrl():
               compressed_encoding = ObjectIsGzipEncoded(cat_object)
               self.command_obj.gsutil_api.GetObjectMedia(

--- a/gslib/utils/cat_helper.py
+++ b/gslib/utils/cat_helper.py
@@ -138,8 +138,9 @@ class CatHelper(object):
             cat_object = blr.root_object
             # This if statement ensures nothing is ouputted and no error
             # is thrown if the user enters an out of bounds range for the object.
-            if getattr(cat_object, 'size',
-                       None) is not None and start_byte >= cat_object.size:
+            if getattr(
+                cat_object, 'size', None
+            ) is not None and cat_object.size > 0 and start_byte >= cat_object.size:
               sys.stdout = old_stdout
               return 0
             storage_url = StorageUrlFromString(blr.url_string)

--- a/gslib/utils/cat_helper.py
+++ b/gslib/utils/cat_helper.py
@@ -138,7 +138,7 @@ class CatHelper(object):
             cat_object = blr.root_object
             # This if statement ensures nothing is ouputted and no error
             # is thrown if the user enters an out of bounds range for the object.
-            if start_byte >= cat_object.size:
+            if cat_object.size is not None and start_byte >= cat_object.size:
               sys.stdout = old_stdout
               return 0
             storage_url = StorageUrlFromString(blr.url_string)

--- a/gslib/utils/cat_helper.py
+++ b/gslib/utils/cat_helper.py
@@ -136,11 +136,11 @@ class CatHelper(object):
               print('==> %s <==' % blr)
               printed_one = True
             cat_object = blr.root_object
-            storage_url = StorageUrlFromString(blr.url_string)
             # This if statement ensures nothing is ouputted and no error
             # is thrown if the user enters an out of bounds range for the object.
             if start_byte >= cat_object.size:
               return 0
+            storage_url = StorageUrlFromString(blr.url_string)
             if storage_url.IsCloudUrl():
               compressed_encoding = ObjectIsGzipEncoded(cat_object)
               self.command_obj.gsutil_api.GetObjectMedia(

--- a/gslib/utils/cat_helper.py
+++ b/gslib/utils/cat_helper.py
@@ -139,6 +139,7 @@ class CatHelper(object):
             # This if statement ensures nothing is ouputted and no error
             # is thrown if the user enters an out of bounds range for the object.
             if start_byte >= cat_object.size:
+              sys.stdout = old_stdout
               return 0
             storage_url = StorageUrlFromString(blr.url_string)
             if storage_url.IsCloudUrl():

--- a/gslib/utils/cat_helper.py
+++ b/gslib/utils/cat_helper.py
@@ -136,12 +136,9 @@ class CatHelper(object):
               print('==> %s <==' % blr)
               printed_one = True
             cat_object = blr.root_object
-            # This if statement ensures nothing is ouputted and no error
+            # This if statement ensures nothing is outputted and no error
             # is thrown if the user enters an out of bounds range for the object.
-            if getattr(
-                cat_object, 'size', None
-            ) is not None and cat_object.size > 0 and start_byte >= cat_object.size:
-              sys.stdout = old_stdout
+            if 0 < getattr(cat_object, 'size', float('inf')) <= start_byte:
               return 0
             storage_url = StorageUrlFromString(blr.url_string)
             if storage_url.IsCloudUrl():

--- a/gslib/utils/cat_helper.py
+++ b/gslib/utils/cat_helper.py
@@ -138,7 +138,8 @@ class CatHelper(object):
             cat_object = blr.root_object
             # This if statement ensures nothing is ouputted and no error
             # is thrown if the user enters an out of bounds range for the object.
-            if cat_object.size is not None and start_byte >= cat_object.size:
+            if getattr(cat_object, 'size',
+                       None) is not None and start_byte >= cat_object.size:
               sys.stdout = old_stdout
               return 0
             storage_url = StorageUrlFromString(blr.url_string)

--- a/gslib/utils/cat_helper.py
+++ b/gslib/utils/cat_helper.py
@@ -138,7 +138,7 @@ class CatHelper(object):
             cat_object = blr.root_object
             # This if statement ensures nothing is outputted and no error
             # is thrown if the user enters an out of bounds range for the object.
-            if 0 < getattr(cat_object, 'size', float('inf')) <= start_byte:
+            if 0 < getattr(cat_object, 'size', -1) <= start_byte:
               return 0
             storage_url = StorageUrlFromString(blr.url_string)
             if storage_url.IsCloudUrl():


### PR DESCRIPTION
Under the old cat command, if the user entered a gsutil cat -r x-y gs://object and the starting range is out of bounds, an error was thrown. Under the new behavior, nothing is outputted and no error is thrown, just like Python's behavior.
Additionally, under the old gsutil cat code, when a user entered `gsutil cat -r - gs://object' a "CommandException" was thrown. Under the new code, the whole object is printed, just like Python's default behavior.