### PR TITLE
Fix formatting behavior in rsync and logging help text

### DIFF
--- a/gslib/commands/logging.py
+++ b/gslib/commands/logging.py
@@ -120,7 +120,7 @@ _DESCRIPTION = """
   `Usage and storage log format
   <https://cloud.google.com/storage/docs/access-logs#format>`_.
   
-  The <code>logging</code> command has two sub-commands:
+  The ``logging`` command has two sub-commands:
 """ + _SET_DESCRIPTION + _GET_DESCRIPTION + """
 
 <B>OPTIONS</B>

--- a/gslib/commands/rsync.py
+++ b/gslib/commands/rsync.py
@@ -490,21 +490,21 @@ _DETAILED_HELP_TEXT = ("""
                  path is always relative (similar to Unix rsync or tar exclude
                  options). For example, if you run the command:
 
-                   gsutil rsync -x "data.[/\\\\].*\\.txt$" dir gs://my-bucket
+                   gsutil rsync -x "data.[/\\].*\.txt$" dir gs://my-bucket
 
                  it skips the file dir/data1/a.txt.
 
                  You can use regex alternation to specify multiple exclusions,
                  for example:
 
-                   gsutil rsync -x ".*\\.txt$|.*\\.jpg$" dir gs://my-bucket
+                   gsutil rsync -x ".*\.txt$|.*\.jpg$" dir gs://my-bucket
 
                  skips all .txt and .jpg files in dir.
 
                  NOTE: When using the Windows cmd.exe command line interpreter,
-                 use ^ as an escape character instead of \\ and escape the |
-                 character. When using Windows PowerShell, use ' instead of "
-                 and surround the | character with ".
+                 use ``^`` as an escape character instead of ``\`` and escape
+                 the ``|`` character. When using Windows PowerShell, use ``'``
+                 instead of ``"`` and surround the ``|`` character with ``"``.
 
   -y pattern     Similar to the -x option, but the command will first skip
                  directories/prefixes using the provided pattern and then


### PR DESCRIPTION
Slash escaping is in place to workaround how the documentation generator works, but it means examples presented in the command line help are incorrect.

The plan is to remove the escaping here in source and hope we remember to manually catch generator behavior in the remaining few gsutil releases.

This PR also fixes a minor formatting error in the logging help doc that was discovered in most recent doc generation run