### PR TITLE
Handle reauth challenges gracefully in transfer commands.

### DIFF
--- a/gslib/commands/cp.py
+++ b/gslib/commands/cp.py
@@ -1108,8 +1108,7 @@ class CpCommand(Command):
     )
 
     copy_helper.TriggerReauthForDestinationProviderIfNecessary(
-        dst_url, StorageUrlFromString(src_url_strs[0][0]), self.gsutil_api,
-        self.parallel_operations)
+        dst_url, self.gsutil_api, self.parallel_operations)
 
     seek_ahead_iterator = None
     # Cannot seek ahead with stdin args, since we can only iterate them

--- a/gslib/commands/cp.py
+++ b/gslib/commands/cp.py
@@ -1107,6 +1107,9 @@ class CpCommand(Command):
         copy_helper_opts.daisy_chain,
     )
 
+    copy_helper.TriggerReauthForDestinationProviderIfNecessary(
+        self.gsutil_api, dst_url)
+
     seek_ahead_iterator = None
     # Cannot seek ahead with stdin args, since we can only iterate them
     # once without buffering in memory.

--- a/gslib/commands/cp.py
+++ b/gslib/commands/cp.py
@@ -1108,7 +1108,7 @@ class CpCommand(Command):
     )
 
     copy_helper.TriggerReauthForDestinationProviderIfNecessary(
-        self.gsutil_api, dst_url)
+        self.gsutil_api, dst_url, self.parallel_operations)
 
     seek_ahead_iterator = None
     # Cannot seek ahead with stdin args, since we can only iterate them

--- a/gslib/commands/cp.py
+++ b/gslib/commands/cp.py
@@ -1108,7 +1108,8 @@ class CpCommand(Command):
     )
 
     copy_helper.TriggerReauthForDestinationProviderIfNecessary(
-        self.gsutil_api, dst_url, self.parallel_operations)
+        dst_url, StorageUrlFromString(src_url_strs[0][0]), self.gsutil_api,
+        self.parallel_operations)
 
     seek_ahead_iterator = None
     # Cannot seek ahead with stdin args, since we can only iterate them

--- a/gslib/commands/rsync.py
+++ b/gslib/commands/rsync.py
@@ -1698,7 +1698,6 @@ class RsyncCommand(Command):
 
     copy_helper.TriggerReauthForDestinationProviderIfNecessary(
         dst_url,
-        src_url,
         self.gsutil_api,
         parallelism_requested=True,  # rsync uses parallel_operations_override.
     )

--- a/gslib/commands/rsync.py
+++ b/gslib/commands/rsync.py
@@ -1697,7 +1697,10 @@ class RsyncCommand(Command):
       RegisterSignalHandler(signal_num, _HandleSignals)
 
     copy_helper.TriggerReauthForDestinationProviderIfNecessary(
-        self.gsutil_api, dst_url)
+        self.gsutil_api,
+        dst_url,
+        parallelism_requested=True,  # rsync uses parallel_operations_override.
+    )
 
     # Perform sync requests in parallel (-m) mode, if requested, using
     # configured number of parallel processes and threads. Otherwise,

--- a/gslib/commands/rsync.py
+++ b/gslib/commands/rsync.py
@@ -1697,8 +1697,9 @@ class RsyncCommand(Command):
       RegisterSignalHandler(signal_num, _HandleSignals)
 
     copy_helper.TriggerReauthForDestinationProviderIfNecessary(
-        self.gsutil_api,
         dst_url,
+        src_url,
+        self.gsutil_api,
         parallelism_requested=True,  # rsync uses parallel_operations_override.
     )
 

--- a/gslib/commands/rsync.py
+++ b/gslib/commands/rsync.py
@@ -1696,6 +1696,9 @@ class RsyncCommand(Command):
     for signal_num in GetCaughtSignals():
       RegisterSignalHandler(signal_num, _HandleSignals)
 
+    copy_helper.TriggerReauthForDestinationProviderIfNecessary(
+        self.gsutil_api, dst_url)
+
     # Perform sync requests in parallel (-m) mode, if requested, using
     # configured number of parallel processes and threads. Otherwise,
     # perform requests with sequential function calls in current process.

--- a/gslib/tests/test_cp.py
+++ b/gslib/tests/test_cp.py
@@ -4994,3 +4994,15 @@ class TestCpUnitTests(testcase.GsUtilUnitTestCase):
     obj.metadata = CreateCustomMetadata(entries={UID_ATTR: USER_ID})
     ParseAndSetPOSIXAttributes(fpath, obj, False, True)
     mock_chown.assert_not_called()
+
+  @mock.patch(
+      'gslib.utils.copy_helper.TriggerReauthForDestinationProviderIfNecessary')
+  def test_cp_triggers_reauth(self, mock_trigger_reauth):
+    path = self.CreateTempFile(file_name=('foo'))
+    bucket_uri = self.CreateBucket()
+    self.RunCommand('cp', [path, suri(bucket_uri)])
+    mock_trigger_reauth.assert_called_once_with(
+        StorageUrlFromString(suri(bucket_uri)),
+        mock.ANY,  # Gsutil API.
+        False,  # Parallelism requested.
+    )

--- a/gslib/utils/copy_helper.py
+++ b/gslib/utils/copy_helper.py
@@ -1525,8 +1525,10 @@ def TriggerReauthForDestinationProviderIfNecessary(destination_url, gsutil_api,
     return
 
   # The specific API call is not important, but one must occur.
-  gsutil_api.GetBucket(destination_url.bucket_name,
-                       provider=destination_url.scheme)
+  gsutil_api.GetBucket(
+      destination_url.bucket_name,
+      fields=['location'],  # Single field to limit XML API calls.
+      provider=destination_url.scheme)
 
 
 def FixWindowsNaming(src_url, dst_url):

--- a/gslib/utils/copy_helper.py
+++ b/gslib/utils/copy_helper.py
@@ -1486,8 +1486,7 @@ def ExpandUrlToSingleBlr(url_str,
   return (storage_url, treat_nonexistent_object_as_subdir)
 
 
-def TriggerReauthForDestinationProviderIfNecessary(destination_url,
-                                                   first_source_url, gsutil_api,
+def TriggerReauthForDestinationProviderIfNecessary(destination_url, gsutil_api,
                                                    parallelism_requested):
   """Makes a request to the destination API provider to trigger reauth.
 
@@ -1506,7 +1505,6 @@ def TriggerReauthForDestinationProviderIfNecessary(destination_url,
 
   Args:
     destination_url (StorageUrl): The destination of the transfer.
-    first_source_url (StorageUrl): The first source of the transfer.
     gsutil_api (CloudApiDelegator): API to use for the GetBucket call.
     parallelism_requested (bool): True if the -m flag is provided, or
       the transfer command uses a parallel override.
@@ -1516,12 +1514,6 @@ def TriggerReauthForDestinationProviderIfNecessary(destination_url,
   """
   # Reauth is not necessary for non-cloud destinations.
   if not destination_url.IsCloudUrl():
-    return
-
-  # Source URLs are expanded in the main process, so we already interact
-  # with the relevant provider if its scheme is the same as the destination
-  # URL's.
-  if first_source_url.scheme == destination_url.scheme:
     return
 
   # Destination wildcards are expanded by an API call in the main process.


### PR DESCRIPTION
Should address #1639 by performing at least one API call in the main process. 

Some uploads do not interact with the destination API until the transfer call itself, which must happen in child processes if parallelism is enabled. For users with reauth enabled, this results in a poor experience, since reauth challenges cannot be answered if they're triggered in child processes. This PR adds an API call in the main process to trigger the reauth flow for those users.