### PR TITLE
fix e2e rpo set test for s3

### DIFF
--- a/gslib/tests/test_rpo.py
+++ b/gslib/tests/test_rpo.py
@@ -223,10 +223,16 @@ class TestRpoE2E(testcase.GsUtilIntegrationTestCase):
   def test_s3_fails_for_set(self):
     bucket_uri = self.CreateBucket()
     stderr = self.RunGsUtil(
-        ['rpo', 'set', 'default', suri(bucket_uri)],
+        ['rpo', 'set', 'DEFAULT', suri(bucket_uri)],
         return_stderr=True,
         expected_status=1)
-    self.assertIn('command can only be used for GCS buckets', stderr)
+
+    if self._use_gcloud_storage:
+      self.assertIn(
+          'Features disallowed for S3: Setting Recovery Point Objective',
+          stderr)
+    else:
+      self.assertIn('command can only be used for GCS buckets', stderr)
 
   @SkipForGS('Testing S3 only behavior.')
   def test_s3_fails_for_get(self):


### PR DESCRIPTION
- Fix test_s3_fails_for_set test when it is running with shim mode enabled