### PR TITLE
Shim web command

### DIFF
--- a/gslib/commands/kms.py
+++ b/gslib/commands/kms.py
@@ -151,7 +151,7 @@ _DESCRIPTION = """
   The kms command has three sub-commands that deal with configuring Cloud
   Storage's integration with Cloud KMS: ``authorize``, ``encryption``,
   and ``serviceaccount``.
-  
+
   Before using this command, read the `prerequisites
   <https://cloud.google.com/storage/docs/encryption/using-customer-managed-keys#prereqs>`_.
   for using Cloud KMS with Cloud Storage.
@@ -172,14 +172,6 @@ _AUTHORIZE_COMMAND = GcloudStorageMap(
     flag_map={
         '-p': GcloudStorageFlag('--project'),
         '-k': GcloudStorageFlag('--authorize-cmek'),
-    })
-
-_ENCRYPTION_COMMAND = GcloudStorageMap(
-    gcloud_command='PLACEHOLDER',
-    flag_map={
-        '-d': GcloudStorageFlag('--clear-default-encryption-key'),
-        '-k': GcloudStorageFlag('--default-encryption-key'),
-        '-w': GcloudStorageFlag(''),
     })
 
 _SERVICEACCOUNT_COMMAND = GcloudStorageMap(
@@ -222,26 +214,41 @@ class KmsCommand(Command):
       },
   )
 
-  gcloud_storage_map = GcloudStorageMap(gcloud_command={
-      'authorize': _AUTHORIZE_COMMAND,
-      'encryption': _ENCRYPTION_COMMAND,
-      'serviceaccount': _SERVICEACCOUNT_COMMAND,
-  },
-                                        flag_map={})
+  gcloud_storage_map = GcloudStorageMap(
+      gcloud_command={
+          'authorize': _AUTHORIZE_COMMAND,
+          'serviceaccount': _SERVICEACCOUNT_COMMAND,
+          # "encryption" subcommand handled in get_gcloud_storage_args.
+      },
+      flag_map={})
 
   def get_gcloud_storage_args(self):
-    common_command = ['alpha', 'storage', 'buckets']
     if self.args[0] == 'encryption':
+      gcloud_storage_map = GcloudStorageMap(gcloud_command={
+          'encryption':
+              GcloudStorageMap(
+                  gcloud_command=['alpha', 'storage', 'buckets'],
+                  flag_map={
+                      '-d': GcloudStorageFlag('--clear-default-encryption-key'),
+                      '-k': GcloudStorageFlag('--default-encryption-key'),
+                      '-w': GcloudStorageFlag(''),
+                  }),
+      },
+                                            flag_map={})
       if '-d' in self.args or '-k' in self.args:
-        _ENCRYPTION_COMMAND.gcloud_command = common_command + ['update']
+        gcloud_storage_map.gcloud_command['encryption'].gcloud_command += [
+            'update'
+        ]
       else:
-        _ENCRYPTION_COMMAND.gcloud_command = common_command + [
+        gcloud_storage_map.gcloud_command['encryption'].gcloud_command += [
             'describe',
             ('--format="value[separator=\": \"](\"name\",\"default_kms_key\"'
              '.yesno(no=\"No default encryption key.\"))'),
         ]
+    else:
+      gcloud_storage_map = KmsCommand.gcloud_storage_map
 
-    return super().get_gcloud_storage_args()
+    return super().get_gcloud_storage_args(gcloud_storage_map)
 
   def _GatherSubOptions(self, subcommand_name):
     self.CheckArguments()

--- a/gslib/tests/test_shim_util.py
+++ b/gslib/tests/test_shim_util.py
@@ -167,6 +167,18 @@ class TestGetGCloudStorageArgs(testcase.GsUtilUnitTestCase):
     self.assertEqual(gcloud_args,
                      ['objects', 'fake', '--zip', 'opt1', '-x', 'arg1', 'arg2'])
 
+  def test_get_gcloud_storage_args_parses_custom_command_map(self):
+    gcloud_args = self._fake_command.get_gcloud_storage_args(
+        shim_util.GcloudStorageMap(
+            gcloud_command=['objects', 'custom-fake'],
+            flag_map={
+                '-z': shim_util.GcloudStorageFlag(gcloud_flag='-a'),
+                '-r': shim_util.GcloudStorageFlag(gcloud_flag='-b'),
+            }))
+    self.assertEqual(
+        gcloud_args,
+        ['objects', 'custom-fake', '-a', 'opt1', '-b', 'arg1', 'arg2'])
+
   def test_get_gcloud_storage_args_parses_command_in_list_format(self):
     self._fake_command.gcloud_command = ['objects', 'fake']
     gcloud_args = self._fake_command.get_gcloud_storage_args()

--- a/gslib/tests/test_web.py
+++ b/gslib/tests/test_web.py
@@ -20,9 +20,15 @@ from __future__ import division
 from __future__ import unicode_literals
 
 import json
+import os
+from unittest import mock
+
+from gslib.commands import web
 import gslib.tests.testcase as testcase
 from gslib.tests.testcase.integration_testcase import SkipForS3
 from gslib.tests.util import ObjectToURI as suri
+from gslib.tests.util import SetBotoConfigForTest
+from gslib.tests.util import SetEnvironmentForTest
 
 WEBCFG_FULL = json.loads('{"notFoundPage": "404", "mainPageSuffix": "main"}\n')
 WEBCFG_MAIN = json.loads('{"mainPageSuffix": "main"}\n')
@@ -44,28 +50,41 @@ class TestWeb(testcase.GsUtilIntegrationTestCase):
         ['-m', 'main', '-e', '404', suri(bucket_uri)])
     stdout = self.RunGsUtil(self._get_web_cmd + [suri(bucket_uri)],
                             return_stdout=True)
-    self.assertEquals(json.loads(stdout), WEBCFG_FULL)
+    if self._use_gcloud_storage:
+      self.assertIn('"mainPageSuffix": "main"', stdout)
+      self.assertIn('"notFoundPage": "404"', stdout)
+    else:
+      self.assertEquals(json.loads(stdout), WEBCFG_FULL)
 
   def test_main(self):
     bucket_uri = self.CreateBucket()
     self.RunGsUtil(self._set_web_cmd + ['-m', 'main', suri(bucket_uri)])
     stdout = self.RunGsUtil(self._get_web_cmd + [suri(bucket_uri)],
                             return_stdout=True)
-    self.assertEquals(json.loads(stdout), WEBCFG_MAIN)
+    if self._use_gcloud_storage:
+      self.assertEquals('{\n  "mainPageSuffix": "main"\n}\n', stdout)
+    else:
+      self.assertEquals(json.loads(stdout), WEBCFG_MAIN)
 
   def test_error(self):
     bucket_uri = self.CreateBucket()
     self.RunGsUtil(self._set_web_cmd + ['-e', '404', suri(bucket_uri)])
     stdout = self.RunGsUtil(self._get_web_cmd + [suri(bucket_uri)],
                             return_stdout=True)
-    self.assertEquals(json.loads(stdout), WEBCFG_ERROR)
+    if self._use_gcloud_storage:
+      self.assertEquals('{\n  "notFoundPage": "404"\n}\n', stdout)
+    else:
+      self.assertEquals(json.loads(stdout), WEBCFG_ERROR)
 
   def test_empty(self):
     bucket_uri = self.CreateBucket()
     self.RunGsUtil(self._set_web_cmd + [suri(bucket_uri)])
     stdout = self.RunGsUtil(self._get_web_cmd + [suri(bucket_uri)],
                             return_stdout=True)
-    self.assertIn(WEBCFG_EMPTY, stdout)
+    if self._use_gcloud_storage:
+      self.assertEquals('[]\n', stdout)
+    else:
+      self.assertEquals(json.loads(stdout), WEBCFG_EMPTY)
 
   def testTooFewArgumentsFails(self):
     """Ensures web commands fail with too few arguments."""
@@ -84,6 +103,68 @@ class TestWeb(testcase.GsUtilIntegrationTestCase):
     # Neither arguments nor subcommand.
     stderr = self.RunGsUtil(['web'], return_stderr=True, expected_status=1)
     self.assertIn('command requires at least', stderr)
+
+
+class TestWebShim(testcase.GsUtilUnitTestCase):
+
+  @mock.patch.object(web.WebCommand, '_GetWeb', new=mock.Mock())
+  def test_shim_translates_get_command(self):
+    with SetBotoConfigForTest([('GSUtil', 'use_gcloud_storage', 'True'),
+                               ('GSUtil', 'hidden_shim_mode', 'dry_run')]):
+      with SetEnvironmentForTest({
+          'CLOUDSDK_CORE_PASS_CREDENTIALS_TO_GSUTIL': 'True',
+          'CLOUDSDK_ROOT_DIR': 'fake_dir',
+      }):
+        mock_log_handler = self.RunCommand('web', [
+            'get',
+            'gs://bucket',
+        ],
+                                           return_log_handler=True)
+        info_lines = '\n'.join(mock_log_handler.messages['info'])
+        self.assertIn(
+            ('Gcloud Storage Command: {} alpha storage buckets describe'
+             ' --format=multi(website:format=json) gs://bucket').format(
+                 os.path.join('fake_dir', 'bin', 'gcloud')), info_lines)
+
+  @mock.patch.object(web.WebCommand, '_SetWeb', new=mock.Mock())
+  def test_shim_translates_set_command(self):
+    with SetBotoConfigForTest([('GSUtil', 'use_gcloud_storage', 'True'),
+                               ('GSUtil', 'hidden_shim_mode', 'dry_run')]):
+      with SetEnvironmentForTest({
+          'CLOUDSDK_CORE_PASS_CREDENTIALS_TO_GSUTIL': 'True',
+          'CLOUDSDK_ROOT_DIR': 'fake_dir',
+      }):
+        mock_log_handler = self.RunCommand('web', [
+            'set',
+            '-e',
+            '404',
+            '-m',
+            'main',
+            'gs://bucket',
+        ],
+                                           return_log_handler=True)
+        info_lines = '\n'.join(mock_log_handler.messages['info'])
+        self.assertIn(
+            ('Gcloud Storage Command: {} alpha storage buckets update'
+             ' --web-error-page 404 --web-main-page-suffix main gs://bucket'
+            ).format(os.path.join('fake_dir', 'bin', 'gcloud')), info_lines)
+
+  @mock.patch.object(web.WebCommand, '_SetWeb', new=mock.Mock())
+  def test_shim_translates_clear_command(self):
+    with SetBotoConfigForTest([('GSUtil', 'use_gcloud_storage', 'True'),
+                               ('GSUtil', 'hidden_shim_mode', 'dry_run')]):
+      with SetEnvironmentForTest({
+          'CLOUDSDK_CORE_PASS_CREDENTIALS_TO_GSUTIL': 'True',
+          'CLOUDSDK_ROOT_DIR': 'fake_dir',
+      }):
+        mock_log_handler = self.RunCommand('web', ['set', 'gs://bucket'],
+                                           return_log_handler=True)
+        info_lines = '\n'.join(mock_log_handler.messages['info'])
+        self.assertIn(
+            ('Gcloud Storage Command: {} alpha storage buckets update'
+             ' --clear-web-error-page --clear-web-main-page-suffix'
+             ' gs://bucket').format(os.path.join('fake_dir', 'bin',
+                                                 'gcloud')), info_lines)
 
 
 class TestWebOldAlias(TestWeb):

--- a/gslib/utils/shim_util.py
+++ b/gslib/utils/shim_util.py
@@ -468,11 +468,17 @@ class GcloudStorageCommandMixin(object):
       flags.append('--decryption-keys=' + ','.join(decryption_keys))
     return flags, env_vars
 
-  def get_gcloud_storage_args(self):
+  def get_gcloud_storage_args(self, gcloud_storage_map=None):
     """Translates the gsutil command flags to gcloud storage flags.
 
     It uses the command_spec.gcloud_storage_map field that provides the
     translation mapping for all the flags.
+
+    Args:
+      gcloud_storage_map (GcloudStorageMap|None): Command surface may pass a
+        custom translation map instead of using the default class constant.
+        Useful for when translations change based on conditional logic.
+
 
     Returns:
       A list of all the options and arguments that can be used with the
@@ -482,8 +488,8 @@ class GcloudStorageCommandMixin(object):
       ValueError: If there is any issue with the mapping provided by
         GcloudStorageMap.
     """
-    return self._get_gcloud_storage_args(self.sub_opts, self.args,
-                                         self.gcloud_storage_map)
+    return self._get_gcloud_storage_args(
+        self.sub_opts, self.args, gcloud_storage_map or self.gcloud_storage_map)
 
   def _print_gcloud_storage_command_info(self,
                                          gcloud_command,


### PR DESCRIPTION
Removes custom shimming through global constants because they result in test flakes.