### PR TITLE
Allow setting schema in gs_json_host

### DIFF
--- a/gslib/gcs_json_api.py
+++ b/gslib/gcs_json_api.py
@@ -278,6 +278,12 @@ class GcsJsonApi(CloudApi):
             'gs_json_host and gs_json_port to match your desired endpoint.' %
             gs_host)
 
+    self.http_base = 'https://'
+    if gs_json_host and \
+      (gs_json_host.startswith('http://') \
+       or gs_json_host.startswith('https://')):
+      self.http_base = ''
+
     gs_json_port = config.get('Credentials', 'gs_json_port', None)
 
     if not gs_json_port:

--- a/gslib/tests/test_gcs_json_api.py
+++ b/gslib/tests/test_gcs_json_api.py
@@ -63,9 +63,17 @@ class TestGcsJsonApi(testcase.GsUtilUnitTestCase):
     with SetBotoConfigForTest([('Credentials', 'gs_json_host', 'host')]):
       client = gcs_json_api.GcsJsonApi(None, None, None, None)
       self.assertEqual(client.host_base, 'host')
+      self.assertEqual(client.http_base, 'https://')
+  
+  def testSetsCustomJsonHostWithSchema(self):
+    with SetBotoConfigForTest([('Credentials', 'gs_json_host', 'http://host')]):
+      client = gcs_json_api.GcsJsonApi(None, None, None, None)
+      self.assertEqual(client.host_base, 'http://host')
+      self.assertEqual(client.http_base, '')
 
   def testSetsDefaultHost(self):
     with SetBotoConfigForTest([('Credentials', 'gs_json_host', None),
                                ('Credentials', 'gs_host', None)]):
       client = gcs_json_api.GcsJsonApi(None, None, None, None)
       self.assertEqual(client.host_base, gcs_json_api.DEFAULT_HOST)
+      self.assertEqual(client.http_base, 'https://')

--- a/gslib/tests/test_shim_util.py
+++ b/gslib/tests/test_shim_util.py
@@ -1155,6 +1155,22 @@ class TestBotoTranslation(testcase.GsUtilUnitTestCase):
                   'https://foo_host:1234/storage/v2',
           })
 
+  def test_gcs_json_endpoint_translation_with_schema_in_host(self):
+    with _mock_boto_config({
+        'Credentials': {
+            'gs_json_host': 'http://foo_host',
+            'gs_json_port': '1234',
+            'json_api_version': 'v2',
+        }
+    }):
+      flags, env_vars = self._fake_command._translate_boto_config()
+      self.assertEqual(flags, [])
+      self.assertEqual(
+          env_vars, {
+              'CLOUDSDK_API_ENDPOINT_OVERRIDES_STORAGE':
+                  'http://foo_host:1234/storage/v2',
+          })
+
   def test_gcs_json_endpoint_translation_with_missing_port(self):
     with _mock_boto_config({
         'Credentials': {

--- a/gslib/utils/shim_util.py
+++ b/gslib/utils/shim_util.py
@@ -254,10 +254,14 @@ def _get_gcloud_binary_path():
 def _get_gcs_json_endpoint_from_boto_config(config):
   gs_json_host = config.get('Credentials', 'gs_json_host')
   if gs_json_host:
+    http_base = '' \
+      if gs_json_host.startswith('http://') \
+        or gs_json_host.startswith('https://') \
+      else 'https://'
     gs_json_port = config.get('Credentials', 'gs_json_port')
     port = ':' + gs_json_port if gs_json_port else ''
     json_api_version = config.get('Credentials', 'json_api_version', 'v1')
-    return 'https://{}{}/storage/{}'.format(gs_json_host, port,
+    return '{}{}{}/storage/{}'.format(http_base,gs_json_host, port,
                                             json_api_version)
   return None
 


### PR DESCRIPTION
Allowing the user to specify the schema when providing the `gc_json_host`