### PR TITLE
Allow custom storage class flag for PCU

### DIFF
--- a/gslib/tests/test_copy_helper_funcs.py
+++ b/gslib/tests/test_copy_helper_funcs.py
@@ -111,13 +111,13 @@ class TestCpFuncs(GsUtilUnitTestCase):
     self.assertEqual(50, component_size)
 
   def testFilterExistingComponentsNonVersioned(self):
-    """Tests upload with a variety of component states, including custom storage class."""
+    """Tests upload with a variety of component states."""
     mock_api = MockCloudApi()
     bucket_name = self.MakeTempName('bucket')
     tracker_file = self.CreateTempFile(file_name='foo', contents=b'asdf')
     tracker_file_lock = parallelism_framework_util.CreateLock()
 
-    # dst_obj_metadata used for passing content-type and storage-class.
+    # dst_obj_metadata used for passing content-type and storage class.
     content_type = 'ContentType'
     storage_class = 'StorageClass'
 
@@ -223,13 +223,13 @@ class TestCpFuncs(GsUtilUnitTestCase):
                      existing_objects_to_delete[0].url_string)
 
   def testFilterExistingComponentsVersioned(self):
-    """Tests upload with versionined parallel components and custom storage class."""
+    """Tests upload with versionined parallel components."""
 
     mock_api = MockCloudApi()
     bucket_name = self.MakeTempName('bucket')
     mock_api.MockCreateVersionedBucket(bucket_name)
 
-    # dst_obj_metadata used for passing content-type and storage-class.
+    # dst_obj_metadata used for passing content-type and storage class.
     content_type = 'ContentType'
     storage_class = 'StorageClass'
 

--- a/gslib/tests/test_copy_helper_funcs.py
+++ b/gslib/tests/test_copy_helper_funcs.py
@@ -111,14 +111,15 @@ class TestCpFuncs(GsUtilUnitTestCase):
     self.assertEqual(50, component_size)
 
   def testFilterExistingComponentsNonVersioned(self):
-    """Tests upload with a variety of component states."""
+    """Tests upload with a variety of component states, including custom storage class."""
     mock_api = MockCloudApi()
     bucket_name = self.MakeTempName('bucket')
     tracker_file = self.CreateTempFile(file_name='foo', contents=b'asdf')
     tracker_file_lock = parallelism_framework_util.CreateLock()
 
-    # dst_obj_metadata used for passing content-type.
-    empty_object = apitools_messages.Object()
+    # dst_obj_metadata used for passing content-type and storage-class.
+    content_type = 'ContentType'
+    storage_class = 'StorageClass'
 
     # Already uploaded, contents still match, component still used.
     fpath_uploaded_correctly = self.CreateTempFile(file_name='foo1',
@@ -138,8 +139,8 @@ class TestCpFuncs(GsUtilUnitTestCase):
 
     args_uploaded_correctly = PerformParallelUploadFileToObjectArgs(
         fpath_uploaded_correctly, 0, 1, fpath_uploaded_correctly_url,
-        object_uploaded_correctly_url, '', empty_object, tracker_file,
-        tracker_file_lock, None, False)
+        object_uploaded_correctly_url, '', content_type, storage_class,
+        tracker_file, tracker_file_lock, None, False)
 
     # Not yet uploaded, but needed.
     fpath_not_uploaded = self.CreateTempFile(file_name='foo2', contents=b'2')
@@ -148,7 +149,7 @@ class TestCpFuncs(GsUtilUnitTestCase):
         '%s://%s/%s' % (self.default_provider, bucket_name, fpath_not_uploaded))
     args_not_uploaded = PerformParallelUploadFileToObjectArgs(
         fpath_not_uploaded, 0, 1, fpath_not_uploaded_url,
-        object_not_uploaded_url, '', empty_object, tracker_file,
+        object_not_uploaded_url, '', content_type, storage_class, tracker_file,
         tracker_file_lock, None, False)
 
     # Already uploaded, but contents no longer match. Even though the contents
@@ -169,15 +170,16 @@ class TestCpFuncs(GsUtilUnitTestCase):
 
     args_wrong_contents = PerformParallelUploadFileToObjectArgs(
         fpath_wrong_contents, 0, 1, fpath_wrong_contents_url,
-        object_wrong_contents_url, '', empty_object, tracker_file,
-        tracker_file_lock, None, False)
+        object_wrong_contents_url, '', content_type, storage_class,
+        tracker_file, tracker_file_lock, None, False)
 
     # Exists in tracker file, but component object no longer exists.
     fpath_remote_deleted = self.CreateTempFile(file_name='foo5', contents=b'5')
     fpath_remote_deleted_url = StorageUrlFromString(str(fpath_remote_deleted))
     args_remote_deleted = PerformParallelUploadFileToObjectArgs(
         fpath_remote_deleted, 0, 1, fpath_remote_deleted_url, '', '',
-        empty_object, tracker_file, tracker_file_lock, None, False)
+        content_type, storage_class, tracker_file, tracker_file_lock, None,
+        False)
 
     # Exists in tracker file and already uploaded, but no longer needed.
     fpath_no_longer_used = self.CreateTempFile(file_name='foo6', contents=b'6')
@@ -221,14 +223,15 @@ class TestCpFuncs(GsUtilUnitTestCase):
                      existing_objects_to_delete[0].url_string)
 
   def testFilterExistingComponentsVersioned(self):
-    """Tests upload with versionined parallel components."""
+    """Tests upload with versionined parallel components and custom storage class."""
 
     mock_api = MockCloudApi()
     bucket_name = self.MakeTempName('bucket')
     mock_api.MockCreateVersionedBucket(bucket_name)
 
-    # dst_obj_metadata used for passing content-type.
-    empty_object = apitools_messages.Object()
+    # dst_obj_metadata used for passing content-type and storage-class.
+    content_type = 'ContentType'
+    storage_class = 'StorageClass'
 
     tracker_file = self.CreateTempFile(file_name='foo', contents=b'asdf')
     tracker_file_lock = parallelism_framework_util.CreateLock()
@@ -252,7 +255,8 @@ class TestCpFuncs(GsUtilUnitTestCase):
     args_uploaded_correctly = PerformParallelUploadFileToObjectArgs(
         fpath_uploaded_correctly, 0, 1, fpath_uploaded_correctly_url,
         object_uploaded_correctly_url, object_uploaded_correctly.generation,
-        empty_object, tracker_file, tracker_file_lock, None, False)
+        content_type, storage_class, tracker_file, tracker_file_lock, None,
+        False)
 
     # Duplicate object name in tracker file, but uploaded correctly.
     fpath_duplicate = fpath_uploaded_correctly
@@ -269,8 +273,8 @@ class TestCpFuncs(GsUtilUnitTestCase):
     args_duplicate = PerformParallelUploadFileToObjectArgs(
         fpath_duplicate, 0, 1, fpath_duplicate_url,
         duplicate_uploaded_correctly_url,
-        duplicate_uploaded_correctly.generation, empty_object, tracker_file,
-        tracker_file_lock, None, False)
+        duplicate_uploaded_correctly.generation, content_type, storage_class,
+        tracker_file, tracker_file_lock, None, False)
 
     # Already uploaded, but contents no longer match.
     fpath_wrong_contents = self.CreateTempFile(file_name='foo4', contents=b'4')
@@ -288,8 +292,8 @@ class TestCpFuncs(GsUtilUnitTestCase):
          object_wrong_contents.generation))
     args_wrong_contents = PerformParallelUploadFileToObjectArgs(
         fpath_wrong_contents, 0, 1, fpath_wrong_contents_url,
-        wrong_contents_url, '', empty_object, tracker_file, tracker_file_lock,
-        None, False)
+        wrong_contents_url, '', content_type, storage_class, tracker_file,
+        tracker_file_lock, None, False)
 
     dst_args = {
         fpath_uploaded_correctly: args_uploaded_correctly,

--- a/gslib/tests/test_cp.py
+++ b/gslib/tests/test_cp.py
@@ -3327,7 +3327,7 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
 
   @SkipForS3('No composite upload support for S3.')
   def test_nearline_applied_to_parallel_composite_upload(self):
-    bucket_uri = self.CreateBucket()
+    bucket_uri = self.CreateBucket(storage_class='standard')
     fpath = self.CreateTempFile(contents=b'abcd')
     obj_suri = suri(bucket_uri, 'composed')
 

--- a/gslib/tests/test_cp.py
+++ b/gslib/tests/test_cp.py
@@ -3338,7 +3338,7 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
       self.RunGsUtil(['cp', '-s', 'nearline', fpath, obj_suri])
     stdout = self.RunGsUtil(['ls', '-L', obj_suri], return_stdout=True)
     self.assertRegexpMatchesWithFlags(stdout,
-                                      r'Storage class:\s+NEARLINE',
+                                      r'Storage class:          NEARLINE',
                                       flags=re.IGNORECASE)
 
   # This temporarily changes the tracker directory to unwritable which

--- a/gslib/tests/test_web.py
+++ b/gslib/tests/test_web.py
@@ -84,7 +84,7 @@ class TestWeb(testcase.GsUtilIntegrationTestCase):
     if self._use_gcloud_storage:
       self.assertEquals('[]\n', stdout)
     else:
-      self.assertEquals(json.loads(stdout), WEBCFG_EMPTY)
+      self.assertIn(WEBCFG_EMPTY, stdout)
 
   def testTooFewArgumentsFails(self):
     """Ensures web commands fail with too few arguments."""

--- a/gslib/utils/copy_helper.py
+++ b/gslib/utils/copy_helper.py
@@ -331,7 +331,7 @@ def _PerformParallelUploadFileToObject(cls, args, thread_state=None):
     # reach a state in which uploads will always fail on retries.
     preconditions = None
 
-    # Fill in content type if one was provided.
+    # Fill in content type and storage class if one was provided.
     dst_object_metadata = apitools_messages.Object(
         name=args.dst_url.object_name,
         bucket=args.dst_url.bucket_name,
@@ -998,14 +998,14 @@ def CheckForDirFileConflict(exp_src_url, dst_url):
                            (exp_src_url.url_string, dst_path))
 
 
-def _PartitionFile(fp,
-                   file_size,
-                   src_url,
+def _PartitionFile(canned_acl,
                    content_type,
-                   storage_class,
-                   canned_acl,
                    dst_bucket_url,
+                   file_size,
+                   fp,
                    random_prefix,
+                   src_url,
+                   storage_class,
                    tracker_file,
                    tracker_file_lock,
                    encryption_key_sha256=None,
@@ -1018,15 +1018,15 @@ def _PartitionFile(fp,
   corresponding to each part.
 
   Args:
-    fp: The file object to be partitioned.
-    file_size: The size of fp, in bytes.
-    src_url: Source FileUrl from the original command.
-    content_type: content type for the component and final objects.
-    storage_class: storage class for the component and final objects.
     canned_acl: The user-provided canned_acl, if applicable.
+    content_type: content type for the component and final objects.
     dst_bucket_url: CloudUrl for the destination bucket.
+    file_size: The size of fp, in bytes.
+    fp: The file object to be partitioned.
     random_prefix: The randomly-generated prefix used to prevent collisions
                    among the temporary component names.
+    src_url: Source FileUrl from the original command.
+    storage_class: storage class for the component and final objects.
     tracker_file: The path to the parallel composite upload tracker file.
     tracker_file_lock: The lock protecting access to the tracker file.
     encryption_key_sha256: Encryption key SHA256 for use in this upload, if any.
@@ -1167,14 +1167,14 @@ def _DoParallelCompositeUpload(fp,
   # before and after the operation.
   components_info = {}
   # Get the set of all components that should be uploaded.
-  dst_args = _PartitionFile(fp,
-                            file_size,
-                            src_url,
+  dst_args = _PartitionFile(canned_acl,
                             dst_obj_metadata.contentType,
-                            dst_obj_metadata.storageClass,
-                            canned_acl,
                             dst_bucket_url,
+                            file_size,
+                            fp,
                             random_prefix,
+                            src_url,
+                            dst_obj_metadata.storageClass,
                             tracker_file_name,
                             tracker_file_lock,
                             encryption_key_sha256=encryption_key_sha256,

--- a/gslib/utils/copy_helper.py
+++ b/gslib/utils/copy_helper.py
@@ -237,7 +237,7 @@ UPLOAD_RETURN_FIELDS = [
 PerformParallelUploadFileToObjectArgs = namedtuple(
     'PerformParallelUploadFileToObjectArgs',
     'filename file_start file_length src_url dst_url canned_acl '
-    'content_type tracker_file tracker_file_lock encryption_key_sha256 '
+    'content_type storage_class tracker_file tracker_file_lock encryption_key_sha256 '
     'gzip_encoded')
 
 PerformSlicedDownloadObjectToFileArgs = namedtuple(
@@ -335,7 +335,8 @@ def _PerformParallelUploadFileToObject(cls, args, thread_state=None):
     dst_object_metadata = apitools_messages.Object(
         name=args.dst_url.object_name,
         bucket=args.dst_url.bucket_name,
-        contentType=args.content_type)
+        contentType=args.content_type,
+        storageClass=args.storage_class)
 
     orig_prefer_api = gsutil_api.prefer_api
     try:
@@ -1001,6 +1002,7 @@ def _PartitionFile(fp,
                    file_size,
                    src_url,
                    content_type,
+                   storage_class,
                    canned_acl,
                    dst_bucket_url,
                    random_prefix,
@@ -1020,6 +1022,7 @@ def _PartitionFile(fp,
     file_size: The size of fp, in bytes.
     src_url: Source FileUrl from the original command.
     content_type: content type for the component and final objects.
+    storage_class: storage class for the final object
     canned_acl: The user-provided canned_acl, if applicable.
     dst_bucket_url: CloudUrl for the destination bucket
     random_prefix: The randomly-generated prefix used to prevent collisions
@@ -1064,8 +1067,8 @@ def _PartitionFile(fp,
     offset = i * component_size
     func_args = PerformParallelUploadFileToObjectArgs(
         fp.name, offset, file_part_length, src_url, tmp_dst_url, canned_acl,
-        content_type, tracker_file, tracker_file_lock, encryption_key_sha256,
-        gzip_encoded)
+        content_type, storage_class, tracker_file, tracker_file_lock,
+        encryption_key_sha256, gzip_encoded)
     file_names.append(temp_file_name)
     dst_args[temp_file_name] = func_args
 
@@ -1168,6 +1171,7 @@ def _DoParallelCompositeUpload(fp,
                             file_size,
                             src_url,
                             dst_obj_metadata.contentType,
+                            dst_obj_metadata.storageClass,
                             canned_acl,
                             dst_bucket_url,
                             random_prefix,

--- a/gslib/utils/copy_helper.py
+++ b/gslib/utils/copy_helper.py
@@ -1022,9 +1022,9 @@ def _PartitionFile(fp,
     file_size: The size of fp, in bytes.
     src_url: Source FileUrl from the original command.
     content_type: content type for the component and final objects.
-    storage_class: storage class for the final object
+    storage_class: storage class for the component and final objects.
     canned_acl: The user-provided canned_acl, if applicable.
-    dst_bucket_url: CloudUrl for the destination bucket
+    dst_bucket_url: CloudUrl for the destination bucket.
     random_prefix: The randomly-generated prefix used to prevent collisions
                    among the temporary component names.
     tracker_file: The path to the parallel composite upload tracker file.


### PR DESCRIPTION
Before, chunks were being uploaded as the default storage class.
After, chunks are being uploaded as the custom storage class.