### PR TITLE
Fix external_account_authorized_user implementation in wrapped_credentials.py + update google-auth dependency

### DIFF
--- a/gslib/tests/test_wrapped_credentials.py
+++ b/gslib/tests/test_wrapped_credentials.py
@@ -197,6 +197,7 @@ class TestWrappedCredentials(testcase.GsUtilUnitTestCase):
     creds.access_token = ACCESS_TOKEN
     creds.token_expiry = datetime.datetime(2001, 12, 5, 0, 0)
     creds_json = creds.to_json()
+    self.maxDiff = None
     json_values = json.loads(creds_json)
     expected_json_values = {
         "_class":
@@ -204,7 +205,7 @@ class TestWrappedCredentials(testcase.GsUtilUnitTestCase):
         "_module":
             "gslib.utils.wrapped_credentials",
         "client_id":
-            "//iam.googleapis.com/locations/global/workforcePools/$WORKFORCE_POOL_ID/providers/$PROVIDER_ID",
+            "clientId",
         "access_token":
             ACCESS_TOKEN,
         "token_expiry":
@@ -259,7 +260,7 @@ class TestWrappedCredentials(testcase.GsUtilUnitTestCase):
                           external_account_authorized_user.Credentials)
     self.assertEquals(
         creds2.client_id,
-        "//iam.googleapis.com/locations/global/workforcePools/$WORKFORCE_POOL_ID/providers/$PROVIDER_ID"
+        "clientId"
     )
 
   def testFromJsonAWSCredentials(self):

--- a/gslib/tests/test_wrapped_credentials.py
+++ b/gslib/tests/test_wrapped_credentials.py
@@ -210,9 +210,9 @@ class TestWrappedCredentials(testcase.GsUtilUnitTestCase):
         "token_expiry":
             "2001-12-05T00:00:00Z",
         "client_secret":
-            None,
+            "clientSecret",
         "refresh_token":
-            None,
+            "refreshToken",
         "id_token":
             None,
         "id_token_jwt":

--- a/gslib/tests/test_wrapped_credentials.py
+++ b/gslib/tests/test_wrapped_credentials.py
@@ -197,7 +197,6 @@ class TestWrappedCredentials(testcase.GsUtilUnitTestCase):
     creds.access_token = ACCESS_TOKEN
     creds.token_expiry = datetime.datetime(2001, 12, 5, 0, 0)
     creds_json = creds.to_json()
-    self.maxDiff = None
     json_values = json.loads(creds_json)
     expected_json_values = {
         "_class":

--- a/gslib/utils/wrapped_credentials.py
+++ b/gslib/utils/wrapped_credentials.py
@@ -58,18 +58,26 @@ class WrappedCredentials(oauth2client.client.OAuth2Credentials):
     Args:
       external_account_creds: subclass of google.auth.external_account.Credentials
     """
-    if not isinstance(base_creds, external_account.Credentials):
-      if not isinstance(base_creds,
-                        external_account_authorized_user.Credentials):
-        raise TypeError("Invalid Credentials")
     self._base = base_creds
-    super(WrappedCredentials, self).__init__(access_token=self._base.token,
-                                             client_id=self._base._audience,
-                                             client_secret=None,
-                                             refresh_token=None,
-                                             token_expiry=self._base.expiry,
-                                             token_uri=None,
-                                             user_agent=None)
+    if isinstance(base_creds, external_account.Credentials):
+      super(WrappedCredentials, self).__init__(access_token=self._base.token,
+                                              client_id=self._base._audience,
+                                              client_secret=None,
+                                              refresh_token=None,
+                                              token_expiry=self._base.expiry,
+                                              token_uri=None,
+                                              user_agent=None)
+    elif isinstance(base_creds,
+                        external_account_authorized_user.Credentials):
+      super(WrappedCredentials, self).__init__(access_token=self._base.token,
+                                              client_id=self._base._audience,
+                                              client_secret=self._base.client_secret,
+                                              refresh_token=self._base.refresh_token,
+                                              token_expiry=self._base.expiry,
+                                              token_uri=None,
+                                              user_agent=None)
+    else:
+      raise TypeError("Invalid Credentials")
 
   def _do_refresh_request(self, http):
     self._base.refresh(requests.Request())

--- a/gslib/utils/wrapped_credentials.py
+++ b/gslib/utils/wrapped_credentials.py
@@ -60,24 +60,24 @@ class WrappedCredentials(oauth2client.client.OAuth2Credentials):
     """
     self._base = base_creds
     if isinstance(base_creds, external_account.Credentials):
-      super(WrappedCredentials, self).__init__(access_token=self._base.token,
-                                              client_id=self._base._audience,
-                                              client_secret=None,
-                                              refresh_token=None,
-                                              token_expiry=self._base.expiry,
-                                              token_uri=None,
-                                              user_agent=None)
+      client_id = self._base._audience
+      client_secret = None
+      refresh_token = None
     elif isinstance(base_creds,
                         external_account_authorized_user.Credentials):
-      super(WrappedCredentials, self).__init__(access_token=self._base.token,
-                                              client_id=self._base.client_id,
-                                              client_secret=self._base.client_secret,
-                                              refresh_token=self._base.refresh_token,
-                                              token_expiry=self._base.expiry,
-                                              token_uri=None,
-                                              user_agent=None)
+      client_id = self._base.client_id
+      client_secret = self._base.client_secret
+      refresh_token = self._base.refresh_token
     else:
       raise TypeError("Invalid Credentials")
+
+    super(WrappedCredentials, self).__init__(access_token=self._base.token,
+                                            client_id=client_id,
+                                            client_secret=client_secret,
+                                            refresh_token=refresh_token,
+                                            token_expiry=self._base.expiry,
+                                            token_uri=None,
+                                            user_agent=None)
 
   def _do_refresh_request(self, http):
     self._base.refresh(requests.Request())

--- a/gslib/utils/wrapped_credentials.py
+++ b/gslib/utils/wrapped_credentials.py
@@ -70,7 +70,7 @@ class WrappedCredentials(oauth2client.client.OAuth2Credentials):
     elif isinstance(base_creds,
                         external_account_authorized_user.Credentials):
       super(WrappedCredentials, self).__init__(access_token=self._base.token,
-                                              client_id=self._base._audience,
+                                              client_id=self._base.client_id,
                                               client_secret=self._base.client_secret,
                                               refresh_token=self._base.refresh_token,
                                               token_expiry=self._base.expiry,


### PR DESCRIPTION
Changing wrapped_credentials to store the client_secret and refresh_token from external account authorized user credentials. External account credentials did not have these fields so they were never added to wrapped credentials in the previous implementation. This led to a caching bug where the library did not recognize a newer version of the external account authorized user credential since the caching key did not include the refresh token.