### PR TITLE
Minor change to default event based hold test for parity

### DIFF
--- a/gslib/addlhelp/shim.py
+++ b/gslib/addlhelp/shim.py
@@ -140,7 +140,7 @@ _DETAILED_HELP_TEXT = ("""
   ls
   ------------------------
 
-  - Works as expected.
+  - `ls -L` output uses spaces instead of tabs.
 
   mb
   ------------------------

--- a/gslib/tests/test_ls.py
+++ b/gslib/tests/test_ls.py
@@ -1107,7 +1107,7 @@ class TestLs(testcase.GsUtilIntegrationTestCase):
     bucket_uri = self.CreateBucketWithRetentionPolicy(
         retention_period_in_seconds=1)
     stdout = self.RunGsUtil(['ls', '-Lb', suri(bucket_uri)], return_stdout=True)
-    self.assertRegex(stdout, r'Retention Policy\:\t*Present')
+    self.assertRegex(stdout, r'Retention Policy\:\s*Present')
     # Clearing Retention Policy on the bucket.
     self.RunGsUtil(['retention', 'clear', suri(bucket_uri)])
     stdout = self.RunGsUtil(['ls', '-Lb', suri(bucket_uri)], return_stdout=True)


### PR DESCRIPTION
Also updating the shim.py page to highlight the space vs tabs differences.