### PR TITLE
Adding support for HMAC auth to the shim.

### DIFF
--- a/gslib/cloud_api_delegator.py
+++ b/gslib/cloud_api_delegator.py
@@ -27,6 +27,7 @@ from gslib.cloud_api import CloudApi
 from gslib.cs_api_map import ApiMapConstants
 from gslib.cs_api_map import ApiSelector
 from gslib.exception import CommandException
+from gslib.utils import boto_util
 
 
 class CloudApiDelegator(CloudApi):
@@ -175,13 +176,7 @@ class CloudApiDelegator(CloudApi):
 
     api = self.api_map[ApiMapConstants.DEFAULT_MAP][selected_provider]
 
-    using_gs_hmac = (
-        provider == 'gs' and
-        not config.has_option('Credentials', 'gs_oauth2_refresh_token') and
-        not (config.has_option('Credentials', 'gs_service_client_id') and
-             config.has_option('Credentials', 'gs_service_key_file')) and
-        (config.has_option('Credentials', 'gs_access_key_id') and
-         config.has_option('Credentials', 'gs_secret_access_key')))
+    using_gs_hmac = provider == 'gs' and boto_util.UsingGsHmac()
 
     configured_encryption = (provider == 'gs' and
                              (config.has_option('GSUtil', 'encryption_key') or

--- a/gslib/tests/test_boto_util.py
+++ b/gslib/tests/test_boto_util.py
@@ -144,3 +144,75 @@ class TestBotoUtil(testcase.GsUtilUnitTestCase):
         ('Credentials', 'gs_service_key_file', None),
     ]):
       self.assertTrue(boto_util.HasConfiguredCredentials())
+
+  def testUsingGsHmacWithHmacAndServiceAccountCreds(self):
+    with SetBotoConfigForTest([
+        ('Credentials', 'gs_access_key_id', "?????"),
+        ('Credentials', 'gs_secret_access_key', "?????"),
+        ('Credentials', 'gs_external_account_file', None),
+        ('Credentials', 'gs_external_account_authorized_user_file', None),
+        ('Credentials', 'gs_oauth2_refresh_token', None),
+        ('Credentials', 'gs_service_client_id', "?????"),
+        ('Credentials', 'gs_service_key_file', "?????"),
+    ]):
+      self.assertFalse(boto_util.UsingGsHmac())
+
+  def testUsingGsHmacWithHmacAndOauth2RefreshToken(self):
+    with SetBotoConfigForTest([
+        ('Credentials', 'gs_access_key_id', "?????"),
+        ('Credentials', 'gs_secret_access_key', "?????"),
+        ('Credentials', 'gs_external_account_file', None),
+        ('Credentials', 'gs_external_account_authorized_user_file', None),
+        ('Credentials', 'gs_oauth2_refresh_token', "?????"),
+        ('Credentials', 'gs_service_client_id', None),
+        ('Credentials', 'gs_service_key_file', None),
+    ]):
+      self.assertFalse(boto_util.UsingGsHmac())
+
+  def testUsingGsHmacWithIncompleteHmacOnly(self):
+    with SetBotoConfigForTest([
+        ('Credentials', 'gs_access_key_id', "?????"),
+        ('Credentials', 'gs_secret_access_key', None),
+        ('Credentials', 'gs_external_account_file', None),
+        ('Credentials', 'gs_external_account_authorized_user_file', None),
+        ('Credentials', 'gs_oauth2_refresh_token', None),
+        ('Credentials', 'gs_service_client_id', None),
+        ('Credentials', 'gs_service_key_file', None),
+    ]):
+      self.assertFalse(boto_util.UsingGsHmac())
+
+  def testUsingGsHmacWithHmacAndExternalAccountFile(self):
+    with SetBotoConfigForTest([
+        ('Credentials', 'gs_access_key_id', "?????"),
+        ('Credentials', 'gs_secret_access_key', "?????"),
+        ('Credentials', 'gs_external_account_file', "?????"),
+        ('Credentials', 'gs_external_account_authorized_user_file', None),
+        ('Credentials', 'gs_oauth2_refresh_token', None),
+        ('Credentials', 'gs_service_client_id', None),
+        ('Credentials', 'gs_service_key_file', None),
+    ]):
+      self.assertTrue(boto_util.UsingGsHmac())
+
+  def testUsingGsHmacWithHmacAndExternalAccountAuthorizedUserFile(self):
+    with SetBotoConfigForTest([
+        ('Credentials', 'gs_access_key_id', "?????"),
+        ('Credentials', 'gs_secret_access_key', "?????"),
+        ('Credentials', 'gs_external_account_file', None),
+        ('Credentials', 'gs_external_account_authorized_user_file', "?????"),
+        ('Credentials', 'gs_oauth2_refresh_token', None),
+        ('Credentials', 'gs_service_client_id', None),
+        ('Credentials', 'gs_service_key_file', None),
+    ]):
+      self.assertTrue(boto_util.UsingGsHmac())
+
+  def testUsingGsHmacWithHmacOnly(self):
+    with SetBotoConfigForTest([
+        ('Credentials', 'gs_access_key_id', "?????"),
+        ('Credentials', 'gs_secret_access_key', "?????"),
+        ('Credentials', 'gs_external_account_file', None),
+        ('Credentials', 'gs_external_account_authorized_user_file', None),
+        ('Credentials', 'gs_oauth2_refresh_token', None),
+        ('Credentials', 'gs_service_client_id', None),
+        ('Credentials', 'gs_service_key_file', None),
+    ]):
+      self.assertTrue(boto_util.UsingGsHmac())

--- a/gslib/tests/test_context_config.py
+++ b/gslib/tests/test_context_config.py
@@ -265,11 +265,12 @@ class TestContextConfig(testcase.GsUtilUnitTestCase):
 
   @mock.patch('os.path.exists', new=mock.Mock(return_value=False))
   def test_default_provider_not_found_error(self):
-    with SetBotoConfigForTest([('Credentials', 'use_client_certificate',
-                                'True'),
-                               ('Credentials', 'cert_provider_command', None),
-                               # Avoids permissions error on Windows tests:
-                               ('GSUtil', 'state_dir', self.CreateTempDir())]):
+    with SetBotoConfigForTest([
+        ('Credentials', 'use_client_certificate', 'True'),
+        ('Credentials', 'cert_provider_command', None),
+        # Avoids permissions error on Windows tests:
+        ('GSUtil', 'state_dir', self.CreateTempDir())
+    ]):
       context_config.create_context_config(self.mock_logger)
 
       self.mock_logger.error.assert_called_once_with(

--- a/gslib/tests/test_shim_util.py
+++ b/gslib/tests/test_shim_util.py
@@ -1156,26 +1156,18 @@ class TestBotoTranslation(testcase.GsUtilUnitTestCase):
       flags, _ = self._fake_command._translate_boto_config()
       self.assertEqual(flags, ['--decryption-keys=key1,key12,key100'])
 
-  @mock.patch.object(boto_util, 'UsingGsHmac')
-  def test_gs_hmac_auth_env_set_correctly(self, mock_using_gs_hmac):
+  @mock.patch.object(boto_util, 'UsingGsHmac', return_value=False)
+  def test_gs_hmac_auth_env_when_not_using_gs_hmac(self, mock_using_gs_hmac):
     with _mock_boto_config({
         'Credentials': {
-            'gs_access_key_id': 'unmapped',
-            'gs_secret_access_key': 'mapped',
+            'gs_access_key_id': 'foo',
+            'gs_secret_access_key': 'bar',
         }
     }):
-      # Another use case that would have been good for parameterized.
-      # UsingGsHmac ultimately controls whether the gs HMAC creds
-      # are mapped, so the first key, gs_access_key_id, will not be
-      # mapped, while the second, gs_secret_access_key will.
-      mock_using_gs_hmac.side_effect = [False, True]
       flags, env_vars = self._fake_command._translate_boto_config()
       self.assertEqual(mock_using_gs_hmac.call_count, 2)
       self.assertEqual(flags, [])
-      expected_env_vars = {
-          'CLOUDSDK_STORAGE_GS_XML_SECRET_ACCESS_KEY': 'mapped'
-      }
-      self.assertEqual(env_vars, expected_env_vars)
+      self.assertEqual(env_vars, {})
 
   @mock.patch.object(boto_util, 'UsingGsHmac', return_value=True)
   def test_boto_config_translation_for_supported_fields(self, _):

--- a/gslib/tests/test_shim_util.py
+++ b/gslib/tests/test_shim_util.py
@@ -33,6 +33,7 @@ from gslib import exception
 from gslib.commands import version
 from gslib.commands import test
 from gslib.tests import testcase
+from gslib.utils import boto_util
 from gslib.utils import constants
 from gslib.utils import shim_util
 from gslib.tests import util
@@ -1155,12 +1156,40 @@ class TestBotoTranslation(testcase.GsUtilUnitTestCase):
       flags, _ = self._fake_command._translate_boto_config()
       self.assertEqual(flags, ['--decryption-keys=key1,key12,key100'])
 
+  @mock.patch.object(boto_util, 'UsingGsHmac')
+  def test_gs_hmac_auth_env_set_correctly(self, mock_using_gs_hmac):
+    with _mock_boto_config({
+        'Credentials': {
+            'gs_access_key_id': 'unmapped',
+            'gs_secret_access_key': 'mapped',
+        }
+    }):
+      # Another use case that would have been good for parameterized.
+      # UsingGsHmac ultimately controls whether the gs HMAC creds
+      # are mapped, so the first key, gs_access_key_id, will not be
+      # mapped, while the second, gs_secret_access_key will.
+      mock_using_gs_hmac.side_effect = [False, True]
+      flags, env_vars = self._fake_command._translate_boto_config()
+      self.assertEqual(mock_using_gs_hmac.call_count, 2)
+      self.assertEqual(flags, [])
+      expected_env_vars = {
+          'CLOUDSDK_STORAGE_GS_XML_SECRET_ACCESS_KEY': 'mapped'
+      }
+      self.assertEqual(env_vars, expected_env_vars)
+
   def test_boto_config_translation_for_supported_fields(self):
     with _mock_boto_config({
         'Credentials': {
-            'aws_access_key_id': 'AWS_ACCESS_KEY_ID_value',
-            'aws_secret_access_key': 'AWS_SECRET_ACCESS_KEY_value',
-            'use_client_certificate': True,
+            'aws_access_key_id':
+                'AWS_ACCESS_KEY_ID_value',
+            'aws_secret_access_key':
+                'AWS_SECRET_ACCESS_KEY_value',
+            'gs_access_key_id':
+                'CLOUDSDK_STORAGE_GS_XML_ACCESS_KEY_ID_value',
+            'gs_secret_access_key':
+                'CLOUDSDK_STORAGE_GS_XML_SECRET_ACCESS_KEY_value',
+            'use_client_certificate':
+                True,
         },
         'Boto': {
             'proxy': 'CLOUDSDK_PROXY_ADDRESS_value',
@@ -1195,31 +1224,60 @@ class TestBotoTranslation(testcase.GsUtilUnitTestCase):
       self.maxDiff = None
       self.assertDictEqual(
           env_vars, {
-              'AWS_ACCESS_KEY_ID': 'AWS_ACCESS_KEY_ID_value',
-              'AWS_SECRET_ACCESS_KEY': 'AWS_SECRET_ACCESS_KEY_value',
-              'CLOUDSDK_CONTEXT_AWARE_USE_CLIENT_CERTIFICATE': True,
-              'CLOUDSDK_PROXY_ADDRESS': 'CLOUDSDK_PROXY_ADDRESS_value',
-              'CLOUDSDK_PROXY_ADDRESS': 'CLOUDSDK_PROXY_ADDRESS_value',
-              'CLOUDSDK_PROXY_TYPE': 'CLOUDSDK_PROXY_TYPE_value',
-              'CLOUDSDK_PROXY_PORT': 'CLOUDSDK_PROXY_PORT_value',
-              'CLOUDSDK_PROXY_USERNAME': 'CLOUDSDK_PROXY_USERNAME_value',
-              'CLOUDSDK_PROXY_PASSWORD': 'CLOUDSDK_PROXY_PASSWORD_value',
-              'CLOUDSDK_PROXY_RDNS': 'CLOUDSDK_PROXY_RDNS_value',
-              'CLOUDSDK_CORE_HTTP_TIMEOUT': 'HTTP_TIMEOUT_value',
-              'CLOUDSDK_CORE_CUSTOM_CA_CERTS_FILE': 'CA_CERTS_FILE_value',
-              'CLOUDSDK_AUTH_DISABLE_SSL_VALIDATION': True,
-              'CLOUDSDK_STORAGE_BASE_RETRY_DELAY': 'BASE_RETRY_DELAY_value',
-              'CLOUDSDK_STORAGE_MAX_RETRIES': 'MAX_RETRIES_value',
-              'CLOUDSDK_STORAGE_CHECK_HASHES': 'CHECK_HASHES_value',
-              'CLOUDSDK_CORE_PROJECT': 'CLOUDSDK_CORE_PROJECT_value',
-              'CLOUDSDK_CORE_DISABLE_USAGE_REPORTING': 'USAGE_REPORTING_value',
-              'CLOUDSDK_STORAGE_USE_MAGICFILE': 'USE_MAGICFILE_value',
-              'CLOUDSDK_STORAGE_PARALLEL_COMPOSITE_UPLOAD_THRESHOLD': '100M',
-              'CLOUDSDK_STORAGE_RESUMABLE_THRESHOLD': '256K',
-              'CLOUDSDK_AUTH_CLIENT_ID': 'CLOUDSDK_AUTH_CLIENT_ID_value',
-              'CLOUDSDK_AUTH_CLIENT_SECRET': 'AUTH_CLIENT_SECRET_value',
-              'CLOUDSDK_AUTH_AUTH_HOST': 'CLOUDSDK_AUTH_AUTH_HOST_value',
-              'CLOUDSDK_AUTH_TOKEN_HOST': 'CLOUDSDK_AUTH_TOKEN_HOST_value',
+              'AWS_ACCESS_KEY_ID':
+                  'AWS_ACCESS_KEY_ID_value',
+              'AWS_SECRET_ACCESS_KEY':
+                  'AWS_SECRET_ACCESS_KEY_value',
+              'CLOUDSDK_STORAGE_GS_XML_ACCESS_KEY_ID':
+                  'CLOUDSDK_STORAGE_GS_XML_ACCESS_KEY_ID_value',
+              'CLOUDSDK_STORAGE_GS_XML_SECRET_ACCESS_KEY':
+                  'CLOUDSDK_STORAGE_GS_XML_SECRET_ACCESS_KEY_value',
+              'CLOUDSDK_CONTEXT_AWARE_USE_CLIENT_CERTIFICATE':
+                  True,
+              'CLOUDSDK_PROXY_ADDRESS':
+                  'CLOUDSDK_PROXY_ADDRESS_value',
+              'CLOUDSDK_PROXY_ADDRESS':
+                  'CLOUDSDK_PROXY_ADDRESS_value',
+              'CLOUDSDK_PROXY_TYPE':
+                  'CLOUDSDK_PROXY_TYPE_value',
+              'CLOUDSDK_PROXY_PORT':
+                  'CLOUDSDK_PROXY_PORT_value',
+              'CLOUDSDK_PROXY_USERNAME':
+                  'CLOUDSDK_PROXY_USERNAME_value',
+              'CLOUDSDK_PROXY_PASSWORD':
+                  'CLOUDSDK_PROXY_PASSWORD_value',
+              'CLOUDSDK_PROXY_RDNS':
+                  'CLOUDSDK_PROXY_RDNS_value',
+              'CLOUDSDK_CORE_HTTP_TIMEOUT':
+                  'HTTP_TIMEOUT_value',
+              'CLOUDSDK_CORE_CUSTOM_CA_CERTS_FILE':
+                  'CA_CERTS_FILE_value',
+              'CLOUDSDK_AUTH_DISABLE_SSL_VALIDATION':
+                  True,
+              'CLOUDSDK_STORAGE_BASE_RETRY_DELAY':
+                  'BASE_RETRY_DELAY_value',
+              'CLOUDSDK_STORAGE_MAX_RETRIES':
+                  'MAX_RETRIES_value',
+              'CLOUDSDK_STORAGE_CHECK_HASHES':
+                  'CHECK_HASHES_value',
+              'CLOUDSDK_CORE_PROJECT':
+                  'CLOUDSDK_CORE_PROJECT_value',
+              'CLOUDSDK_CORE_DISABLE_USAGE_REPORTING':
+                  'USAGE_REPORTING_value',
+              'CLOUDSDK_STORAGE_USE_MAGICFILE':
+                  'USE_MAGICFILE_value',
+              'CLOUDSDK_STORAGE_PARALLEL_COMPOSITE_UPLOAD_THRESHOLD':
+                  '100M',
+              'CLOUDSDK_STORAGE_RESUMABLE_THRESHOLD':
+                  '256K',
+              'CLOUDSDK_AUTH_CLIENT_ID':
+                  'CLOUDSDK_AUTH_CLIENT_ID_value',
+              'CLOUDSDK_AUTH_CLIENT_SECRET':
+                  'AUTH_CLIENT_SECRET_value',
+              'CLOUDSDK_AUTH_AUTH_HOST':
+                  'CLOUDSDK_AUTH_AUTH_HOST_value',
+              'CLOUDSDK_AUTH_TOKEN_HOST':
+                  'CLOUDSDK_AUTH_TOKEN_HOST_value',
           })
 
   def test_missing_mappging_gets_ignored(self):

--- a/gslib/tests/test_shim_util.py
+++ b/gslib/tests/test_shim_util.py
@@ -1177,7 +1177,8 @@ class TestBotoTranslation(testcase.GsUtilUnitTestCase):
       }
       self.assertEqual(env_vars, expected_env_vars)
 
-  def test_boto_config_translation_for_supported_fields(self):
+  @mock.patch.object(boto_util, 'UsingGsHmac', return_value=True)
+  def test_boto_config_translation_for_supported_fields(self, _):
     with _mock_boto_config({
         'Credentials': {
             'aws_access_key_id':

--- a/gslib/utils/boto_util.py
+++ b/gslib/utils/boto_util.py
@@ -655,8 +655,12 @@ def UsingGsHmac():
   # NOTE: External credentials are omitted intentionally as HMAC takes priority
   # over the external credentials types.
   config = boto.config
-  return (not config.has_option('Credentials', 'gs_oauth2_refresh_token') and
-        not (config.has_option('Credentials', 'gs_service_client_id') and
-             config.has_option('Credentials', 'gs_service_key_file')) and
-        (config.has_option('Credentials', 'gs_access_key_id') and
-         config.has_option('Credentials', 'gs_secret_access_key')))
+  has_refresh_token = config.has_option('Credentials', 'gs_oauth2_refresh_token')
+  has_service_account_credentials = (
+    config.has_option('Credentials', 'gs_service_client_id')
+    and config.has_option('Credentials', 'gs_service_key_file'))
+  has_hmac_creds = (
+    config.has_option('Credentials', 'gs_access_key_id')
+    and config.has_option('Credentials', 'gs_secret_access_key'))
+  return (not has_refresh_token and not has_service_account_credentials
+    and has_hmac_creds)

--- a/gslib/utils/boto_util.py
+++ b/gslib/utils/boto_util.py
@@ -659,8 +659,8 @@ def UsingGsHmac():
   has_service_account_credentials = (
     config.has_option('Credentials', 'gs_service_client_id')
     and config.has_option('Credentials', 'gs_service_key_file'))
-  has_hmac_creds = (
+  has_hmac_credentials = (
     config.has_option('Credentials', 'gs_access_key_id')
     and config.has_option('Credentials', 'gs_secret_access_key'))
   return (not has_refresh_token and not has_service_account_credentials
-    and has_hmac_creds)
+    and has_hmac_credentials)

--- a/gslib/utils/boto_util.py
+++ b/gslib/utils/boto_util.py
@@ -650,3 +650,13 @@ def HasUserSpecifiedGsHost():
     return default_host == six.ensure_str(gs_host)
 
   return False
+
+def UsingGsHmac():
+  # NOTE: External credentials are omitted intentionally as HMAC takes priority
+  # over the external credentials types.
+  config = boto.config
+  return (not config.has_option('Credentials', 'gs_oauth2_refresh_token') and
+        not (config.has_option('Credentials', 'gs_service_client_id') and
+             config.has_option('Credentials', 'gs_service_key_file')) and
+        (config.has_option('Credentials', 'gs_access_key_id') and
+         config.has_option('Credentials', 'gs_secret_access_key')))

--- a/gslib/utils/shim_util.py
+++ b/gslib/utils/shim_util.py
@@ -27,6 +27,8 @@ import subprocess
 
 from boto import config
 from gslib import exception
+from gslib.cs_api_map import ApiSelector
+from gslib.exception import CommandException
 from gslib.utils import boto_util
 from gslib.utils import constants
 
@@ -590,6 +592,12 @@ class GcloudStorageCommandMixin(object):
               ' You can make gsutil use the same credentials by running:\n'
               '{} config set pass_credentials_to_gsutil True'.format(
                   gcloud_binary_path))
+        elif (boto_util.UsingGsHmac and
+              ApiSelector.XML not in self.command_spec.gs_api_support):
+          raise CommandException(
+              'Requested to use "gcloud storage" with Cloud Storage XML API'
+              ' HMAC credentials but the "{}" command can only be used'
+              ' with the Cloud Storage JSON API.'.format(self.command_name))
         else:
           self._print_gcloud_storage_command_info(gcloud_storage_command,
                                                   env_variables)

--- a/gslib/utils/shim_util.py
+++ b/gslib/utils/shim_util.py
@@ -491,8 +491,8 @@ class GcloudStorageCommandMixin(object):
         elif key == 'https_validate_certificates' and not value:
           env_vars['CLOUDSDK_AUTH_DISABLE_SSL_VALIDATION'] = True
         # Skip mapping GS HMAC auth keys if gsutil wouldn't use them.
-        elif (not boto_util.UsingGsHmac() and
-              key in ('gs_access_key_id', 'gs_secret_access_key')):
+        elif (key in ('gs_access_key_id', 'gs_secret_access_key') and
+              not boto_util.UsingGsHmac()):
           self.logger.debug('The boto config field {}:{} skipped translation'
                             ' to the gcloud storage equivalent as it would'
                             ' have been unused in gsutil.'.format(

--- a/gslib/utils/shim_util.py
+++ b/gslib/utils/shim_util.py
@@ -592,7 +592,7 @@ class GcloudStorageCommandMixin(object):
               ' You can make gsutil use the same credentials by running:\n'
               '{} config set pass_credentials_to_gsutil True'.format(
                   gcloud_binary_path))
-        elif (boto_util.UsingGsHmac and
+        elif (boto_util.UsingGsHmac() and
               ApiSelector.XML not in self.command_spec.gs_api_support):
           raise CommandException(
               'Requested to use "gcloud storage" with Cloud Storage XML API'


### PR DESCRIPTION
This will apply HMAC credentials to gcloud storage when appropriate. When supplied to gcloud storage, the HMAC credentials take precedence, so the shim needs to include gsutil's prioritization logic when applying those credentials. This PR encapsulates that prioritization logic in `boto_util.UsingGsHmac()` and applies it in both `cloud_api_delegator` and `shim_util`.