### PR TITLE
Add check for empty socket.error args

### DIFF
--- a/gslib/gcs_json_media.py
+++ b/gslib/gcs_json_media.py
@@ -583,7 +583,7 @@ class HttpWithNoRetries(httplib2.Http):
       raise
     except socket.error as e:
       err = 0
-      if hasattr(e, 'args'):
+      if hasattr(e, 'args') and getattr(e, 'args'):
         err = getattr(e, 'args')[0]
       else:
         err = e.errno


### PR DESCRIPTION
When doing a

```
gsutil cp myfile gs://mybucket/name
```

With a https_proxy that was limiting the number of concurrent sockets. I got a

```
socket.timeout: timed out

During handling of the above exception, another exception occurred:
...
socks.GeneralProxyError: Socket error: timed out

During handling of the above exception, another exception occurred:
...
~/Applications/google-cloud-sdk/platform/gsutil/gslib/gcs_json_media.py", line 587, in _conn_request
    err = getattr(e, 'args')[0]
```

It seems `socket.error` can have empty args. This PR adds a check.

[gsutil_IndexError_tuple_index_out_of_range.txt](https://github.com/GoogleCloudPlatform/gsutil/files/9456102/gsutil_IndexError_tuple_index_out_of_range.txt)