### PR TITLE
Fix rpo get shimming command

### DIFF
--- a/gslib/commands/rpo.py
+++ b/gslib/commands/rpo.py
@@ -83,7 +83,7 @@ _get_help_text = CreateHelpText(_GET_SYNOPSIS, _GET_DESCRIPTION)
 
 GET_COMMAND = GcloudStorageMap(gcloud_command=[
     'storage', 'buckets', 'list',
-    '--format=value[separator=": "](name.sub("^", "gs://"),'
+    '--format=value[separator=": "](format("gs://{}", name),'
     'rpo.yesno(no="None"))'
 ],
                                flag_map={})

--- a/gslib/tests/test_rpo.py
+++ b/gslib/tests/test_rpo.py
@@ -244,9 +244,7 @@ class TestRpoE2E(testcase.GsUtilIntegrationTestCase):
         return_stdout=True,
         expected_status=expected_status)
     if self._use_gcloud_storage:
-      # TODO gcloud storage buckets list command doesn't raise an error when a
-      # s3 bucket is listed, instead it prints out "gs://None: None",
-      # this is an edge case.
+      # TODO(b/265304295)
       self.assertIn('gs://None: None', stdout)
     else:
       self.assertIn('command can only be used for GCS buckets', stderr)


### PR DESCRIPTION
There is a failing test for rpo command:  [test](https://github.com/GoogleCloudPlatform/gsutil/blob/a238e7e3500461dcd8ab15fcb6e7523a2b0f1e51/gslib/tests/test_rpo.py#L238)

The problem is that the [shimming_command_for_rpo_get](https://github.com/GoogleCloudPlatform/gsutil/blob/a238e7e3500461dcd8ab15fcb6e7523a2b0f1e51/gslib/commands/rpo.py#L86) crashes when an s3 bucket is passed due to `sub`  [transform_function](https://cloud.google.com/sdk/gcloud/reference/topic/projections) is expecting a string value, but instead is getting a `None` value, this PR fixes this issue by replacing the `sub` function for the `format` function