### PR TITLE
Fixed rsync -x test for Windows and updated docs to match

### DIFF
--- a/gslib/commands/rsync.py
+++ b/gslib/commands/rsync.py
@@ -513,7 +513,7 @@ _DETAILED_HELP_TEXT = ("""
                  path is always relative (similar to Unix rsync or tar exclude
                  options). For example, if you run the command:
 
-                   gsutil rsync -x "data./.*\\.txt$" dir gs://my-bucket
+                   gsutil rsync -x "data.[/\\\\].*\\.txt$" dir gs://my-bucket
 
                  it skips the file dir/data1/a.txt.
 
@@ -732,7 +732,7 @@ def _FieldedListingIterator(cls, gsutil_api, base_url_str, desc):
           'metadata/%s' % UID_ATTR,
       ])
     expanded_exclude_pattern = re.compile('{}/{}'.format(
-        base_url_str.rstrip('/\\'), cls.exclude_pattern.pattern
+        re.escape(base_url_str).rstrip('/\\'), cls.exclude_pattern.pattern
     )) if cls.exclude_pattern is not None else None
     iterator = CreateWildcardIterator(
         wildcard,

--- a/gslib/tests/test_rsync.py
+++ b/gslib/tests/test_rsync.py
@@ -2769,11 +2769,11 @@ class TestRsync(testcase.GsUtilIntegrationTestCase):
     @Retry(AssertionError, tries=3, timeout_secs=1)
     def _Check1():
       """Tests rsync skips the excluded pattern."""
+      regex = 'data.[/\\\\].*\\.txt$'
       # Add a trailing slash to the source directory to ensure its removed.
-      self.RunGsUtil([
-          'rsync', '-r', '-x', 'data./.*\\.txt$', tmpdir + '/',
-          suri(bucket_uri)
-      ])
+      local = tmpdir + ('\\' if IS_WINDOWS else '/')
+      self.RunGsUtil(['rsync', '-r', '-x', regex, local, suri(bucket_uri)])
+
       listing1 = TailSet(tmpdir, self.FlatListDir(tmpdir))
       listing2 = TailSet(suri(bucket_uri), self.FlatListBucket(bucket_uri))
       self.assertEquals(

--- a/gslib/tests/test_wildcard_iterator.py
+++ b/gslib/tests/test_wildcard_iterator.py
@@ -505,7 +505,7 @@ class FileIteratorTests(testcase.GsUtilUnitTestCase):
     """Tests that the exclude regex will omit a nested directory."""
     exp_uri_strs = self.root_files_uri_strs
     uri = self._test_storage_uri(suri(self.test_dir, '*'))
-    exclude_pattern = re.compile(suri(self.test_dir, 'dir1'))
+    exclude_pattern = re.compile(re.escape(suri(self.test_dir, 'dir1')))
     actual_uri_strs = set(
         str(u) for u in self._test_wildcard_iterator(
             uri, exclude_pattern=exclude_pattern).IterAll(


### PR DESCRIPTION
The test I edited tested a regex pattern that was in the docs, so I made sure the regex worked on both Windows and non-Windows systems.