### PR TITLE
Allow accessing public data with anonymous user  when shim is turned ON

### DIFF
--- a/gslib/utils/shim_util.py
+++ b/gslib/utils/shim_util.py
@@ -362,6 +362,11 @@ class GcloudStorageCommandMixin(object):
         [gcloud_path, 'config', 'get', 'account'],
         stdout=subprocess.PIPE, stderr=subprocess.PIPE
       )
+      if process.returncode:
+        raise exception.GcloudStorageTranslationError(
+          "Error occurred while trying to retrieve gcloud's active account."
+          " Error: {}".format(process.stderr)
+        )
       # stdout will have the name of the account if active account is available.
       # Empty string indicates no active account available.
       self._gcloud_has_active_account = process.stdout.strip() !=  b''

--- a/gslib/utils/shim_util.py
+++ b/gslib/utils/shim_util.py
@@ -590,7 +590,7 @@ class GcloudStorageCommandMixin(object):
 
     if not self.gcloud_has_active_account(gcloud_binary_path):
       # Allow running gcloud with anonymous credentials.
-      env_variables['CLOUDSDK_AUTH_DISABLE_CREDENTIALS'] = True
+      env_variables['CLOUDSDK_AUTH_DISABLE_CREDENTIALS'] = 'True'
 
     gcloud_storage_command = ([gcloud_binary_path] + args + top_level_flags +
                               header_flags + flags_from_boto)


### PR DESCRIPTION
Accessing public data does not require authentication. In gsutil, this works out-of-the-box. In `gcloud storage`, the user has to set `auth/disable_credentials` property to use it without authentication (i.e without setting up an active account). For the shim, in order to not break the workflow of existing users who rely on the gsutil behavior, we will set the `auth/disable_credentials` property automatically if we detect that `gcloud` doesn't have any active account configured.

The change has been tested manually

### Before:
```
$ CLOUDSDK_CORE_PASS_CREDENTIALS_TO_GSUTIL=1 GCLOUD_BINARY_PATH=/usr/bin/gcloud python3 gsutil.py -o "GSUtil:use_gcloud_storage=True"  ls  gs://pub/test.txt
ERROR: (gcloud.storage.ls) You do not currently have an active account selected.
Please run:

  $ gcloud auth login

to obtain new credentials.

If you have already logged in with a different account, run:

  $ gcloud config set account ACCOUNT

to select an already authenticated account to use.

```

### After:
```
$ CLOUDSDK_CORE_PASS_CREDENTIALS_TO_GSUTIL=1 GCLOUD_BINARY_PATH=/usr/bin/gcloud python3 gsutil.py -o "GSUtil:use_gcloud_storage=True"  ls  gs://pub/test.txt
gs://pub/test.txt
```