### PR TITLE
Adding shim support for custom dual regions

### DIFF
--- a/gslib/commands/mb.py
+++ b/gslib/commands/mb.py
@@ -255,6 +255,8 @@ class MbCommand(Command):
                   'enforced': '--public-access-prevention',
                   'inherited': None,
               }),
+          '--placement':
+              GcloudStorageFlag('--placement'),
           _RETENTION_FLAG:
               GcloudStorageFlag('--retention-period'),
       },

--- a/gslib/tests/test_mb.py
+++ b/gslib/tests/test_mb.py
@@ -308,7 +308,7 @@ class TestMb(testcase.GsUtilIntegrationTestCase):
                                   suppress_consec_slashes=False)
     self.RunGsUtil(['mb', '-l', 'us-east1+us-east4', suri(bucket_uri)])
     stdout = self.RunGsUtil(['ls', '-Lb', suri(bucket_uri)], return_stdout=True)
-    self.assertRegex(stdout, r"locations:\t\t\[\'US-EAST1\', \'US-EAST4")
+    self.assertRegex(stdout, r"ocations:\s*\[\s*.US-EAST1.,\s*.US-EAST4")
 
   @SkipForXML('Custom Dual Region is not supported for the XML API.')
   @SkipForS3('Custom Dual Region is not supported for S3 buckets.')
@@ -332,8 +332,7 @@ class TestMb(testcase.GsUtilIntegrationTestCase):
         ['mb', '--placement', 'us-central1,us-west1',
          suri(bucket_uri)])
     stdout = self.RunGsUtil(['ls', '-Lb', suri(bucket_uri)], return_stdout=True)
-    self.assertRegex(stdout,
-                     r"Placement locations:\t\t\['US-CENTRAL1', 'US-WEST1'\]")
+    self.assertRegex(stdout, r"ocations:\s*\[\s*.US-CENTRAL1.,\s*.US-WEST1")
 
   @SkipForXML('The --placement flag only works for GCS JSON API.')
   def test_create_with_invalid_placement_flag_raises_error(self):
@@ -346,7 +345,7 @@ class TestMb(testcase.GsUtilIntegrationTestCase):
         return_stderr=True,
         expected_status=1)
     self.assertRegex(
-        stderr, r'.*BadRequestException: 400 (Invalid custom placement config|'
+        stderr, r'.*400.*(Invalid custom placement config|'
         r'One or more unrecognized regions in dual-region, received:'
         r' INVALID_REG1, INVALID_REG2).*')
 
@@ -356,14 +355,18 @@ class TestMb(testcase.GsUtilIntegrationTestCase):
     bucket_uri = boto.storage_uri('gs://%s' % (bucket_name.lower()),
                                   suppress_consec_slashes=False)
     # Location nam4 is used for dual-region.
+    expected_status = 2 if self._use_gcloud_storage else 1
     stderr = self.RunGsUtil(
         ['mb', '--placement', 'val1,val2,val3',
          suri(bucket_uri)],
         return_stderr=True,
-        expected_status=1)
-    self.assertIn(
-        'CommandException: Please specify two regions separated by comma'
-        ' without space. Specified: val1,val2,val3', stderr)
+        expected_status=expected_status)
+    if self._use_gcloud_storage:
+      self.assertIn('--placement: too many args', stderr)
+    else:
+      self.assertIn(
+          'CommandException: Please specify two regions separated by comma'
+          ' without space. Specified: val1,val2,val3', stderr)
 
   @SkipForJSON('Testing XML only behavior.')
   def test_single_json_only_flag_raises_error_with_xml_api(self):

--- a/gslib/tests/test_mb.py
+++ b/gslib/tests/test_mb.py
@@ -134,12 +134,7 @@ class TestMb(testcase.GsUtilIntegrationTestCase):
                              suri(bucket_uri)],
                             expected_status=1,
                             return_stderr=True)
-    if self._use_gcloud_storage:
-      # The "s" from "second" is cut b/c "s" is a valid unit.
-      self.assertIn("Duration unit 'econd' must be preceded by a number",
-                    stderr)
-    else:
-      self.assertRegexpMatches(stderr, r'Incorrect retention period specified')
+    self.assertRegexpMatches(stderr, r'Incorrect retention period specified')
 
   def test_create_with_retention_on_s3_urls_fails(self):
     bucket_name = self.MakeTempName('bucket')
@@ -185,8 +180,8 @@ class TestMb(testcase.GsUtilIntegrationTestCase):
                             expected_status=1,
                             return_stderr=True)
     if self._use_gcloud_storage:
-      self.assertIn('Flag value not in translation map for --pap: invalid_arg',
-                    stderr)
+      self.assertIn(
+          'Flag value not in translation map for "--pap": invalid_arg', stderr)
     else:
       self.assertRegexpMatches(stderr, r'invalid_arg is not a valid value')
 


### PR DESCRIPTION
The mb tests have been modified so that they pass with the shim turned on, and I also fixed a few tests not related to CDR.