### PR TITLE
Adding a warning about the deprecation of the OAuth2 flow.

### DIFF
--- a/gslib/commands/config.py
+++ b/gslib/commands/config.py
@@ -874,6 +874,17 @@ class ConfigCommand(Command):
                                                ' ')
         self._CheckPrivateKeyFilePermissions(gs_service_key_file)
       elif cred_type == CredTypes.OAUTH2_USER_ACCOUNT:
+        if not system_util.InvokedViaCloudSdk():
+          sys.stdout.write(
+              '\n********************************************************\n' +
+              textwrap.fill(
+                  "WARNING: The following authentication flow will fail on "
+                  "or after Febuary 1 2023. Tokens generated before this date "
+                  "will continue to work. To authenticate with your user "
+                  "account after this date, install gsutil via Cloud SDK and "
+                  "run \"gcloud auth login\"",
+                  width=55) +
+              '\n********************************************************\n\n')
         oauth2_client = oauth2_helper.OAuth2ClientFromBotoConfig(
             boto.config, cred_type)
         try:


### PR DESCRIPTION
Here's what the new OAuth2 flow will look like:
```
$ gsutil config
This command will create a boto config file at
/home/thomasmaclean/.boto containing your credentials, based on your
responses to the following questions.

********************************************************
WARNING: The following authentication flow will fail on
or after Febuary 1 2023. Tokens generated before this
date will continue to work. To authenticate with your
user after this date, install gsutil via Cloud SDK and
run "gcloud auth login"
********************************************************

Please navigate your browser to the following URL:
https://accounts.google.com/o/oauth2/auth...
In your browser you should see a page that requests you to authorize access to Google Cloud Platform APIs and Services on your behalf. After you approve, an authorization code will be displayed.

Enter the authorization code:
```