### PR TITLE
Shim output formatting fixes for hmac and bpo

### DIFF
--- a/gslib/commands/bucketpolicyonly.py
+++ b/gslib/commands/bucketpolicyonly.py
@@ -123,9 +123,13 @@ class BucketPolicyOnlyCommand(Command):
       },
   )
 
-  # Get command will display "Uniform bucket-level access" display string, but
-  # contents are otherwise identical.
+  # The get subcommand works exactly like ubla except we want to replace
+  # "Uniform bucket-level access" with the bpo text.
   gcloud_storage_map = ubla.UblaCommand.gcloud_storage_map
+  format_flag = gcloud_storage_map.gcloud_command['get'].gcloud_command[4]
+  gcloud_storage_map.gcloud_command['get'].gcloud_command[
+      4] = format_flag.replace('Uniform bucket-level access',
+                               'Bucket Policy Only')
 
   def _ValidateBucketListingRefAndReturnBucketName(self, blr):
     if blr.storage_url.scheme != 'gs':

--- a/gslib/commands/bucketpolicyonly.py
+++ b/gslib/commands/bucketpolicyonly.py
@@ -126,9 +126,9 @@ class BucketPolicyOnlyCommand(Command):
   # The get subcommand works exactly like ubla except we want to replace
   # "Uniform bucket-level access" with the bpo text.
   gcloud_storage_map = ubla.UblaCommand.gcloud_storage_map
-  format_flag = gcloud_storage_map.gcloud_command['get'].gcloud_command[4]
+  format_flag = gcloud_storage_map.gcloud_command['get'].gcloud_command[3]
   gcloud_storage_map.gcloud_command['get'].gcloud_command[
-      4] = format_flag.replace('Uniform bucket-level access',
+      3] = format_flag.replace('Uniform bucket-level access',
                                'Bucket Policy Only')
 
   def _ValidateBucketListingRefAndReturnBucketName(self, blr):

--- a/gslib/commands/hmac.py
+++ b/gslib/commands/hmac.py
@@ -215,13 +215,15 @@ _CREATE_COMMAND_FORMAT = ('--format=value[separator="' +
                           'format("Secret:      {}", secret))')
 _DESCRIBE_COMMAND_FORMAT = (
     '--format=value[separator="' + shim_util.get_format_flag_newline() +
-    '"](format("Access ID {}:", accessId),' + 'format("\tState: {}", state),' +
-    'format("\tService Account: {}", serviceAccountEmail),' +
-    'format("\tProject: {}", projectId),' + 'format("\tTime Created: {}",' +
+    '"](format("Access ID {}:", accessId),' +
+    'format("\tState:                 {}", state),' +
+    'format("\tService Account:       {}", serviceAccountEmail),' +
+    'format("\tProject:               {}", projectId),' +
+    'format("\tTime Created:          {}",' +
     ' timeCreated.date(format="%a %d %b %Y %H:%M:%S GMT")),' +
-    'format("\tTime Last Updated: {}",' +
+    'format("\tTime Last Updated:     {}",' +
     ' updated.date(format="%a %d %b %Y %H:%M:%S GMT")),' +
-    'format("\tEtag: {}", etag))')
+    'format("\tEtag:                  {}", etag))')
 
 _LIST_COMMAND_SHORT_FORMAT = (
     '--format=table[no-heading](format("{} ", accessId),'


### PR DESCRIPTION
- Adds tabs to hmac get shim output string to make it match gsutil.
- Fixes shim output string for bucketpolicyonly get command so it maches gsutil.