### PR TITLE
Fix error message for external account authorized user credentials

### DIFF
--- a/gslib/tests/test_boto_util.py
+++ b/gslib/tests/test_boto_util.py
@@ -64,6 +64,7 @@ class TestBotoUtil(testcase.GsUtilUnitTestCase):
         ('Credentials', 'aws_secret_access_key', None),
         ('Credentials', 'gs_oauth2_refresh_token', None),
         ('Credentials', 'gs_external_account_file', None),
+        ('Credentials', 'gs_external_account_authorized_user_file', None),
         ('Credentials', 'gs_service_client_id', None),
         ('Credentials', 'gs_service_key_file', None),
     ]):
@@ -78,6 +79,7 @@ class TestBotoUtil(testcase.GsUtilUnitTestCase):
         ('Credentials', 'aws_secret_access_key', None),
         ('Credentials', 'gs_oauth2_refresh_token', None),
         ('Credentials', 'gs_external_account_file', None),
+        ('Credentials', 'gs_external_account_authorized_user_file', None),
         ('Credentials', 'gs_service_client_id', None),
         ('Credentials', 'gs_service_key_file', None),
     ]):
@@ -92,6 +94,7 @@ class TestBotoUtil(testcase.GsUtilUnitTestCase):
         ('Credentials', 'aws_secret_access_key', "?????"),
         ('Credentials', 'gs_oauth2_refresh_token', None),
         ('Credentials', 'gs_external_account_file', None),
+        ('Credentials', 'gs_external_account_authorized_user_file', None),
         ('Credentials', 'gs_service_client_id', None),
         ('Credentials', 'gs_service_key_file', None),
     ]):
@@ -106,6 +109,7 @@ class TestBotoUtil(testcase.GsUtilUnitTestCase):
         ('Credentials', 'aws_secret_access_key', None),
         ('Credentials', 'gs_oauth2_refresh_token', "?????"),
         ('Credentials', 'gs_external_account_file', None),
+        ('Credentials', 'gs_external_account_authorized_user_file', None),
         ('Credentials', 'gs_service_client_id', None),
         ('Credentials', 'gs_service_key_file', None),
     ]):
@@ -120,6 +124,22 @@ class TestBotoUtil(testcase.GsUtilUnitTestCase):
         ('Credentials', 'aws_secret_access_key', None),
         ('Credentials', 'gs_oauth2_refresh_token', None),
         ('Credentials', 'gs_external_account_file', "?????"),
+        ('Credentials', 'gs_external_account_authorized_user_file', None),
+        ('Credentials', 'gs_service_client_id', None),
+        ('Credentials', 'gs_service_key_file', None),
+    ]):
+      self.assertTrue(boto_util.HasConfiguredCredentials())
+
+  @mock.patch.object(boto.auth, 'get_auth_handler', return_value=None)
+  def testHasConfiguredCredentialsExternalAuthorizedUserCreds(self, _):
+    with SetBotoConfigForTest([
+        ('Credentials', 'gs_access_key_id', None),
+        ('Credentials', 'gs_secret_access_key', None),
+        ('Credentials', 'aws_access_key_id', None),
+        ('Credentials', 'aws_secret_access_key', None),
+        ('Credentials', 'gs_oauth2_refresh_token', None),
+        ('Credentials', 'gs_external_account_file', None),
+        ('Credentials', 'gs_external_account_authorized_user_file', "?????"),
         ('Credentials', 'gs_service_client_id', None),
         ('Credentials', 'gs_service_key_file', None),
     ]):

--- a/gslib/tests/test_data/test_external_account_authorized_user_credentials.json
+++ b/gslib/tests/test_data/test_external_account_authorized_user_credentials.json
@@ -1,0 +1,9 @@
+{
+  "audience": "//iam.googleapis.com/locations/global/workforcePools/foobarr/providers/bazbas",
+  "client_id": "foobar",
+  "client_secret": "foobar",
+  "refresh_token": "foobar",
+  "token_info_url": "https://sts.googleapis.com/v1/introspect",
+  "token_url": "https://sts.googleapis.com/v1/oauthtoken",
+  "type": "external_account_authorized_user"
+}

--- a/gslib/tests/test_gcs_json_credentials.py
+++ b/gslib/tests/test_gcs_json_credentials.py
@@ -66,7 +66,7 @@ def getBotoCredentialsConfig(
       ("Credentials", "gs_oauth2_refresh_token", user_account_creds),
       ("GoogleCompute", "service_account", gce_creds),
       ("Credentials", "gs_external_account_file", external_account_creds),
-      ("Credentials", "gs_external_account_authorized_file", external_account_authorized_user_creds)
+      ("Credentials", "gs_external_account_authorized_user_file", external_account_authorized_user_creds)
   ])
   return config
 
@@ -188,7 +188,7 @@ class TestGcsJsonCredentials(testcase.GsUtilUnitTestCase):
   @mock.patch.object(WrappedCredentials,
                      "__init__",
                      side_effect=ValueError(ERROR_MESSAGE))
-  def testExternalAccountAuthorizedUser(self, _):
+  def testExternalAccountAuthorizedUserFailure(self, _):
     contents = pkgutil.get_data(
         "gslib", "tests/test_data/test_external_account_authorized_user_credentials.json")
     tmpfile = self.CreateTempFile(contents=contents)

--- a/gslib/tests/test_gcs_json_credentials.py
+++ b/gslib/tests/test_gcs_json_credentials.py
@@ -52,6 +52,7 @@ def getBotoCredentialsConfig(
     user_account_creds=None,
     gce_creds=None,
     external_account_creds=None,
+    external_account_authorized_user_creds=None,
 ):
   config = []
   if service_account_creds:
@@ -65,6 +66,7 @@ def getBotoCredentialsConfig(
       ("Credentials", "gs_oauth2_refresh_token", user_account_creds),
       ("GoogleCompute", "service_account", gce_creds),
       ("Credentials", "gs_external_account_file", external_account_creds),
+      ("Credentials", "gs_external_account_authorized_file", external_account_authorized_user_creds)
   ])
   return config
 
@@ -173,6 +175,30 @@ class TestGcsJsonCredentials(testcase.GsUtilUnitTestCase):
           gcs_json_api.GcsJsonApi(None, logging.getLogger(), None, None)
         self.assertIn(ERROR_MESSAGE, str(exc.exception))
         self.assertIn(CredTypes.EXTERNAL_ACCOUNT, logger.output[0])
+
+  def testExternalAccountAuthorizedUserCredential(self):
+    contents = pkgutil.get_data(
+        "gslib", "tests/test_data/test_external_account_authorized_user_credentials.json")
+    tmpfile = self.CreateTempFile(contents=contents)
+    with SetBotoConfigForTest(
+        getBotoCredentialsConfig(external_account_authorized_user_creds=tmpfile)):
+      client = gcs_json_api.GcsJsonApi(None, None, None, None)
+      self.assertIsInstance(client.credentials, WrappedCredentials)
+
+  @mock.patch.object(WrappedCredentials,
+                     "__init__",
+                     side_effect=ValueError(ERROR_MESSAGE))
+  def testExternalAccountAuthorizedUser(self, _):
+    contents = pkgutil.get_data(
+        "gslib", "tests/test_data/test_external_account_authorized_user_credentials.json")
+    tmpfile = self.CreateTempFile(contents=contents)
+    with SetBotoConfigForTest(
+        getBotoCredentialsConfig(external_account_authorized_user_creds=tmpfile)):
+      with self.assertLogs() as logger:
+        with self.assertRaises(Exception) as exc:
+          gcs_json_api.GcsJsonApi(None, logging.getLogger(), None, None)
+        self.assertIn(ERROR_MESSAGE, str(exc.exception))
+        self.assertIn(CredTypes.EXTERNAL_ACCOUNT_AUTHORIZED_USER, logger.output[0])
 
   def testOauth2ServiceAccountAndOauth2UserCredential(self):
     with SetBotoConfigForTest(

--- a/gslib/utils/boto_util.py
+++ b/gslib/utils/boto_util.py
@@ -334,13 +334,15 @@ def HasConfiguredCredentials():
                                        'gs_oauth2_refresh_token'))
   has_external_creds = (config.has_option('Credentials',
                                           'gs_external_account_file'))
+  has_external_account_authorized_user_creds = (
+    config.has_option('Credentials', 'gs_external_account_authorized_user_file'))
   has_service_account_creds = (
       HAS_CRYPTO and
       config.has_option('Credentials', 'gs_service_client_id') and
       config.has_option('Credentials', 'gs_service_key_file'))
 
   if (has_goog_creds or has_amzn_creds or has_oauth_creds or
-      has_service_account_creds or has_external_creds):
+      has_service_account_creds or has_external_creds or has_external_account_authorized_user_creds):
     return True
 
   valid_auth_handler = None


### PR DESCRIPTION
Fix error handling for the new external account authorized user credential type and added tests.

The external account authorized user credential type was added previously in #1617 but the type was missed in hasConfiguredCredentials. This results in the CLI returning misleading error messages when a failure occurs when using the new type.