### PR TITLE
ACL command shim fixes for test parity.

### DIFF
--- a/gslib/commands/acl.py
+++ b/gslib/commands/acl.py
@@ -23,6 +23,7 @@ import os
 
 from apitools.base.py import encoding
 from gslib import metrics
+from gslib import gcs_json_api
 from gslib.cloud_api import AccessDeniedException
 from gslib.cloud_api import BadRequestException
 from gslib.cloud_api import PreconditionException
@@ -297,6 +298,7 @@ _get_help_text = CreateHelpText(_GET_SYNOPSIS, _GET_DESCRIPTION)
 _set_help_text = CreateHelpText(_SET_SYNOPSIS, _SET_DESCRIPTION)
 _ch_help_text = CreateHelpText(_CH_SYNOPSIS, _CH_DESCRIPTION)
 
+
 def _ApplyExceptionHandler(cls, exception):
   cls.logger.error('Encountered a problem: %s', exception)
   cls.everything_set_okay = False
@@ -360,10 +362,19 @@ class AclCommand(Command):
     elif sub_command == 'set':
       # Flags must be at the start of self.args to get parsed.
       self.ParseSubOpts()
-      if os.path.isfile(self.args[0]):
-        acl_flag = '--acl-file=' + self.args.pop(0)
-      else:  # Assume the string represents a predefined (canned) ACL.
-        acl_flag = '--predefined-acl=' + self.args.pop(0)
+      acl_file_or_predefined_acl = self.args.pop(0)
+      if os.path.isfile(acl_file_or_predefined_acl):
+        acl_flag = '--acl-file=' + acl_file_or_predefined_acl
+      else:
+        if acl_file_or_predefined_acl in (
+            gcs_json_api.FULL_PREDEFINED_ACL_XML_TO_JSON_TRANSLATION):
+          predefined_acl = (
+              gcs_json_api.FULL_PREDEFINED_ACL_XML_TO_JSON_TRANSLATION[
+                  acl_file_or_predefined_acl])
+        else:
+          predefined_acl = acl_file_or_predefined_acl
+        acl_flag = '--predefined-acl=' + predefined_acl
+
       object_or_bucket_urls = [StorageUrlFromString(i) for i in self.args]
       recurse = False
       for (flag_key, _) in self.sub_opts:

--- a/gslib/gcs_json_api.py
+++ b/gslib/gcs_json_api.py
@@ -159,6 +159,27 @@ _ACL_FIELDS_SET = set([
     'items/owner',
     'owner',
 ])
+_BUCKET_PREDEFINED_ACL_XML_TO_JSON_TRANSLATION = {
+    None: None,
+    'authenticated-read': 'authenticatedRead',
+    'private': 'private',
+    'project-private': 'projectPrivate',
+    'public-read': 'publicRead',
+    'public-read-write': 'publicReadWrite'
+}
+_OBJECT_PREDEFINED_ACL_XML_TO_JSON_TRANSLATION = {
+    None: None,
+    'authenticated-read': 'authenticatedRead',
+    'bucket-owner-read': 'bucketOwnerRead',
+    'bucket-owner-full-control': 'bucketOwnerFullControl',
+    'private': 'private',
+    'project-private': 'projectPrivate',
+    'public-read': 'publicRead'
+}
+FULL_PREDEFINED_ACL_XML_TO_JSON_TRANSLATION = _BUCKET_PREDEFINED_ACL_XML_TO_JSON_TRANSLATION.copy(
+)
+FULL_PREDEFINED_ACL_XML_TO_JSON_TRANSLATION.update(
+    _OBJECT_PREDEFINED_ACL_XML_TO_JSON_TRANSLATION)
 
 # Fields that may be encrypted.
 _ENCRYPTED_HASHES_SET = set(['crc32c', 'md5Hash'])
@@ -2183,17 +2204,8 @@ class GcsJsonApi(CloudApi):
       corresponds to a flavor of *PredefinedAclValueValuesEnum and can be
       used as input to apitools requests that affect bucket access controls.
     """
-    # XML : JSON
-    translation_dict = {
-        None: None,
-        'authenticated-read': 'authenticatedRead',
-        'private': 'private',
-        'project-private': 'projectPrivate',
-        'public-read': 'publicRead',
-        'public-read-write': 'publicReadWrite'
-    }
-    if canned_acl_string in translation_dict:
-      return translation_dict[canned_acl_string]
+    if canned_acl_string in _BUCKET_PREDEFINED_ACL_XML_TO_JSON_TRANSLATION:
+      return _BUCKET_PREDEFINED_ACL_XML_TO_JSON_TRANSLATION[canned_acl_string]
     raise ArgumentException('Invalid canned ACL %s' % canned_acl_string)
 
   def _ObjectCannedAclToPredefinedAcl(self, canned_acl_string):
@@ -2207,18 +2219,8 @@ class GcsJsonApi(CloudApi):
       corresponds to a flavor of *PredefinedAclValueValuesEnum and can be
       used as input to apitools requests that affect object access controls.
     """
-    # XML : JSON
-    translation_dict = {
-        None: None,
-        'authenticated-read': 'authenticatedRead',
-        'bucket-owner-read': 'bucketOwnerRead',
-        'bucket-owner-full-control': 'bucketOwnerFullControl',
-        'private': 'private',
-        'project-private': 'projectPrivate',
-        'public-read': 'publicRead'
-    }
-    if canned_acl_string in translation_dict:
-      return translation_dict[canned_acl_string]
+    if canned_acl_string in _OBJECT_PREDEFINED_ACL_XML_TO_JSON_TRANSLATION:
+      return _OBJECT_PREDEFINED_ACL_XML_TO_JSON_TRANSLATION[canned_acl_string]
     raise ArgumentException('Invalid canned ACL %s' % canned_acl_string)
 
   def _ValidateHttpAccessTokenRefreshError(self, e):

--- a/gslib/tests/test_storage_url.py
+++ b/gslib/tests/test_storage_url.py
@@ -140,30 +140,34 @@ class TestStorageUrl(base.GsUtilTestCase):
   def test_urls_raise_error_if_bucket_followed_by_object(self):
     urls = list(map(storage_url.StorageUrlFromString, ['gs://b1', 'gs://b/o']))
     with self.assertRaisesRegex(
-            CommandException,
-            'Cannot operate on a mix of buckets and objects.'):
-      storage_url.RaiseErrorIfUrlsAreMixOfBucketsAndObjects(urls, recursion_requested=False)
+        CommandException, 'Cannot operate on a mix of buckets and objects.'):
+      storage_url.RaiseErrorIfUrlsAreMixOfBucketsAndObjects(
+          urls, recursion_requested=False)
 
   def test_urls_raise_error_if_object_followed_by_bucket(self):
     urls = list(map(storage_url.StorageUrlFromString, ['gs://b/o', 'gs://b']))
     with self.assertRaisesRegex(
-            CommandException,
-            'Cannot operate on a mix of buckets and objects.'):
-      storage_url.RaiseErrorIfUrlsAreMixOfBucketsAndObjects(urls, recursion_requested=False)
+        CommandException, 'Cannot operate on a mix of buckets and objects.'):
+      storage_url.RaiseErrorIfUrlsAreMixOfBucketsAndObjects(
+          urls, recursion_requested=False)
 
   def test_accepts_mix_of_objects_and_buckets_if_recursion_requested(self):
     # No error raised.
     urls = list(map(storage_url.StorageUrlFromString, ['gs://b1', 'gs://b/o']))
-    storage_url.RaiseErrorIfUrlsAreMixOfBucketsAndObjects(urls, recursion_requested=True)
+    storage_url.RaiseErrorIfUrlsAreMixOfBucketsAndObjects(
+        urls, recursion_requested=True)
 
   def test_not_raising_error_if_multiple_objects_without_recursion(self):
     urls = list(map(storage_url.StorageUrlFromString, ['gs://b/o', 'gs://b/p']))
-    storage_url.RaiseErrorIfUrlsAreMixOfBucketsAndObjects(urls, recursion_requested=False)
-  
+    storage_url.RaiseErrorIfUrlsAreMixOfBucketsAndObjects(
+        urls, recursion_requested=False)
+
   def test_not_raising_error_if_multiple_buckets_with_recursion(self):
     urls = list(map(storage_url.StorageUrlFromString, ['gs://b/o', 'gs://b/p']))
-    storage_url.RaiseErrorIfUrlsAreMixOfBucketsAndObjects(urls, recursion_requested=True)
-  
+    storage_url.RaiseErrorIfUrlsAreMixOfBucketsAndObjects(
+        urls, recursion_requested=True)
+
   def test_not_raising_error_if_multiple_objects_with_recursion(self):
     urls = list(map(storage_url.StorageUrlFromString, ['gs://b/o', 'gs://b/p']))
-    storage_url.RaiseErrorIfUrlsAreMixOfBucketsAndObjects(urls, recursion_requested=True)
+    storage_url.RaiseErrorIfUrlsAreMixOfBucketsAndObjects(
+        urls, recursion_requested=True)


### PR DESCRIPTION
Running tests via gcloud storage revealed a few issues.

These are all the fixes I could make without stripping the extra ACL object fields gcloud storage displays. Mostly just translating XML to JSON predefined ACLs.

Lots of lines edited by the yapf formatter.