### PR TITLE
Backfill cl/471889749

### DIFF
--- a/gslib/addlhelp/creds.py
+++ b/gslib/addlhelp/creds.py
@@ -27,8 +27,7 @@ _DETAILED_HELP_TEXT = ("""
   well as the ability to `access public data anonymously
   <https://cloud.google.com/storage/docs/access-public-data>`_. Each of these
   type of credentials is discussed in more detail below, along with
-  information about configuring and using credentials via either the Cloud SDK
-  or standalone installations of gsutil.
+  information about configuring and using credentials via the Cloud SDK.
 
 
 <B>Configuring/Using Credentials via Cloud SDK Distribution of gsutil</B>
@@ -47,29 +46,6 @@ _DETAILED_HELP_TEXT = ("""
   environment variable). However, gsutil will still look for credentials in the
   boto config file if a type of non-GCS credential is needed that's not stored
   in the gcloud credential store (e.g., an HMAC credential for an S3 account).
-
-
-<B>Configuring/Using Credentials via Standalone gsutil Distribution</B>
-  If you installed a standalone distribution of gsutil (downloaded from
-  https://pub.storage.googleapis.com/gsutil.tar.gz,
-  https://pub.storage.googleapis.com/gsutil.zip, or PyPi), credentials are
-  configured using the gsutil config command, and are stored in the
-  user-editable boto config file (located at ~/.boto unless a different path is
-  specified in the BOTO_CONFIG environment). In this case if you want to set up
-  multiple credentials (e.g., one for an individual user account and a second
-  for a service account), you run gsutil config once for each credential, and
-  save each of the generated boto config files (e.g., renaming one to
-  ~/.boto_user_account and the second to ~/.boto_service_account), and you
-  switch between the credentials using the BOTO_CONFIG environment variable
-  (e.g., by running BOTO_CONFIG=~/.boto_user_account gsutil ls).
-
-  Note that when using the standalone version of gsutil with the JSON API you
-  can configure at most one of the following types of Google Cloud Storage
-  credentials in a single boto config file: OAuth2 User Account, OAuth2 Service
-  Account. In addition to these, you may also have S3 HMAC credentials
-  (necessary for using s3:// URLs) and Google Compute Engine Internal Service
-  Account credentials. Google Compute Engine Internal Service Account
-  credentials are used only when OAuth2 credentials are not present.
 
 
 <B>SUPPORTED CREDENTIAL TYPES</B>

--- a/gslib/addlhelp/security.py
+++ b/gslib/addlhelp/security.py
@@ -142,12 +142,10 @@ _DETAILED_HELP_TEXT = ("""
 
 
 <B>SOFTWARE INTEGRITY AND UPDATES</B>
-  gsutil is distributed as a standalone bundle via tar and zip files stored in
-  the gs://pub bucket, as a PyPi module, and as part of the bundled Cloud
-  SDK release. Each of these distribution methods takes a variety of security
-  precautions to protect the integrity of the software. We strongly recommend
-  against getting a copy of gsutil from any other sources (such as mirror
-  sites).
+  gsutil is distributed as a part of the bundled Cloud SDK release. This
+  distribution method takes a variety of security precautions to protect the
+  integrity of the software. We strongly recommend against getting a copy of
+  gsutil from any other sources (such as mirror sites).
 
 
 <B>PROXY USAGE</B>

--- a/gslib/commands/config.py
+++ b/gslib/commands/config.py
@@ -64,16 +64,16 @@ _DETAILED_HELP_TEXT = ("""
 
 
 <B>DESCRIPTION</B>
-  The ``gsutil config`` command applies to users who have installed gsutil as a
-  standalone tool. If you installed gsutil via the Cloud SDK, ``gsutil config``
-  fails unless you are specifically using the ``-a`` flag or have configured
-  gcloud to not pass its managed credentials to gsutil (via the command ``gcloud
-  config set pass_credentials_to_gsutil false``). For all other use cases, Cloud
-  SDK users should use the ``gcloud auth`` group of commands instead, which
-  configures OAuth2 credentials that gcloud implicitly passes to gsutil at
-  runtime. To check if you are using gsutil from the Cloud SDK or as a
-  stand-alone, use ``gsutil version -l`` and in the output look for "using cloud
-  sdk".
+  The ``gsutil config`` command applies to users who have legacy stand-alone
+  installations of gsutil. If you installed gsutil via the Cloud SDK, ``gsutil
+  config`` fails unless you are specifically using the ``-a`` flag or have
+  configured gcloud to not pass its managed credentials to gsutil (via the
+  command ``gcloud config set pass_credentials_to_gsutil false``). For all other
+  use cases, Cloud SDK users should use the ``gcloud auth`` group of commands
+  instead, which configures OAuth2 credentials that gcloud implicitly passes to
+  gsutil at runtime. To check if you are using gsutil from the Cloud SDK or as a
+  legacy stand-alone, use ``gsutil version -l`` and in the output look for
+  "using cloud sdk".
 
   The ``gsutil config`` command obtains access credentials for Google Cloud
   Storage and writes a `boto/gsutil configuration file
@@ -128,8 +128,9 @@ _DETAILED_HELP_TEXT = ("""
 
 <B>CONFIGURING SERVICE ACCOUNT CREDENTIALS</B>
   Service accounts are useful for authenticating on behalf of a service or
-  application (as opposed to a user). If you use gsutil as a standalone tool,
-  you configure credentials for service accounts using the ``-e`` option:
+  application (as opposed to a user). If you use gsutil as a legacy
+  stand-alone tool, you configure credentials for service accounts using the
+  ``-e`` option:
 
     gsutil config -e
 


### PR DESCRIPTION
Remove discussion of installing stand-alone versions of gsutil. In the config.py help doc, call stand-alone gsutil "legacy"