### PR TITLE
Handles OAuthException from google-auth

### DIFF
--- a/gslib/__main__.py
+++ b/gslib/__main__.py
@@ -36,7 +36,7 @@ import six
 from six.moves import configparser
 from six.moves import range
 
-from google.auth import exceptions
+from google.auth import exceptions as google_auth_exceptions
 import gslib.exception
 from gslib.exception import CommandException
 from gslib.exception import ControlCException
@@ -703,7 +703,8 @@ def _RunNamedCommandAndHandleExceptions(command_runner,
     _OutputAndExit(message=e, exception=e)
   except ServiceException as e:
     _OutputAndExit(message=e, exception=e)
-  except oauth2client.client.HttpAccessTokenRefreshError as e:
+  except (oauth2client.client.HttpAccessTokenRefreshError,
+          google_auth_exceptions.OAuthError) as e:
     if system_util.InvokedViaCloudSdk():
       _OutputAndExit(
           'Your credentials are invalid. '
@@ -761,18 +762,6 @@ def _RunNamedCommandAndHandleExceptions(command_runner,
     else:
       _OutputAndExit('You must re-authenticate with your SAML IdP. '
                      'Please run\n$ gsutil config')
-  except exceptions.OAuthError as e:
-    if system_util.InvokedViaCloudSdk():
-      _OutputAndExit(
-          'Your credentials are invalid. '
-          'Please run\n$ gcloud auth login',
-          exception=e)
-    else:
-      _OutputAndExit(
-          'Your credentials are invalid. For more help, see '
-          '"gsutil help creds", or re-run the gsutil config command (see '
-          '"gsutil help config").',
-          exception=e)
   except Exception as e:  # pylint: disable=broad-except
     config_paths = ', '.join(boto_util.GetFriendlyConfigFilePaths())
     # Check for two types of errors related to service accounts. These errors

--- a/gslib/__main__.py
+++ b/gslib/__main__.py
@@ -36,6 +36,7 @@ import six
 from six.moves import configparser
 from six.moves import range
 
+from google.auth import exceptions
 import gslib.exception
 from gslib.exception import CommandException
 from gslib.exception import ControlCException
@@ -760,6 +761,18 @@ def _RunNamedCommandAndHandleExceptions(command_runner,
     else:
       _OutputAndExit('You must re-authenticate with your SAML IdP. '
                      'Please run\n$ gsutil config')
+  except exceptions.OAuthError as e:
+    if system_util.InvokedViaCloudSdk():
+      _OutputAndExit(
+          'Your credentials are invalid. '
+          'Please run\n$ gcloud auth login',
+          exception=e)
+    else:
+      _OutputAndExit(
+          'Your credentials are invalid. For more help, see '
+          '"gsutil help creds", or re-run the gsutil config command (see '
+          '"gsutil help config").',
+          exception=e)
   except Exception as e:  # pylint: disable=broad-except
     config_paths = ', '.join(boto_util.GetFriendlyConfigFilePaths())
     # Check for two types of errors related to service accounts. These errors


### PR DESCRIPTION
gsutil does not handle OAuthException's from google-auth, which results in the entire stack trace being printed when an error occurs when using external account credentials. We should prompt the user to sign-in again in this case. 