### PR TITLE
Fix SSL missing error by updating Linux Python 3.5 version.

### DIFF
--- a/test/ci/kokoro/run_integ_tests.sh
+++ b/test/ci/kokoro/run_integ_tests.sh
@@ -36,9 +36,14 @@ BOTO_CONFIG="/tmpfs/src/.boto_$API"
 # https://cloud.google.com/storage/docs/boto-gsutil
 export BOTO_PATH="$BOTO_CONFIG"
 
-# Set the locale to utf-8 for macos b/154863917
-if [[ $KOKORO_JOB_NAME =~ "macos" ]]; then
+# Set the locale to utf-8 for macos b/154863917 and linux
+# https://github.com/GoogleCloudPlatform/gsutil/pull/1692
+if [[ $KOKORO_JOB_NAME =~ "linux" ]]; then
+  export LANG=C.UTF-8
+  export LC_ALL=C.UTF-8
+elif [[ $KOKORO_JOB_NAME =~ "macos" ]]; then
   export LANG=en_US.UTF-8
+  export LC_ALL=en_US.UTF-8
 fi
 
 function preferred_python_release {
@@ -47,7 +52,7 @@ function preferred_python_release {
     # lower. Hence we want to make sure that we run these tests with 3.5.2.
     # There is too much overhead to run this for MacOS because of OpenSSL 1.0
     # requirement for Python 3.5.2. Hence, we force 3.5.2 only for linux.
-    echo "3.5.2"
+    echo "3.5.4"
     return
   fi
   # Return string with latest Python version triplet for a given version tuple.


### PR DESCRIPTION
See https://github.com/pyenv/pyenv/wiki/Common-build-problems#2-your-openssl-version-is-incompatible-with-the-python-version-youre-trying-to-install