### PR TITLE
Fix Python 3.8 Unicode error in test

### DIFF
--- a/gslib/tests/test_rewrite.py
+++ b/gslib/tests/test_rewrite.py
@@ -185,9 +185,9 @@ class TestRewrite(testcase.GsUtilIntegrationTestCase):
 
     # Rotate all keys to TEST_ENCRYPTION_KEY1.
     boto_config_for_test = [
-        ('GSUtil', 'encryption_key', TEST_ENCRYPTION_KEY1.decode('ascii')),
-        ('GSUtil', 'decryption_key1', TEST_ENCRYPTION_KEY2.decode('ascii')),
-        ('GSUtil', 'decryption_key2', TEST_ENCRYPTION_KEY3.decode('ascii'))
+        ('GSUtil', 'encryption_key', TEST_ENCRYPTION_KEY1.decode('utf-8')),
+        ('GSUtil', 'decryption_key1', TEST_ENCRYPTION_KEY2.decode('utf-8')),
+        ('GSUtil', 'decryption_key2', TEST_ENCRYPTION_KEY3.decode('utf-8'))
     ]
 
     with SetBotoConfigForTest(boto_config_for_test):


### PR DESCRIPTION
The tests mentioned in the bug are 
```
gslib.tests.test_rewrite.TestRewrite.test_parallel_rewrite_bucket_flat_wildcard
gslib.tests.test_cp.TestCp.test_gzip_transport_encoded_parallel_upload_resumable
```

I couldn't reproduce flakes regarding the second test, and the bug does not contain a sponge log or details for it. Therefore, I'm ignoring it for now.

For the first test, I'm not certain why this PR works. I theorize something about the encryption key text does not interact well with the conversion from ASCII (with `.encode`) to Unicode (from `RunGsUtil`).

There are some mentions of encoding in the Python 3.8 change log that may explain why this issue affects 3.8 only.

https://docs.python.org/3/whatsnew/3.8.html

I also saw this in the 3.9 changelog, which might explain why the issue was fixed after 3.8: "Decoding short ASCII strings with UTF-8 and ascii codecs is now about 15% faster." Perhaps, the optimization also contained a bug fix because "short ASCII strings" decoded to UTF-8 sounds like our case.
https://docs.python.org/3/whatsnew/3.9.html

Despite this unsatisfactory explanation for the flakes, I re-ran Kokoro three times and was not able to reproduce the `test_parallel_rewrite_bucket_flat_wildcard` issue with this PR.