### PR TITLE
Fix invalid value for property api_endpoint_overrides/storage

### DIFF
--- a/gslib/tests/test_shim_util.py
+++ b/gslib/tests/test_shim_util.py
@@ -1082,7 +1082,7 @@ class TestBotoTranslation(testcase.GsUtilUnitTestCase):
       self.assertEqual(
           env_vars, {
               'CLOUDSDK_API_ENDPOINT_OVERRIDES_STORAGE':
-                  'https://foo_host:1234/storage/v2',
+                  'https://foo_host:1234/storage/v2/',
           })
 
   def test_gcs_json_endpoint_translation_with_missing_port(self):
@@ -1094,10 +1094,11 @@ class TestBotoTranslation(testcase.GsUtilUnitTestCase):
     }):
       flags, env_vars = self._fake_command._translate_boto_config()
       self.assertEqual(flags, [])
-      self.assertEqual(env_vars, {
-          'CLOUDSDK_API_ENDPOINT_OVERRIDES_STORAGE':
-              'https://foo_host/storage/v2',
-      })
+      self.assertEqual(
+          env_vars, {
+              'CLOUDSDK_API_ENDPOINT_OVERRIDES_STORAGE':
+                  'https://foo_host/storage/v2/',
+          })
 
   def test_gcs_json_endpoint_translation_usees_default_version_v1(self):
     with _mock_boto_config(
@@ -1110,8 +1111,23 @@ class TestBotoTranslation(testcase.GsUtilUnitTestCase):
       self.assertEqual(
           env_vars, {
               'CLOUDSDK_API_ENDPOINT_OVERRIDES_STORAGE':
-                  'https://foo_host:1234/storage/v1'
+                  'https://foo_host:1234/storage/v1/'
           })
+
+  def test_gcs_json_endpoint_translation_should_start_with_https(self):
+    with _mock_boto_config({'Credentials': {'gs_json_host': 'foo_host',}}):
+      flags, env_vars = self._fake_command._translate_boto_config()
+      self.assertEqual(flags, [])
+      self.assertTrue(
+          env_vars['CLOUDSDK_API_ENDPOINT_OVERRIDES_STORAGE'].startswith(
+              'https://'))
+
+  def test_gcs_json_endpoint_translation_should_end_with_trailing_slash(self):
+    with _mock_boto_config({'Credentials': {'gs_json_host': 'foo_host',}}):
+      flags, env_vars = self._fake_command._translate_boto_config()
+      self.assertEqual(flags, [])
+      self.assertTrue(
+          env_vars['CLOUDSDK_API_ENDPOINT_OVERRIDES_STORAGE'].endswith('v1/'))
 
   def test_s3_endpoint_translation(self):
     with _mock_boto_config(

--- a/gslib/utils/shim_util.py
+++ b/gslib/utils/shim_util.py
@@ -248,8 +248,8 @@ def _get_gcs_json_endpoint_from_boto_config(config):
     gs_json_port = config.get('Credentials', 'gs_json_port')
     port = ':' + gs_json_port if gs_json_port else ''
     json_api_version = config.get('Credentials', 'json_api_version', 'v1')
-    return 'https://{}{}/storage/{}'.format(gs_json_host, port,
-                                            json_api_version)
+    return 'https://{}{}/storage/{}/'.format(gs_json_host, port,
+                                             json_api_version)
   return None
 
 


### PR DESCRIPTION
When the `shim` is used the following error is thrown by `gcloud`:

```
Invalid value for property [api_endpoint_overrides/storage]: The endpoint_overrides property must be an absolute URI beginning with http:// or https:// and ending with a trailing '/'. [https://storage.googleapis.com/storage/v1] is not a valid endpoint override.
```
