### PR TITLE
Change state directory for mTLS.

### DIFF
--- a/gslib/context_config.py
+++ b/gslib/context_config.py
@@ -27,6 +27,7 @@ from boto import config
 
 import gslib
 from gslib import exception
+from gslib.utils import boto_util
 from gslib.utils import execution_util
 
 # Maintain a single context configuration.
@@ -194,7 +195,8 @@ class _ContextConfig(object):
 
     # Generates certificate and deletes it afterwards.
     atexit.register(self._unprovision_client_cert)
-    self.client_cert_path = os.path.join(gslib.GSUTIL_DIR, 'caa_cert.pem')
+    self.client_cert_path = os.path.join(boto_util.GetGsutilStateDir(),
+                                         'caa_cert.pem')
     try:
       # Certs provisioned using endpoint verification are stored as a
       # single file holding both the public certificate and the private key.

--- a/gslib/tests/test_context_config.py
+++ b/gslib/tests/test_context_config.py
@@ -260,7 +260,9 @@ class TestContextConfig(testcase.GsUtilUnitTestCase):
   def test_default_provider_not_found_error(self):
     with SetBotoConfigForTest([('Credentials', 'use_client_certificate',
                                 'True'),
-                               ('Credentials', 'cert_provider_command', None)]):
+                               ('Credentials', 'cert_provider_command', None),
+                               # Avoids permissions error on Windows tests:
+                               ('GSUtil', 'state_dir', self.CreateTempDir())]):
       context_config.create_context_config(self.mock_logger)
 
       self.mock_logger.error.assert_called_once_with(

--- a/gslib/tests/test_gcs_json_credentials.py
+++ b/gslib/tests/test_gcs_json_credentials.py
@@ -62,12 +62,12 @@ def getBotoCredentialsConfig(
                    service_account_creds["client_id"]))
   else:
     config.append(("Credentials", "gs_service_key_file", None))
-  config.extend([
-      ("Credentials", "gs_oauth2_refresh_token", user_account_creds),
-      ("GoogleCompute", "service_account", gce_creds),
-      ("Credentials", "gs_external_account_file", external_account_creds),
-      ("Credentials", "gs_external_account_authorized_user_file", external_account_authorized_user_creds)
-  ])
+  config.extend([("Credentials", "gs_oauth2_refresh_token", user_account_creds),
+                 ("GoogleCompute", "service_account", gce_creds),
+                 ("Credentials", "gs_external_account_file",
+                  external_account_creds),
+                 ("Credentials", "gs_external_account_authorized_user_file",
+                  external_account_authorized_user_creds)])
   return config
 
 
@@ -178,10 +178,13 @@ class TestGcsJsonCredentials(testcase.GsUtilUnitTestCase):
 
   def testExternalAccountAuthorizedUserCredential(self):
     contents = pkgutil.get_data(
-        "gslib", "tests/test_data/test_external_account_authorized_user_credentials.json")
+        "gslib",
+        "tests/test_data/test_external_account_authorized_user_credentials.json"
+    )
     tmpfile = self.CreateTempFile(contents=contents)
     with SetBotoConfigForTest(
-        getBotoCredentialsConfig(external_account_authorized_user_creds=tmpfile)):
+        getBotoCredentialsConfig(
+            external_account_authorized_user_creds=tmpfile)):
       client = gcs_json_api.GcsJsonApi(None, None, None, None)
       self.assertIsInstance(client.credentials, WrappedCredentials)
 
@@ -190,15 +193,19 @@ class TestGcsJsonCredentials(testcase.GsUtilUnitTestCase):
                      side_effect=ValueError(ERROR_MESSAGE))
   def testExternalAccountAuthorizedUserFailure(self, _):
     contents = pkgutil.get_data(
-        "gslib", "tests/test_data/test_external_account_authorized_user_credentials.json")
+        "gslib",
+        "tests/test_data/test_external_account_authorized_user_credentials.json"
+    )
     tmpfile = self.CreateTempFile(contents=contents)
     with SetBotoConfigForTest(
-        getBotoCredentialsConfig(external_account_authorized_user_creds=tmpfile)):
+        getBotoCredentialsConfig(
+            external_account_authorized_user_creds=tmpfile)):
       with self.assertLogs() as logger:
         with self.assertRaises(Exception) as exc:
           gcs_json_api.GcsJsonApi(None, logging.getLogger(), None, None)
         self.assertIn(ERROR_MESSAGE, str(exc.exception))
-        self.assertIn(CredTypes.EXTERNAL_ACCOUNT_AUTHORIZED_USER, logger.output[0])
+        self.assertIn(CredTypes.EXTERNAL_ACCOUNT_AUTHORIZED_USER,
+                      logger.output[0])
 
   def testOauth2ServiceAccountAndOauth2UserCredential(self):
     with SetBotoConfigForTest(

--- a/gslib/tests/test_rpo.py
+++ b/gslib/tests/test_rpo.py
@@ -100,12 +100,12 @@ class TestRpoUnit(testcase.GsUtilUnitTestCase):
             return_log_handler=True)
 
         info_lines = '\n'.join(mock_log_handler.messages['info'])
-        self.assertIn(('Gcloud Storage Command: {} storage'
-                       ' buckets list --format=value[separator=": "]'
-                       '(format("gs://{}", name),rpo.yesno(no="None"))'
-                       ' --raw').format(
-                           os.path.join('fake_dir', 'bin', 'gcloud'), r'{}'),
-                      info_lines)
+        self.assertIn(
+            ('Gcloud Storage Command: {} storage'
+             ' buckets list --format=value[separator=": "]'
+             '(format("gs://{}", name),rpo.yesno(no="None"))'
+             ' --raw').format(os.path.join('fake_dir', 'bin', 'gcloud'),
+                              r'{}'), info_lines)
 
   def test_shim_translates_recovery_point_objective_set_command(self):
     fake_cloudsdk_dir = 'fake_dir'

--- a/gslib/tests/test_wrapped_credentials.py
+++ b/gslib/tests/test_wrapped_credentials.py
@@ -199,37 +199,22 @@ class TestWrappedCredentials(testcase.GsUtilUnitTestCase):
     creds_json = creds.to_json()
     json_values = json.loads(creds_json)
     expected_json_values = {
-        "_class":
-            "WrappedCredentials",
-        "_module":
-            "gslib.utils.wrapped_credentials",
-        "client_id":
-            "clientId",
-        "access_token":
-            ACCESS_TOKEN,
-        "token_expiry":
-            "2001-12-05T00:00:00Z",
-        "client_secret":
-            "clientSecret",
-        "refresh_token":
-            "refreshToken",
-        "id_token":
-            None,
-        "id_token_jwt":
-            None,
-        "invalid":
-            False,
-        "revoke_uri":
-            None,
+        "_class": "WrappedCredentials",
+        "_module": "gslib.utils.wrapped_credentials",
+        "client_id": "clientId",
+        "access_token": ACCESS_TOKEN,
+        "token_expiry": "2001-12-05T00:00:00Z",
+        "client_secret": "clientSecret",
+        "refresh_token": "refreshToken",
+        "id_token": None,
+        "id_token_jwt": None,
+        "invalid": False,
+        "revoke_uri": None,
         "scopes": [],
-        "token_info_uri":
-            None,
-        "token_response":
-            None,
-        "token_uri":
-            None,
-        "user_agent":
-            None,
+        "token_info_uri": None,
+        "token_response": None,
+        "token_uri": None,
+        "user_agent": None,
         "_base": {
             "type":
                 "external_account_authorized_user",
@@ -257,10 +242,7 @@ class TestWrappedCredentials(testcase.GsUtilUnitTestCase):
     self.assertIsInstance(creds2, WrappedCredentials)
     self.assertIsInstance(creds2._base,
                           external_account_authorized_user.Credentials)
-    self.assertEquals(
-        creds2.client_id,
-        "clientId"
-    )
+    self.assertEquals(creds2.client_id, "clientId")
 
   def testFromJsonAWSCredentials(self):
     creds = WrappedCredentials.from_json(

--- a/gslib/utils/boto_util.py
+++ b/gslib/utils/boto_util.py
@@ -334,15 +334,16 @@ def HasConfiguredCredentials():
                                        'gs_oauth2_refresh_token'))
   has_external_creds = (config.has_option('Credentials',
                                           'gs_external_account_file'))
-  has_external_account_authorized_user_creds = (
-    config.has_option('Credentials', 'gs_external_account_authorized_user_file'))
+  has_external_account_authorized_user_creds = (config.has_option(
+      'Credentials', 'gs_external_account_authorized_user_file'))
   has_service_account_creds = (
       HAS_CRYPTO and
       config.has_option('Credentials', 'gs_service_client_id') and
       config.has_option('Credentials', 'gs_service_key_file'))
 
   if (has_goog_creds or has_amzn_creds or has_oauth_creds or
-      has_service_account_creds or has_external_creds or has_external_account_authorized_user_creds):
+      has_service_account_creds or has_external_creds or
+      has_external_account_authorized_user_creds):
     return True
 
   valid_auth_handler = None

--- a/gslib/utils/system_util.py
+++ b/gslib/utils/system_util.py
@@ -114,7 +114,7 @@ def CreateDirIfNeeded(dir_path, mode=0o777):
     # resumable uploads concurrently from a machine where no tracker dir had
     # yet been created.
     except OSError as e:
-      if e.errno != errno.EEXIST:
+      if e.errno != errno.EEXIST and e.errno != errno.EISDIR:
         raise
 
 

--- a/gslib/utils/wrapped_credentials.py
+++ b/gslib/utils/wrapped_credentials.py
@@ -63,8 +63,7 @@ class WrappedCredentials(oauth2client.client.OAuth2Credentials):
       client_id = self._base._audience
       client_secret = None
       refresh_token = None
-    elif isinstance(base_creds,
-                        external_account_authorized_user.Credentials):
+    elif isinstance(base_creds, external_account_authorized_user.Credentials):
       client_id = self._base.client_id
       client_secret = self._base.client_secret
       refresh_token = self._base.refresh_token
@@ -72,12 +71,12 @@ class WrappedCredentials(oauth2client.client.OAuth2Credentials):
       raise TypeError("Invalid Credentials")
 
     super(WrappedCredentials, self).__init__(access_token=self._base.token,
-                                            client_id=client_id,
-                                            client_secret=client_secret,
-                                            refresh_token=refresh_token,
-                                            token_expiry=self._base.expiry,
-                                            token_uri=None,
-                                            user_agent=None)
+                                             client_id=client_id,
+                                             client_secret=client_secret,
+                                             refresh_token=refresh_token,
+                                             token_expiry=self._base.expiry,
+                                             token_uri=None,
+                                             user_agent=None)
 
   def _do_refresh_request(self, http):
     self._base.refresh(requests.Request())


### PR DESCRIPTION
Temporary certificate files used to be in the gsutil install directory. Now they're in the directory that contains the tracker file directory, which is controlled by the `state_dir` boto config option. Addresses #1517.

It looks like a recent PR didn't run the formatter, so there's some noise in this PR. The novel changes are in `context_config.py` and `test_context_config.py`.