### PR TITLE
Add --raw flag to shim commands calling "describe" or "list".

### DIFF
--- a/gslib/commands/acl.py
+++ b/gslib/commands/acl.py
@@ -355,7 +355,7 @@ class AclCommand(Command):
         command_group = 'buckets'
       gcloud_storage_map = GcloudStorageMap(gcloud_command=[
           'alpha', 'storage', command_group, 'describe',
-          '--format=multi(acl:format=json)'
+          '--format=multi(acl:format=json)', '--raw'
       ],
                                             flag_map={})
 

--- a/gslib/commands/autoclass.py
+++ b/gslib/commands/autoclass.py
@@ -52,9 +52,9 @@ _GET_DESCRIPTION = """
 <B>GET</B>
   The ``get`` sub-command gets the current Autoclass configuration for a
   bucket. The returned configuration has the following fields:
-  
+
   ``enabled``: a boolean field indicating whether the feature is on or off.
-     
+
   ``toggleTime``: a timestamp indicating when the enabled field was set.
 """
 
@@ -118,7 +118,7 @@ class AutoclassCommand(Command):
               GcloudStorageMap(
                   gcloud_command=[
                       'alpha', 'storage', 'buckets', 'list',
-                      GCLOUD_FORMAT_STRING
+                      GCLOUD_FORMAT_STRING, '--raw'
                   ],
                   flag_map={},
                   supports_output_translation=True,

--- a/gslib/commands/cors.py
+++ b/gslib/commands/cors.py
@@ -147,7 +147,7 @@ class CorsCommand(Command):
               GcloudStorageMap(
                   gcloud_command=[
                       'alpha', 'storage', 'buckets', 'describe',
-                      '--format=multi(cors:format=json)'
+                      '--format=multi(cors:format=json)', '--raw'
                   ],
                   flag_map={},
               ),

--- a/gslib/commands/defacl.py
+++ b/gslib/commands/defacl.py
@@ -201,7 +201,7 @@ class DefAclCommand(Command):
       gcloud_storage_map = GcloudStorageMap(
           gcloud_command=[
               'storage', 'buckets', 'describe',
-              '--format=multi(defaultObjectAcl:format=json)'
+              '--format=multi(defaultObjectAcl:format=json)', '--raw'
           ],
           flag_map={},
       )

--- a/gslib/commands/defstorageclass.py
+++ b/gslib/commands/defstorageclass.py
@@ -80,7 +80,8 @@ SHIM_GET_COMMAND_MAP = GcloudStorageMap(
         # The url_string for buckets ends with a slash.
         # Substitute the last slash with a colon.
         '--format=value[separator=\": \"](name.sub("^", "gs://"),'
-        'storageClass)'
+        'storageClass)',
+        '--raw'
     ],
     flag_map={},
 )

--- a/gslib/commands/kms.py
+++ b/gslib/commands/kms.py
@@ -246,6 +246,7 @@ class KmsCommand(Command):
             'describe',
             ('--format=value[separator=\": \"](name, encryption'
              '.defaultKmsKeyName.yesno(no="No default encryption key."))'),
+            '--raw'
         ]
     else:
       gcloud_storage_map = KmsCommand.gcloud_storage_map

--- a/gslib/commands/label.py
+++ b/gslib/commands/label.py
@@ -184,7 +184,7 @@ class LabelCommand(Command):
           GcloudStorageMap(
               gcloud_command=[
                   'alpha', 'storage', 'buckets', 'describe',
-                  '--format=multi(labels:format=json)'
+                  '--format=multi(labels:format=json)', '--raw'
               ],
               flag_map={},
           ),

--- a/gslib/commands/lifecycle.py
+++ b/gslib/commands/lifecycle.py
@@ -165,7 +165,7 @@ class LifecycleCommand(Command):
                   GcloudStorageMap(
                       gcloud_command=[
                           'alpha', 'storage', 'buckets', 'describe',
-                          '--format=multi(lifecycle:format=json)'
+                          '--format=multi(lifecycle:format=json)', '--raw'
                       ],
                       flag_map={},
                   ),

--- a/gslib/commands/logging.py
+++ b/gslib/commands/logging.py
@@ -176,7 +176,7 @@ class LoggingCommand(Command):
               GcloudStorageMap(
                   gcloud_command=[
                       'alpha', 'storage', 'buckets', 'list',
-                      '--format=multi(logging:format=json)'
+                      '--format=multi(logging:format=json)', '--raw'
                   ],
                   flag_map={},
               ),

--- a/gslib/commands/notification.py
+++ b/gslib/commands/notification.py
@@ -511,7 +511,7 @@ class NotificationCommand(Command):
               GcloudStorageMap(
                   gcloud_command=[
                       'alpha', 'storage', 'buckets', 'notifications', 'list',
-                      _GCLOUD_LIST_FORMAT
+                      _GCLOUD_LIST_FORMAT, '--raw'
                   ],
                   flag_map={},
                   supports_output_translation=True,

--- a/gslib/commands/pap.py
+++ b/gslib/commands/pap.py
@@ -128,7 +128,8 @@ class PapCommand(Command):
           'get':
               GcloudStorageMap(
                   gcloud_command=[
-                      'alpha', 'storage', 'buckets', 'list', _GCLOUD_LIST_FORMAT
+                      'alpha', 'storage', 'buckets', 'list',
+                      _GCLOUD_LIST_FORMAT, '--raw'
                   ],
                   flag_map={},
                   supports_output_translation=True,

--- a/gslib/commands/retention.py
+++ b/gslib/commands/retention.py
@@ -400,7 +400,7 @@ class RetentionCommand(Command):
               'get':
                   GcloudStorageMap(gcloud_command=[
                       'alpha', 'storage', 'buckets', 'describe',
-                      '--format=yaml(retentionPolicy)'
+                      '--format=yaml(retentionPolicy)', '--raw'
                   ],
                                    flag_map={}),
               'lock':

--- a/gslib/commands/rpo.py
+++ b/gslib/commands/rpo.py
@@ -84,7 +84,7 @@ _get_help_text = CreateHelpText(_GET_SYNOPSIS, _GET_DESCRIPTION)
 GET_COMMAND = GcloudStorageMap(gcloud_command=[
     'storage', 'buckets', 'list',
     '--format=value[separator=": "](format("gs://{}", name),'
-    'rpo.yesno(no="None"))'
+    'rpo.yesno(no="None"))', '--raw'
 ],
                                flag_map={})
 

--- a/gslib/commands/ubla.py
+++ b/gslib/commands/ubla.py
@@ -135,7 +135,7 @@ class UblaCommand(Command):
               GcloudStorageMap(
                   gcloud_command=[
                       'alpha', 'storage', 'buckets', 'list',
-                      GCLOUD_FORMAT_STRING
+                      GCLOUD_FORMAT_STRING, '--raw'
                   ],
                   flag_map={},
               ),

--- a/gslib/commands/versioning.py
+++ b/gslib/commands/versioning.py
@@ -120,7 +120,7 @@ class VersioningCommand(Command):
                       'name'
                       '.sub("^", "gs://").sub("$", ": "),'
                       'versioning.enabled'
-                      '.yesno("Enabled", "Suspended"))'
+                      '.yesno("Enabled", "Suspended"))', '--raw'
                   ],
                   flag_map={},
                   supports_output_translation=True,

--- a/gslib/commands/web.py
+++ b/gslib/commands/web.py
@@ -162,7 +162,7 @@ class WebCommand(Command):
               GcloudStorageMap(
                   gcloud_command=[
                       'alpha', 'storage', 'buckets', 'describe',
-                      '--format=multi(website:format=json)'
+                      '--format=multi(website:format=json)', '--raw'
                   ],
                   flag_map={},
                   supports_output_translation=True,

--- a/gslib/tests/test_acl.py
+++ b/gslib/tests/test_acl.py
@@ -806,7 +806,8 @@ class TestAclShim(testcase.GsUtilUnitTestCase):
         info_lines = '\n'.join(mock_log_handler.messages['info'])
         self.assertIn(
             ('Gcloud Storage Command: {} alpha storage objects describe'
-             ' --format=multi(acl:format=json) gs://bucket/object').format(
+             ' --format=multi(acl:format=json)'
+             ' --raw gs://bucket/object').format(
                  os.path.join('fake_dir', 'bin', 'gcloud')), info_lines)
 
   @mock.patch.object(acl.AclCommand, 'RunCommand', new=mock.Mock())
@@ -822,7 +823,8 @@ class TestAclShim(testcase.GsUtilUnitTestCase):
         info_lines = '\n'.join(mock_log_handler.messages['info'])
         self.assertIn(
             ('Gcloud Storage Command: {} alpha storage buckets describe'
-             ' --format=multi(acl:format=json) gs://bucket').format(
+             ' --format=multi(acl:format=json)'
+             ' --raw gs://bucket').format(
                  os.path.join('fake_dir', 'bin', 'gcloud')), info_lines)
 
   @mock.patch.object(acl.AclCommand, 'RunCommand', new=mock.Mock())

--- a/gslib/tests/test_defacl.py
+++ b/gslib/tests/test_defacl.py
@@ -241,10 +241,11 @@ class TestDefaclShim(case.GsUtilUnitTestCase):
         mock_log_handler = self.RunCommand('defacl', ['get', 'gs://bucket'],
                                            return_log_handler=True)
         info_lines = '\n'.join(mock_log_handler.messages['info'])
-        self.assertIn((
-            'Gcloud Storage Command: {} storage buckets describe'
-            ' --format=multi(defaultObjectAcl:format=json) gs://bucket').format(
-                os.path.join('fake_dir', 'bin', 'gcloud')), info_lines)
+        self.assertIn(('Gcloud Storage Command: {} storage buckets describe'
+                       ' --format=multi(defaultObjectAcl:format=json)'
+                       ' --raw gs://bucket').format(
+                           os.path.join('fake_dir', 'bin', 'gcloud')),
+                      info_lines)
 
   @mock.patch.object(defacl.DefAclCommand, 'RunCommand', new=mock.Mock())
   def test_shim_translates_set_defacl_file(self):

--- a/gslib/tests/test_kms.py
+++ b/gslib/tests/test_kms.py
@@ -350,9 +350,9 @@ class TestKmsUnitTests(testcase.GsUtilUnitTestCase):
         self.assertIn(
             'Gcloud Storage Command: {} alpha storage buckets describe '
             '--format=value[separator=\": \"](name, encryption'
-            '.defaultKmsKeyName.yesno(no="No default encryption key.")) {}'.
-            format(os.path.join('fake_dir', 'bin', 'gcloud'),
-                   suri(bucket_uri)), info_lines)
+            '.defaultKmsKeyName.yesno(no="No default encryption key."))'
+            ' --raw {}'.format(os.path.join('fake_dir', 'bin', 'gcloud'),
+                               suri(bucket_uri)), info_lines)
 
   @mock.patch(
       'gslib.cloud_api_delegator.CloudApiDelegator.GetProjectServiceAccount')

--- a/gslib/tests/test_lifecycle.py
+++ b/gslib/tests/test_lifecycle.py
@@ -289,9 +289,9 @@ class TestLifecycleUnitTests(testcase.GsUtilUnitTestCase):
         info_lines = '\n'.join(mock_log_handler.messages['info'])
         self.assertIn(
             ('Gcloud Storage Command: {} alpha storage buckets'
-             ' describe --format=multi(lifecycle:format=json) {}').format(
-                 os.path.join('fake_dir', 'bin', 'gcloud'),
-                 suri(bucket_uri)), info_lines)
+             ' describe --format=multi(lifecycle:format=json)'
+             ' --raw {}').format(os.path.join('fake_dir', 'bin', 'gcloud'),
+                                 suri(bucket_uri)), info_lines)
 
   @mock.patch('gslib.commands.lifecycle.LifecycleCommand._SetLifecycleConfig',
               new=mock.Mock())

--- a/gslib/tests/test_rpo.py
+++ b/gslib/tests/test_rpo.py
@@ -102,7 +102,8 @@ class TestRpoUnit(testcase.GsUtilUnitTestCase):
         info_lines = '\n'.join(mock_log_handler.messages['info'])
         self.assertIn(('Gcloud Storage Command: {} storage'
                        ' buckets list --format=value[separator=": "]'
-                       '(format("gs://{}", name),rpo.yesno(no="None"))').format(
+                       '(format("gs://{}", name),rpo.yesno(no="None"))'
+                       ' --raw').format(
                            os.path.join('fake_dir', 'bin', 'gcloud'), r'{}'),
                       info_lines)
 

--- a/gslib/tests/test_web.py
+++ b/gslib/tests/test_web.py
@@ -123,7 +123,8 @@ class TestWebShim(testcase.GsUtilUnitTestCase):
         info_lines = '\n'.join(mock_log_handler.messages['info'])
         self.assertIn(
             ('Gcloud Storage Command: {} alpha storage buckets describe'
-             ' --format=multi(website:format=json) gs://bucket').format(
+             ' --format=multi(website:format=json)'
+             ' --raw gs://bucket').format(
                  os.path.join('fake_dir', 'bin', 'gcloud')), info_lines)
 
   @mock.patch.object(web.WebCommand, '_SetWeb', new=mock.Mock())


### PR DESCRIPTION
This will fetch raw metadata, avoiding breaks in the keys the shim format strings are based on while gcloud transitions to standardized display formats.

Do not push until `--raw` flag is in gcloud storage. EDIT: It is time.