### PR TITLE
Added shim support for cat

### DIFF
--- a/gslib/commands/cat.py
+++ b/gslib/commands/cat.py
@@ -30,6 +30,8 @@ from gslib.cs_api_map import ApiSelector
 from gslib.exception import CommandException
 from gslib.utils import cat_helper
 from gslib.utils import constants
+from gslib.utils.shim_util import GcloudStorageFlag
+from gslib.utils.shim_util import GcloudStorageMap
 
 if six.PY3:
   long = int
@@ -113,6 +115,14 @@ class CatCommand(Command):
       help_one_line_summary='Concatenate object content to stdout',
       help_text=_DETAILED_HELP_TEXT,
       subcommand_help_text={},
+  )
+
+  gcloud_storage_map = GcloudStorageMap(
+      gcloud_command=['alpha', 'storage', 'cat'],
+      flag_map={
+          '-h': GcloudStorageFlag('-d'),
+          '-r': GcloudStorageFlag('-r'),
+      },
   )
 
   # Command entry point.

--- a/gslib/utils/shim_util.py
+++ b/gslib/utils/shim_util.py
@@ -46,7 +46,7 @@ DECRYPTION_KEY_REGEX = re.compile(r'^decryption_key([1-9]$|[1-9][0-9]$|100$)')
 # Required for headers translation and boto config translation.
 DATA_TRANSFER_COMMANDS = frozenset(['cp', 'mv', 'rsync'])
 ENCRYPTION_SUPPORTED_COMMANDS = DATA_TRANSFER_COMMANDS | frozenset(
-    ['ls', 'rewrite', 'stat'])
+    ['ls', 'rewrite', 'stat', 'cat'])
 PRECONDITONS_ONLY_SUPPORTED_COMMANDS = frozenset(
     ['compose', 'rewrite', 'rm', 'retention'])
 DATA_TRANSFER_HEADERS = frozenset([


### PR DESCRIPTION
Before, there was no shim support for the cat command.
After, there is now shim support and the gsutil cat tests ensure the
gcloud command passes them.