### PR TITLE
Update google auth dependency

### DIFF
--- a/gslib/tests/test_wrapped_credentials.py
+++ b/gslib/tests/test_wrapped_credentials.py
@@ -18,8 +18,10 @@ import datetime
 import json
 import httplib2
 
+from google.auth import aws
 from google.auth import external_account
 from google.auth import identity_pool
+from google.auth import pluggable
 from gslib.tests import testcase
 from gslib.utils.wrapped_credentials import WrappedCredentials
 import oauth2client
@@ -143,3 +145,84 @@ class TestWrappedCredentials(testcase.GsUtilUnitTestCase):
 
     self.assertIsInstance(creds, WrappedCredentials)
     self.assertIsInstance(creds._base, identity_pool.Credentials)
+
+  def testFromJsonAWSCredentials(self):
+    creds = WrappedCredentials.from_json(
+        json.dumps({
+            "_base": {
+                "audience":
+                    "//iam.googleapis.com/projects/123456/locations/global/workloadIdentityPools/POOL_ID/providers/PROVIDER_ID",
+                "credential_source": {
+                    "environment_id":
+                        "aws1",
+                    "region_url":
+                        "http://169.254.169.254/latest/meta-data/placement/availability-zone",
+                    "regional_cred_verification_url":
+                        "https://sts.{region}.amazonaws.com?Action=GetCallerIdentity&Version=2011-06-15",
+                    "url":
+                        "http://169.254.169.254/latest/meta-data/iam/security-credentials"
+                },
+                "service_account_impersonation_url":
+                    "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/service-1234@service-name.iam.gserviceaccount.com:generateAccessToken",
+                "subject_token_type":
+                    "urn:ietf:params:aws:token-type:aws4_request",
+                "token_url":
+                    "https://sts.googleapis.com/v1/token",
+                "type":
+                    "external_account"
+            }
+        }))
+
+    self.assertIsInstance(creds, WrappedCredentials)
+    self.assertIsInstance(creds._base, external_account.Credentials)
+    self.assertIsInstance(creds._base, aws.Credentials)
+
+  def testFromJsonFileBasedCredentials(self):
+    creds = WrappedCredentials.from_json(
+        json.dumps({
+            "_base": {
+                "audience":
+                    "//iam.googleapis.com/projects/123456/locations/global/workloadIdentityPools/POOL_ID/providers/PROVIDER_ID",
+                "credential_source": {
+                    "file": "/var/run/secrets/goog.id/token"
+                },
+                "service_account_impersonation_url":
+                    "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/service-1234@service-name.iam.gserviceaccount.com:generateAccessToken",
+                "subject_token_type":
+                    "urn:ietf:params:oauth:token-type:jwt",
+                "token_url":
+                    "https://sts.googleapis.com/v1/token",
+                "type":
+                    "external_account"
+            }
+        }))
+
+    self.assertIsInstance(creds, WrappedCredentials)
+    self.assertIsInstance(creds._base, external_account.Credentials)
+    self.assertIsInstance(creds._base, identity_pool.Credentials)
+
+  def testFromJsonPluggableCredentials(self):
+    creds = WrappedCredentials.from_json(
+        json.dumps({
+            "_base": {
+                "audience":
+                    "//iam.googleapis.com/projects/123456/locations/global/workloadIdentityPools/POOL_ID/providers/PROVIDER_ID",
+                "credential_source": {
+                    "executable": {
+                        "command": "/path/to/command.sh"
+                    }
+                },
+                "service_account_impersonation_url":
+                    "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/service-1234@service-name.iam.gserviceaccount.com:generateAccessToken",
+                "subject_token_type":
+                    "urn:ietf:params:oauth:token-type:jwt",
+                "token_url":
+                    "https://sts.googleapis.com/v1/token",
+                "type":
+                    "external_account"
+            }
+        }))
+
+    self.assertIsInstance(creds, WrappedCredentials)
+    self.assertIsInstance(creds._base, external_account.Credentials)
+    self.assertIsInstance(creds._base, pluggable.Credentials)

--- a/gslib/utils/wrapped_credentials.py
+++ b/gslib/utils/wrapped_credentials.py
@@ -153,7 +153,6 @@ def _get_external_account_credentials_from_info(info):
       return identity_pool.Credentials.from_info(info, scopes=DEFAULT_SCOPES)
   except (ValueError, TypeError, exceptions.RefreshError):
     return None
-  return creds
 
 
 def _get_external_account_credentials_from_file(filename):

--- a/gslib/utils/wrapped_credentials.py
+++ b/gslib/utils/wrapped_credentials.py
@@ -144,12 +144,14 @@ def _get_external_account_credentials_from_info(info):
   try:
     if info.get(
         'subject_token_type') == 'urn:ietf:params:aws:token-type:aws4_request':
-      # Check if configuration corresponds to an AWS credentials.
+      # Configuration corresponds to an AWS credentials.
       return aws.Credentials.from_info(info, scopes=DEFAULT_SCOPES)
     elif (info.get('credential_source') is not None and
           info.get('credential_source').get('executable') is not None):
+      # Configuration corresponds to pluggable credentials.
       return pluggable.Credentials.from_info(info, scopes=DEFAULT_SCOPES)
     else:
+      # Configuration corresponds to an identity pool credentials.
       return identity_pool.Credentials.from_info(info, scopes=DEFAULT_SCOPES)
   except (ValueError, TypeError, exceptions.RefreshError):
     return None


### PR DESCRIPTION
This allows executable-sourced external account credentials, and 
configurable token lifespans for service account impersonation