### PR TITLE
Fix rsync -x test for windows

### DIFF
--- a/gslib/tests/test_rsync.py
+++ b/gslib/tests/test_rsync.py
@@ -2807,8 +2807,9 @@ class TestRsync(testcase.GsUtilIntegrationTestCase):
       stderr = _check_exclude_regex(
           'data3',
           set(['/a', '/b', '/c', '/data1/ok', '/data1/a.txt', '/data2/b.txt']))
-      self.assertIn('Skipping excluded directory {}...'.format(
-          os.path.join(tmpdir, 'data3'), stderr))
+      self.assertIn(
+          'Skipping excluded directory {}...'.format(
+              os.path.join(tmpdir, 'data3')), stderr)
       self.assertNotIn(
           'Skipping excluded directory {}...'.format(
               os.path.join(tmpdir, 'data3', 'data4')), stderr)

--- a/gslib/tests/test_rsync.py
+++ b/gslib/tests/test_rsync.py
@@ -2807,9 +2807,11 @@ class TestRsync(testcase.GsUtilIntegrationTestCase):
       stderr = _check_exclude_regex(
           'data3',
           set(['/a', '/b', '/c', '/data1/ok', '/data1/a.txt', '/data2/b.txt']))
-      self.assertIn('Skipping excluded directory %s/data3...' % tmpdir, stderr)
-      self.assertNotIn('Skipping excluded directory %s/data3/data4...' % tmpdir,
-                       stderr)
+      self.assertIn('Skipping excluded directory {}...'.format(
+          os.path.join(tmpdir, 'data3'), stderr))
+      self.assertNotIn(
+          'Skipping excluded directory {}...'.format(
+              os.path.join(tmpdir, 'data3', 'data4')), stderr)
 
     _Check3()
 


### PR DESCRIPTION
The test was failing on windows because of path separator mismatch.