### PR TITLE
Removes the run-by-gcloud check from the broken OAuth (OOB) flow.

### DIFF
--- a/gslib/commands/config.py
+++ b/gslib/commands/config.py
@@ -877,17 +877,16 @@ class ConfigCommand(Command):
                                                ' ')
         self._CheckPrivateKeyFilePermissions(gs_service_key_file)
       elif cred_type == CredTypes.OAUTH2_USER_ACCOUNT:
-        if not system_util.InvokedViaCloudSdk():
-          sys.stdout.write(
-              '\n********************************************************\n' +
-              textwrap.fill(
-                  "WARNING: The following authentication flow will fail on "
-                  "or after Febuary 1 2023. Tokens generated before this date "
-                  "will continue to work. To authenticate with your user "
-                  "account after this date, install gsutil via Cloud SDK and "
-                  "run \"gcloud auth login\"",
-                  width=55) +
-              '\n********************************************************\n\n')
+        sys.stdout.write(
+            '\n********************************************************\n' +
+            textwrap.fill(
+                "WARNING: The following authentication flow will fail on "
+                "or after Febuary 1 2023. Tokens generated before this date "
+                "will continue to work. To authenticate with your user "
+                "account after this date, install gsutil via Cloud SDK and "
+                "run \"gcloud auth login\"",
+                width=55) +
+            '\n********************************************************\n\n')
         oauth2_client = oauth2_helper.OAuth2ClientFromBotoConfig(
             boto.config, cred_type)
         try:


### PR DESCRIPTION
This check still fails if you run the command from gcloud, so this check just hides the explanatory error message.

There are three paths to the failure:

* Run `gsutil config` independently with OAuth creds (which is the default creds type) -> Then you get the gsutil explanatory error message and the failing code.

* Run `gsutil config` via gcloud with the `pass_credentials_to_gsutil=True` -> Gcloud intercepts and raises an error with a  gcloud explanatory message before gsutil runs.

* Run `gsutil config` via gcloud with the `pass_credentials_to_gsutil=False` -> You get the failing gsutil code without the gsutil explanatory error message. That is what this CL fixes.

Updates: https://github.com/GoogleCloudPlatform/gsutil/pull/1658