### PR TITLE
Allow accessing public data with anonymous user when shim is turned ON

### DIFF
--- a/gslib/tests/test_acl.py
+++ b/gslib/tests/test_acl.py
@@ -823,7 +823,7 @@ class TestAclOldAlias(TestAcl):
   _ch_acl_prefix = ['chacl']
 
 
-class TestAclShim(testcase.GsUtilUnitTestCase):
+class TestAclShim(testcase.ShimUnitTestBase):
 
   @mock.patch.object(acl.AclCommand, 'RunCommand', new=mock.Mock())
   def test_shim_translates_acl_get_object(self):

--- a/gslib/tests/test_autoclass.py
+++ b/gslib/tests/test_autoclass.py
@@ -31,22 +31,22 @@ class TestAutoclassUnit(testcase.GsUtilUnitTestCase):
 
   def test_set_too_few_arguments_fails(self):
     with self.assertRaisesRegex(exception.CommandException,
-                                 'command requires at least'):
+                                'command requires at least'):
       self.RunCommand('autoclass', ['set'])
 
   def test_get_too_few_arguments_fails(self):
     with self.assertRaisesRegex(exception.CommandException,
-                                 'command requires at least'):
+                                'command requires at least'):
       self.RunCommand('autoclass', ['get'])
 
   def test_no_subcommand_fails(self):
     with self.assertRaisesRegex(exception.CommandException,
-                                 'command requires at least'):
+                                'command requires at least'):
       self.RunCommand('autoclass', [])
 
   def test_invalid_subcommand_fails(self):
     with self.assertRaisesRegex(exception.CommandException,
-                                 'Invalid subcommand'):
+                                'Invalid subcommand'):
       self.RunCommand('autoclass', ['fakecommand', 'test'])
 
   def test_gets_multiple_buckets_with_wildcard(self):

--- a/gslib/tests/test_cat.py
+++ b/gslib/tests/test_cat.py
@@ -209,7 +209,7 @@ class TestCat(testcase.GsUtilIntegrationTestCase):
       self.assertEqual(stdout, '123')
 
 
-class TestShimCatFlags(testcase.GsUtilUnitTestCase):
+class TestShimCatFlags(testcase.ShimUnitTestBase):
   """Unit tests for shimming cat flags"""
 
   def test_shim_translates_flags(self):

--- a/gslib/tests/test_copy_objects_iterator.py
+++ b/gslib/tests/test_copy_objects_iterator.py
@@ -73,7 +73,7 @@ class TestCopyObjectsIterator(testcase.GsUtilUnitTestCase):
     for (src_string, dst_string) in src_dst_strings:
       copy_object_info = next(copy_objects_iterator)
       self.assertEqual(src_string,
-                        copy_object_info.source_storage_url.object_name)
+                       copy_object_info.source_storage_url.object_name)
       self.assertEqual(dst_string, copy_object_info.exp_dst_url.object_name)
 
     iterator_ended = False

--- a/gslib/tests/test_cp.py
+++ b/gslib/tests/test_cp.py
@@ -2137,8 +2137,8 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
 
     _Check1()
 
-  @unittest.skipIf(
-      IS_WINDOWS, 'Unicode handling on Windows requires mods to site-packages')
+  @unittest.skipIf(IS_WINDOWS,
+                   'Unicode handling on Windows requires mods to site-packages')
   @SequentialAndParallelTransfer
   def test_cp_manifest_upload_unicode(self):
     return self._ManifestUpload('foo-unicöde'.encode(UTF8),

--- a/gslib/tests/test_cp.py
+++ b/gslib/tests/test_cp.py
@@ -5009,6 +5009,10 @@ class TestCpUnitTests(testcase.GsUtilUnitTestCase):
     self.assertEqual(sub_opts, [('--flag-key', 'flag-value'),
                                 ('-a', 'publicRead'), ('-a', 'does-not-exist')])
 
+
+class TestCpShimUnitTests(testcase.ShimUnitTestBase):
+  """Unit tests for shimming cp flags"""
+
   def test_shim_translates_flags(self):
     bucket_uri = self.CreateBucket()
     fpath = self.CreateTempFile(contents=b'abcd')

--- a/gslib/tests/test_defacl.py
+++ b/gslib/tests/test_defacl.py
@@ -232,7 +232,7 @@ class TestDefacl(case.GsUtilIntegrationTestCase):
     self.assertIn('command requires at least', stderr)
 
 
-class TestDefaclShim(case.GsUtilUnitTestCase):
+class TestDefaclShim(case.ShimUnitTestBase):
 
   @mock.patch.object(defacl.DefAclCommand, 'RunCommand', new=mock.Mock())
   def test_shim_translates_defacl_get(self):

--- a/gslib/tests/test_hash.py
+++ b/gslib/tests/test_hash.py
@@ -147,7 +147,7 @@ class TestHash(testcase.GsUtilIntegrationTestCase):
     self.assertIn(('\tHash (crc32c):\t\t%s' % _TEST_COMPOSITE_B64_CRC), stdout)
 
 
-class TestHashShim(testcase.GsUtilUnitTestCase):
+class TestHashShim(testcase.ShimUnitTestBase):
 
   @mock.patch.object(hash.HashCommand, 'RunCommand', new=mock.Mock())
   def test_shim_translates_basic_hash_command(self):

--- a/gslib/tests/test_hmac.py
+++ b/gslib/tests/test_hmac.py
@@ -87,7 +87,7 @@ class TestHmacIntegration(testcase.GsUtilIntegrationTestCase):
     self.assertRegex(output_string, r'Access ID %s:' % access_id)
     self.assertRegex(output_string, r'\sState:\s+%s' % state)
     self.assertRegex(output_string,
-                             r'\s+Service Account:\s+%s\n' % service_account)
+                     r'\s+Service Account:\s+%s\n' % service_account)
     self.assertRegex(output_string, r'\s+Project:\s+%s' % project)
     self.assertRegex(output_string, r'\s+Time Created:\s+.*')
     self.assertRegex(output_string, r'\s+Time Last Updated:\s+.*')

--- a/gslib/tests/test_hmac.py
+++ b/gslib/tests/test_hmac.py
@@ -412,7 +412,7 @@ class TestHmacXmlIntegration(testcase.GsUtilIntegrationTestCase):
             'The "hmac" command can only be used with the GCS JSON API', stderr)
 
 
-class TestHmacUnit(testcase.GsUtilUnitTestCase):
+class TestHmacUnitShim(testcase.ShimUnitTestBase):
 
   @mock.patch.object(hmac.HmacCommand, 'RunCommand', new=mock.Mock())
   def test_shim_translates_hmac_create_command(self):

--- a/gslib/tests/test_iam.py
+++ b/gslib/tests/test_iam.py
@@ -1510,7 +1510,7 @@ class TestIamSet(TestIamIntegration):
                   json.loads(set_iam_string)['bindings'])
 
 
-class TestIamShim(testcase.GsUtilUnitTestCase):
+class TestIamShim(testcase.ShimUnitTestBase):
 
   @mock.patch.object(iam.IamCommand, 'RunCommand', new=mock.Mock())
   def test_shim_translates_iam_get_object(self):

--- a/gslib/tests/test_iam.py
+++ b/gslib/tests/test_iam.py
@@ -1511,6 +1511,17 @@ class TestIamSet(TestIamIntegration):
 
 
 class TestIamShim(testcase.ShimUnitTestBase):
+  _FAKE_CONFIG_GET_ACCOUNT_PROCESS = subprocess.CompletedProcess(
+      args=[], returncode=0, stdout='fake_account@gmail.com')
+  _MOCK_CONFIG_GET_ACCOUNT_CALL = mock.call(
+      [
+          shim_util._get_gcloud_binary_path('fake_dir'), 'config', 'get',
+          'account'
+      ],
+      stderr=-1,
+      stdout=-1,
+      encoding='utf-8',
+  )
 
   @mock.patch.object(iam.IamCommand, 'RunCommand', new=mock.Mock())
   def test_shim_translates_iam_get_object(self):
@@ -1673,8 +1684,7 @@ class TestIamShim(testcase.ShimUnitTestBase):
                      stdout=stdout,
                      text=text)
 
-  @mock.patch.object(subprocess, 'run', autospec=True)
-  def test_iam_ch_adds_updates_and_deletes_bucket_policies(self, mock_run):
+  def test_iam_ch_adds_updates_and_deletes_bucket_policies(self):
     original_policy = {
         'bindings': [{
             'role': 'preserved-role',
@@ -1700,7 +1710,9 @@ class TestIamShim(testcase.ShimUnitTestBase):
       get_process = subprocess.CompletedProcess(
           args=[], returncode=0, stdout=json.dumps(original_policy))
       set_process = subprocess.CompletedProcess(args=[], returncode=0)
-      mock_run.side_effect = [get_process, set_process]
+      self._mock_subprocess_run.side_effect = [
+          self._FAKE_CONFIG_GET_ACCOUNT_PROCESS, get_process, set_process
+      ]
       with SetEnvironmentForTest({
           'CLOUDSDK_CORE_PASS_CREDENTIALS_TO_GSUTIL': 'True',
           'CLOUDSDK_ROOT_DIR': 'fake_dir',
@@ -1711,7 +1723,8 @@ class TestIamShim(testcase.ShimUnitTestBase):
             'gs://b'
         ])
 
-      self.assertEqual(mock_run.call_args_list, [
+      self.assertEqual(self._mock_subprocess_run.call_args_list, [
+          self._MOCK_CONFIG_GET_ACCOUNT_CALL,
           self._get_run_call([
               shim_util._get_gcloud_binary_path('fake_dir'), 'storage',
               'buckets', 'get-iam-policy', 'gs://b/', '--format=json'
@@ -1727,8 +1740,7 @@ class TestIamShim(testcase.ShimUnitTestBase):
                              stdin=json.dumps(new_policy, sort_keys=True))
       ])
 
-  @mock.patch.object(subprocess, 'run', autospec=True)
-  def test_iam_ch_updates_bucket_policies_for_multiple_urls(self, mock_run):
+  def test_iam_ch_updates_bucket_policies_for_multiple_urls(self):
     original_policy1 = {
         'bindings': [{
             'role': 'roles/storage.modified-role',
@@ -1759,8 +1771,9 @@ class TestIamShim(testcase.ShimUnitTestBase):
       get_process2 = subprocess.CompletedProcess(
           args=[], returncode=0, stdout=json.dumps(original_policy2))
       set_process = subprocess.CompletedProcess(args=[], returncode=0)
-      mock_run.side_effect = [
-          get_process1, set_process, get_process2, set_process
+      self._mock_subprocess_run.side_effect = [
+          self._FAKE_CONFIG_GET_ACCOUNT_PROCESS, get_process1, set_process,
+          get_process2, set_process
       ]
 
       with SetEnvironmentForTest({
@@ -1771,7 +1784,8 @@ class TestIamShim(testcase.ShimUnitTestBase):
             'iam',
             ['ch', 'allAuthenticatedUsers:modified-role', 'gs://b1', 'gs://b2'])
 
-      self.assertEqual(mock_run.call_args_list, [
+      self.assertEqual(self._mock_subprocess_run.call_args_list, [
+          self._MOCK_CONFIG_GET_ACCOUNT_CALL,
           self._get_run_call([
               shim_util._get_gcloud_binary_path('fake_dir'), 'storage',
               'buckets', 'get-iam-policy', 'gs://b1/', '--format=json'
@@ -1800,8 +1814,7 @@ class TestIamShim(testcase.ShimUnitTestBase):
                              stdin=json.dumps(new_policy2, sort_keys=True))
       ])
 
-  @mock.patch.object(subprocess, 'run', autospec=True)
-  def test_iam_ch_updates_object_policies(self, mock_run):
+  def test_iam_ch_updates_object_policies(self):
     original_policy = {
         'bindings': [{
             'role': 'roles/storage.modified-role',
@@ -1824,7 +1837,10 @@ class TestIamShim(testcase.ShimUnitTestBase):
       get_process = subprocess.CompletedProcess(
           args=[], returncode=0, stdout=json.dumps(original_policy))
       set_process = subprocess.CompletedProcess(args=[], returncode=0)
-      mock_run.side_effect = [ls_process, get_process, set_process]
+      self._mock_subprocess_run.side_effect = [
+          self._FAKE_CONFIG_GET_ACCOUNT_PROCESS, ls_process, get_process,
+          set_process
+      ]
       with SetEnvironmentForTest({
           'CLOUDSDK_CORE_PASS_CREDENTIALS_TO_GSUTIL': 'True',
           'CLOUDSDK_ROOT_DIR': 'fake_dir',
@@ -1832,7 +1848,8 @@ class TestIamShim(testcase.ShimUnitTestBase):
         self.RunCommand(
             'iam', ['ch', 'allAuthenticatedUsers:modified-role', 'gs://b/o'])
 
-      self.assertEqual(mock_run.call_args_list, [
+      self.assertEqual(self._mock_subprocess_run.call_args_list, [
+          self._MOCK_CONFIG_GET_ACCOUNT_CALL,
           self._get_run_call([
               shim_util._get_gcloud_binary_path('fake_dir'), 'storage', 'ls',
               '--json', 'gs://b/o'
@@ -1852,9 +1869,8 @@ class TestIamShim(testcase.ShimUnitTestBase):
                              stdin=json.dumps(new_policy, sort_keys=True))
       ])
 
-  @mock.patch.object(subprocess, 'run', autospec=True)
   def test_iam_ch_expands_urls_with_recursion_and_ignores_container_headers(
-      self, mock_run):
+      self):
     original_policy = {
         'bindings': [{
             'role': 'modified-role',
@@ -1880,7 +1896,9 @@ class TestIamShim(testcase.ShimUnitTestBase):
       get_process = subprocess.CompletedProcess(
           args=[], returncode=0, stdout=json.dumps(original_policy))
       set_process = subprocess.CompletedProcess(args=[], returncode=0)
-      mock_run.side_effect = [ls_process] + [get_process, set_process] * 3
+      self._mock_subprocess_run.side_effect = (
+          [self._FAKE_CONFIG_GET_ACCOUNT_PROCESS, ls_process] +
+          [get_process, set_process] * 3)
       with SetEnvironmentForTest({
           'CLOUDSDK_CORE_PASS_CREDENTIALS_TO_GSUTIL': 'True',
           'CLOUDSDK_ROOT_DIR': 'fake_dir',
@@ -1889,7 +1907,8 @@ class TestIamShim(testcase.ShimUnitTestBase):
             'iam',
             ['ch', '-r', 'allAuthenticatedUsers:modified-role', 'gs://b'])
 
-      self.assertEqual(mock_run.call_args_list, [
+      self.assertEqual(self._mock_subprocess_run.call_args_list, [
+          self._MOCK_CONFIG_GET_ACCOUNT_CALL,
           self._get_run_call([
               shim_util._get_gcloud_binary_path('fake_dir'), 'storage', 'ls',
               '--json', '-r', 'gs://b/'
@@ -1922,13 +1941,14 @@ class TestIamShim(testcase.ShimUnitTestBase):
                              stdin=mock.ANY)
       ])
 
-  @mock.patch.object(subprocess, 'run', autospec=True)
-  def test_iam_ch_raises_ls_error(self, mock_run):
+  def test_iam_ch_raises_ls_error(self):
     with SetBotoConfigForTest([('GSUtil', 'use_gcloud_storage', 'True')]):
+      get_account_process = subprocess.CompletedProcess(
+          args=[], returncode=0, stdout='fake_account@gmail.com')
       ls_process = subprocess.CompletedProcess(args=[],
                                                returncode=1,
                                                stderr='An error.')
-      mock_run.side_effect = [ls_process]
+      self._mock_subprocess_run.side_effect = [get_account_process, ls_process]
 
       with SetEnvironmentForTest({
           'CLOUDSDK_CORE_PASS_CREDENTIALS_TO_GSUTIL': 'True',
@@ -1937,11 +1957,12 @@ class TestIamShim(testcase.ShimUnitTestBase):
         with self.assertRaisesRegex(CommandException, 'An error.'):
           self.RunCommand(
               'iam', ['ch', 'allAuthenticatedUsers:modified-role', 'gs://b/o'])
-        self.assertEqual(mock_run.call_count, 1)
+        self.assertEqual(self._mock_subprocess_run.call_count, 2)
 
-  @mock.patch.object(subprocess, 'run', autospec=True)
-  def test_iam_ch_raises_get_error(self, mock_run):
+  def test_iam_ch_raises_get_error(self):
     with SetBotoConfigForTest([('GSUtil', 'use_gcloud_storage', 'True')]):
+      get_account_process = subprocess.CompletedProcess(
+          args=[], returncode=0, stdout='fake_account@gmail.com')
       ls_process = subprocess.CompletedProcess(args=[],
                                                returncode=0,
                                                stdout=json.dumps([{
@@ -1951,7 +1972,9 @@ class TestIamShim(testcase.ShimUnitTestBase):
       get_process = subprocess.CompletedProcess(args=[],
                                                 returncode=1,
                                                 stderr='An error.')
-      mock_run.side_effect = [ls_process, get_process]
+      self._mock_subprocess_run.side_effect = [
+          get_account_process, ls_process, get_process
+      ]
 
       with SetEnvironmentForTest({
           'CLOUDSDK_CORE_PASS_CREDENTIALS_TO_GSUTIL': 'True',
@@ -1960,11 +1983,12 @@ class TestIamShim(testcase.ShimUnitTestBase):
         with self.assertRaisesRegex(CommandException, 'An error.'):
           self.RunCommand(
               'iam', ['ch', 'allAuthenticatedUsers:modified-role', 'gs://b/o'])
-        self.assertEqual(mock_run.call_count, 2)
+        self.assertEqual(self._mock_subprocess_run.call_count, 3)
 
-  @mock.patch.object(subprocess, 'run', autospec=True)
-  def test_iam_ch_raises_set_error(self, mock_run):
+  def test_iam_ch_raises_set_error(self):
     with SetBotoConfigForTest([('GSUtil', 'use_gcloud_storage', 'True')]):
+      get_account_process = subprocess.CompletedProcess(
+          args=[], returncode=0, stdout='fake_account@gmail.com')
       ls_process = subprocess.CompletedProcess(args=[],
                                                returncode=0,
                                                stdout=json.dumps([{
@@ -1977,7 +2001,9 @@ class TestIamShim(testcase.ShimUnitTestBase):
       set_process = subprocess.CompletedProcess(args=[],
                                                 returncode=1,
                                                 stderr='An error.')
-      mock_run.side_effect = [ls_process, get_process, set_process]
+      self._mock_subprocess_run.side_effect = [
+          get_account_process, ls_process, get_process, set_process
+      ]
 
       with SetEnvironmentForTest({
           'CLOUDSDK_CORE_PASS_CREDENTIALS_TO_GSUTIL': 'True',
@@ -1986,10 +2012,9 @@ class TestIamShim(testcase.ShimUnitTestBase):
         with self.assertRaisesRegex(CommandException, 'An error.'):
           self.RunCommand(
               'iam', ['ch', 'allAuthenticatedUsers:modified-role', 'gs://b/o'])
-        self.assertEqual(mock_run.call_count, 3)
+        self.assertEqual(self._mock_subprocess_run.call_count, 4)
 
-  @mock.patch.object(subprocess, 'run', autospec=True)
-  def test_iam_ch_continues_on_ls_error(self, mock_run):
+  def test_iam_ch_continues_on_ls_error(self):
     original_policy = {
         'bindings': [{
             'role': 'roles/storage.modified-role',
@@ -2009,7 +2034,9 @@ class TestIamShim(testcase.ShimUnitTestBase):
       ls_process2 = subprocess.CompletedProcess(args=[],
                                                 returncode=1,
                                                 stderr='Another error.')
-      mock_run.side_effect = [ls_process, ls_process2]
+      self._mock_subprocess_run.side_effect = [
+          self._FAKE_CONFIG_GET_ACCOUNT_PROCESS, ls_process, ls_process2
+      ]
 
       with SetEnvironmentForTest({
           'CLOUDSDK_CORE_PASS_CREDENTIALS_TO_GSUTIL': 'True',
@@ -2025,7 +2052,8 @@ class TestIamShim(testcase.ShimUnitTestBase):
                                            debug=1,
                                            return_log_handler=True)
 
-      self.assertEqual(mock_run.call_args_list, [
+      self.assertEqual(self._mock_subprocess_run.call_args_list, [
+          self._MOCK_CONFIG_GET_ACCOUNT_CALL,
           self._get_run_call([
               shim_util._get_gcloud_binary_path('fake_dir'), 'storage', 'ls',
               '--json', 'gs://b/o1'
@@ -2040,8 +2068,7 @@ class TestIamShim(testcase.ShimUnitTestBase):
       self.assertIn('An error.', error_lines)
       self.assertIn('Another error.', error_lines)
 
-  @mock.patch.object(subprocess, 'run', autospec=True)
-  def test_iam_ch_continues_on_get_error(self, mock_run):
+  def test_iam_ch_continues_on_get_error(self):
     original_policy = {
         'bindings': [{
             'role': 'roles/storage.modified-role',
@@ -2067,7 +2094,10 @@ class TestIamShim(testcase.ShimUnitTestBase):
       ls_process2 = subprocess.CompletedProcess(args=[],
                                                 returncode=1,
                                                 stderr='Another error.')
-      mock_run.side_effect = [ls_process, get_process, ls_process2]
+      self._mock_subprocess_run.side_effect = [
+          self._FAKE_CONFIG_GET_ACCOUNT_PROCESS, ls_process, get_process,
+          ls_process2
+      ]
       with SetEnvironmentForTest({
           'CLOUDSDK_CORE_PASS_CREDENTIALS_TO_GSUTIL': 'True',
           'CLOUDSDK_ROOT_DIR': 'fake_dir',
@@ -2082,7 +2112,8 @@ class TestIamShim(testcase.ShimUnitTestBase):
                                            debug=1,
                                            return_log_handler=True)
 
-      self.assertEqual(mock_run.call_args_list, [
+      self.assertEqual(self._mock_subprocess_run.call_args_list, [
+          self._MOCK_CONFIG_GET_ACCOUNT_CALL,
           self._get_run_call([
               shim_util._get_gcloud_binary_path('fake_dir'), 'storage', 'ls',
               '--json', 'gs://b/o1'
@@ -2101,8 +2132,7 @@ class TestIamShim(testcase.ShimUnitTestBase):
       self.assertIn('An error.', error_lines)
       self.assertIn('Another error.', error_lines)
 
-  @mock.patch.object(subprocess, 'run', autospec=True)
-  def test_iam_ch_continues_on_set_error(self, mock_run):
+  def test_iam_ch_continues_on_set_error(self):
     original_policy = {
         'bindings': [{
             'role': 'roles/storage.modified-role',
@@ -2130,7 +2160,10 @@ class TestIamShim(testcase.ShimUnitTestBase):
       ls_process2 = subprocess.CompletedProcess(args=[],
                                                 returncode=1,
                                                 stderr='Another error.')
-      mock_run.side_effect = [ls_process, get_process, set_process, ls_process2]
+      self._mock_subprocess_run.side_effect = [
+          self._FAKE_CONFIG_GET_ACCOUNT_PROCESS, ls_process, get_process,
+          set_process, ls_process2
+      ]
 
       with SetEnvironmentForTest({
           'CLOUDSDK_CORE_PASS_CREDENTIALS_TO_GSUTIL': 'True',
@@ -2143,7 +2176,8 @@ class TestIamShim(testcase.ShimUnitTestBase):
                                            debug=1,
                                            return_log_handler=True)
 
-      self.assertEqual(mock_run.call_args_list, [
+      self.assertEqual(self._mock_subprocess_run.call_args_list, [
+          self._MOCK_CONFIG_GET_ACCOUNT_CALL,
           self._get_run_call([
               shim_util._get_gcloud_binary_path('fake_dir'), 'storage', 'ls',
               '--json', 'gs://b/o1'

--- a/gslib/tests/test_kms.py
+++ b/gslib/tests/test_kms.py
@@ -35,10 +35,8 @@ from gslib.tests.util import SetEnvironmentForTest
 from gslib.utils.retry_util import Retry
 from gslib.utils import shim_util
 
-
-
 _DUMMY_KEYNAME = ('projects/my-project/locations/us-central1/'
-                 'keyRings/my-keyring/cryptoKeys/my-key')
+                  'keyRings/my-keyring/cryptoKeys/my-key')
 
 
 @SkipForS3('gsutil does not support KMS operations for S3 buckets.')
@@ -165,7 +163,7 @@ class TestKmsSubcommandsFailWhenXmlForced(testcase.GsUtilIntegrationTestCase):
       ('Credentials', 'gs_secret_access_key', 'dummysecret'),
   ]
   _DUMMY_KEYNAME = ('projects/my-project/locations/us-central1/'
-                   'keyRings/my-keyring/cryptoKeys/my-key')
+                    'keyRings/my-keyring/cryptoKeys/my-key')
 
   def DoTestSubcommandFailsWhenXmlForcedFromHmacInBotoConfig(self, subcommand):
     with SetBotoConfigForTest(self.boto_config_hmac_auth_only):
@@ -257,6 +255,7 @@ class TestKmsUnitTests(testcase.GsUtilUnitTestCase):
     except AccessDeniedException as e:
       self.assertIn('Permission denied', e.reason)
 
+
 class TestKmsUnitTestsWithShim(testcase.ShimUnitTestBase):
   """Unit tests for gsutil kms using shim."""
 
@@ -289,8 +288,8 @@ class TestKmsUnitTestsWithShim(testcase.ShimUnitTestBase):
         self.assertIn(
             'Gcloud Storage Command: {} storage service-agent'
             ' --project foo --authorize-cmek {}'.format(
-                shim_util._get_gcloud_binary_path('fake_dir'),
-                _DUMMY_KEYNAME), info_lines)
+                shim_util._get_gcloud_binary_path('fake_dir'), _DUMMY_KEYNAME),
+            info_lines)
 
   def test_shim_translates_clear_encryption_key(self):
     bucket_uri = self.CreateBucket()
@@ -330,16 +329,15 @@ class TestKmsUnitTestsWithShim(testcase.ShimUnitTestBase):
           'CLOUDSDK_ROOT_DIR': 'fake_dir',
       }):
         mock_log_handler = self.RunCommand(
-            'kms',
-            ['encryption', '-w', '-k', _DUMMY_KEYNAME,
-             suri(bucket_uri)],
+            'kms', ['encryption', '-w', '-k', _DUMMY_KEYNAME,
+                    suri(bucket_uri)],
             return_log_handler=True)
         info_lines = '\n'.join(mock_log_handler.messages['info'])
         self.assertIn(
             'Gcloud Storage Command: {} storage buckets update'
             '  --default-encryption-key {} {}'.format(
-                shim_util._get_gcloud_binary_path('fake_dir'),
-                _DUMMY_KEYNAME, suri(bucket_uri)), info_lines)
+                shim_util._get_gcloud_binary_path('fake_dir'), _DUMMY_KEYNAME,
+                suri(bucket_uri)), info_lines)
 
   def test_shim_translates_displays_encryption_key(self):
     bucket_uri = self.CreateBucket()

--- a/gslib/tests/test_lifecycle.py
+++ b/gslib/tests/test_lifecycle.py
@@ -270,8 +270,8 @@ class TestSetLifecycle(testcase.GsUtilIntegrationTestCase):
     self.assertEqual(json.loads(stdout), self.lifecycle_json_obj)
 
 
-class TestLifecycleUnitTests(testcase.GsUtilUnitTestCase):
-  """Unit tests for gsutil lifecycle."""
+class TestLifecycleUnitTestsWithShim(testcase.ShimUnitTestBase):
+  """Unit tests for gsutil lifecycle with shim."""
 
   def test_shim_translates_lifecycle_get_correctly(self):
     bucket_uri = self.CreateBucket()

--- a/gslib/tests/test_ls.py
+++ b/gslib/tests/test_ls.py
@@ -192,6 +192,10 @@ class TestLsUnit(testcase.GsUtilUnitTestCase):
                                return_stdout=True)
     self.assertNotRegex(stdout, 'Placement locations:')
 
+
+class TestLsUnitWithShim(testcase.ShimUnitTestBase):
+  """Unit tests for ls command with shim."""
+
   def test_shim_translates_flags(self):
     with SetBotoConfigForTest([('GSUtil', 'use_gcloud_storage', 'True'),
                                ('GSUtil', 'hidden_shim_mode', 'dry_run')]):

--- a/gslib/tests/test_ls.py
+++ b/gslib/tests/test_ls.py
@@ -793,8 +793,8 @@ class TestLs(testcase.GsUtilIntegrationTestCase):
 
     _Check5()
 
-  @unittest.skipIf(
-      IS_WINDOWS, 'Unicode handling on Windows requires mods to site-packages')
+  @unittest.skipIf(IS_WINDOWS,
+                   'Unicode handling on Windows requires mods to site-packages')
   def test_list_unicode_filename(self):
     """Tests listing an object with a unicode filename."""
     # Note: This test fails on Windows (command.exe). I was able to get ls to

--- a/gslib/tests/test_mb.py
+++ b/gslib/tests/test_mb.py
@@ -402,8 +402,8 @@ class TestMb(testcase.GsUtilIntegrationTestCase):
         stderr)
 
 
-class TestMbUnitTests(testcase.GsUtilUnitTestCase):
-  """Unit tests for gsutil mb."""
+class TestMbUnitTestsWithShim(testcase.ShimUnitTestBase):
+  """Unit tests for gsutil mb with shim."""
 
   def test_shim_translates_retention_seconds_flags(self):
     with SetBotoConfigForTest([('GSUtil', 'use_gcloud_storage', 'True'),

--- a/gslib/tests/test_mv.py
+++ b/gslib/tests/test_mv.py
@@ -106,6 +106,10 @@ class TestMvUnitTests(testcase.GsUtilUnitTestCase):
         suri(bucket_uri, 'dir2', 'file.txt'),
     ])
     self.assertEqual(actual, expected)
+        
+
+class TestMvUnitTestsWithShim(testcase.ShimUnitTestBase):
+  """Unit tests for mv command with shim."""
 
   def test_shim_translates_flags(self):
     bucket_uri = self.CreateBucket()

--- a/gslib/tests/test_mv.py
+++ b/gslib/tests/test_mv.py
@@ -106,7 +106,7 @@ class TestMvUnitTests(testcase.GsUtilUnitTestCase):
         suri(bucket_uri, 'dir2', 'file.txt'),
     ])
     self.assertEqual(actual, expected)
-        
+
 
 class TestMvUnitTestsWithShim(testcase.ShimUnitTestBase):
   """Unit tests for mv command with shim."""

--- a/gslib/tests/test_retention.py
+++ b/gslib/tests/test_retention.py
@@ -155,8 +155,7 @@ class TestRetention(testcase.GsUtilIntegrationTestCase):
         retention_period_in_seconds=_SECONDS_IN_DAY)
     stderr = self.RunGsUtil(
         ['retention', 'lock', suri(bucket_uri)], stdin='n', return_stderr=True)
-    self.assertRegex(stderr,
-                             'Abort [Ll]ocking [Rr]etention [Pp]olicy on')
+    self.assertRegex(stderr, 'Abort [Ll]ocking [Rr]etention [Pp]olicy on')
     self.VerifyRetentionPolicy(
         bucket_uri, expected_retention_period_in_seconds=_SECONDS_IN_DAY)
 
@@ -169,8 +168,8 @@ class TestRetention(testcase.GsUtilIntegrationTestCase):
         stdin='y',
         expected_status=1,
         return_stderr=True)
-    self.assertRegex(
-        stderr, 'does not have a(n Unlocked)? [Rr]etention [Pp]olicy')
+    self.assertRegex(stderr,
+                     'does not have a(n Unlocked)? [Rr]etention [Pp]olicy')
     self.VerifyRetentionPolicy(bucket_uri,
                                expected_retention_period_in_seconds=None)
 
@@ -192,8 +191,7 @@ class TestRetention(testcase.GsUtilIntegrationTestCase):
         retention_period_in_seconds=_SECONDS_IN_DAY, is_locked=True)
     stderr = self.RunGsUtil(
         ['retention', 'lock', suri(bucket_uri)], stdin='y', return_stderr=True)
-    self.assertRegex(stderr,
-                             r'Retention [Pp]olicy on .* is already locked')
+    self.assertRegex(stderr, r'Retention [Pp]olicy on .* is already locked')
 
   @SkipForS3('Retention is not supported for s3 objects')
   @SkipForXML('Retention is not supported for XML API')

--- a/gslib/tests/test_retention_util.py
+++ b/gslib/tests/test_retention_util.py
@@ -132,27 +132,26 @@ class TestRetentionUtil(testcase.GsUtilUnitTestCase):
     self.assertRegex(retention_str, r'Duration: 86399 Second\(s\)')
 
     retention_str = _RetentionPeriodToString(SECONDS_IN_DAY + 1)
-    self.assertRegex(retention_str,
-                             r'Duration: 86401 Seconds \(~1 Day\(s\)\)')
+    self.assertRegex(retention_str, r'Duration: 86401 Seconds \(~1 Day\(s\)\)')
 
     retention_str = _RetentionPeriodToString(SECONDS_IN_MONTH)
     self.assertRegex(retention_str, r'Duration: 1 Month\(s\)')
 
     retention_str = _RetentionPeriodToString(SECONDS_IN_MONTH - 1)
     self.assertRegex(retention_str,
-                             r'Duration: 2678399 Seconds \(~30 Day\(s\)\)')
+                     r'Duration: 2678399 Seconds \(~30 Day\(s\)\)')
 
     retention_str = _RetentionPeriodToString(SECONDS_IN_MONTH + 1)
     self.assertRegex(retention_str,
-                             r'Duration: 2678401 Seconds \(~31 Day\(s\)\)')
+                     r'Duration: 2678401 Seconds \(~31 Day\(s\)\)')
 
     retention_str = _RetentionPeriodToString(SECONDS_IN_YEAR)
     self.assertRegex(retention_str, r'Duration: 1 Year\(s\)')
 
     retention_str = _RetentionPeriodToString(SECONDS_IN_YEAR - 1)
     self.assertRegex(retention_str,
-                             r'Duration: 31557599 Seconds \(~365 Day\(s\)\)')
+                     r'Duration: 31557599 Seconds \(~365 Day\(s\)\)')
 
     retention_str = _RetentionPeriodToString(SECONDS_IN_YEAR + 1)
     self.assertRegex(retention_str,
-                             r'Duration: 31557601 Seconds \(~365 Day\(s\)\)')
+                     r'Duration: 31557601 Seconds \(~365 Day\(s\)\)')

--- a/gslib/tests/test_rm.py
+++ b/gslib/tests/test_rm.py
@@ -747,8 +747,8 @@ class TestRm(testcase.GsUtilIntegrationTestCase):
       self.assertIn('2 files/objects could not be removed.', stderr)
 
 
-class TestRmUnitTests(testcase.GsUtilUnitTestCase):
-  """Unit tests for gsutil rm."""
+class TestRmUnitTestsWithShim(testcase.ShimUnitTestBase):
+  """Unit tests for gsutil rm with shim."""
 
   def test_shim_translates_flags(self):
     bucket_uri = self.CreateBucket()

--- a/gslib/tests/test_rpo.py
+++ b/gslib/tests/test_rpo.py
@@ -86,6 +86,9 @@ class TestRpoUnit(testcase.GsUtilUnitTestCase):
         CommandException, 'Invalid subcommand "blah", use get|set instead'):
       self.RunCommand('rpo', ['blah', 'DEFAULT', 'gs://boo*'])
 
+
+class TestRpoUnitWithShim(testcase.ShimUnitTestBase):
+
   def test_shim_translates_recovery_point_objective_get_command(self):
     fake_cloudsdk_dir = 'fake_dir'
     with SetBotoConfigForTest([('GSUtil', 'use_gcloud_storage', 'True'),

--- a/gslib/tests/test_rsync.py
+++ b/gslib/tests/test_rsync.py
@@ -136,6 +136,9 @@ class TestRsyncUnit(testcase.GsUtilUnitTestCase):
         print_macos_warning=False,
     )
 
+
+class TestRsyncUnitWithShim(testcase.ShimUnitTestBase):
+
   def testShimTranslatesFlags(self):
     bucket_uri = self.CreateBucket()
     fpath = self.CreateTempDir()
@@ -375,10 +378,10 @@ class TestRsync(testcase.GsUtilIntegrationTestCase):
       listing2 = TailSet(suri(dst_bucket), self.FlatListBucket(dst_bucket))
       # First bucket should have un-altered content.
       self.assertEqual(listing1,
-                        set(['/obj1', '/obj2', '/obj3', '/obj4', '/obj5']))
+                       set(['/obj1', '/obj2', '/obj3', '/obj4', '/obj5']))
       # dst_bucket should have new content from src_bucket.
       self.assertEqual(listing2,
-                        set(['/obj1', '/obj2', '/obj3', '/obj4', '/obj5']))
+                       set(['/obj1', '/obj2', '/obj3', '/obj4', '/obj5']))
       if self._use_gcloud_storage:
         self.assertIn('Patching', stderr)
       else:
@@ -728,7 +731,7 @@ class TestRsync(testcase.GsUtilIntegrationTestCase):
       listing2 = TailSet(suri(bucket2_uri), self.FlatListBucket(bucket2_uri))
       # First bucket should have un-altered content.
       self.assertEqual(listing1,
-                        set(['/obj1', '/.obj2', '/subdir/obj3', '/obj6']))
+                       set(['/obj1', '/.obj2', '/subdir/obj3', '/obj6']))
       # Second bucket should have new objects added from source bucket (without
       # removing extraneeous object found in dest bucket), and without the
       # subdir objects synchronized.
@@ -1753,14 +1756,11 @@ class TestRsync(testcase.GsUtilIntegrationTestCase):
     def _Check2():
       """Verify mtime was set for objects at destination."""
       self.assertEqual(long(os.path.getmtime(os.path.join(tmpdir, 'obj1'))), 5)
-      self.assertEqual(long(os.path.getmtime(os.path.join(tmpdir, '.obj2'))),
-                        5)
-      self.assertEqual(long(os.path.getmtime(os.path.join(tmpdir, 'obj6'))),
-                        50)
+      self.assertEqual(long(os.path.getmtime(os.path.join(tmpdir, '.obj2'))), 5)
+      self.assertEqual(long(os.path.getmtime(os.path.join(tmpdir, 'obj6'))), 50)
       self.assertEqual(long(os.path.getmtime(os.path.join(tmpdir, 'obj8'))),
-                        100)
-      self.assertEqual(long(os.path.getmtime(os.path.join(tmpdir, 'obj9'))),
-                        25)
+                       100)
+      self.assertEqual(long(os.path.getmtime(os.path.join(tmpdir, 'obj9'))), 25)
 
     _Check2()
 
@@ -2450,11 +2450,11 @@ class TestRsync(testcase.GsUtilIntegrationTestCase):
       listing2 = TailSet(suri(bucket_uri), self.FlatListBucket(bucket_uri))
       # Dir should have un-altered content.
       self.assertEqual(listing1,
-                        set(['/obj1', '/.obj2', '/subdir/obj3', '/symlink1']))
+                       set(['/obj1', '/.obj2', '/subdir/obj3', '/symlink1']))
       # Bucket should have content like dir but without the symlink, and
       # without subdir objects synchronized.
       self.assertEqual(listing2,
-                        set(['/obj1', '/.obj2', '/subdir/obj5', '/symlink1']))
+                       set(['/obj1', '/.obj2', '/subdir/obj5', '/symlink1']))
       self.assertEqual(
           'obj1',
           self.RunGsUtil(['cat', suri(bucket_uri, 'symlink1')],

--- a/gslib/tests/test_setmeta.py
+++ b/gslib/tests/test_setmeta.py
@@ -307,7 +307,7 @@ class TestSetMeta(testcase.GsUtilIntegrationTestCase):
         ' -h flag. See "gsutil help setmeta" for more information.', stderr)
 
 
-class TestSetMetaShim(testcase.GsUtilUnitTestCase):
+class TestSetMetaShim(testcase.ShimUnitTestBase):
 
   @mock.patch.object(setmeta.SetMetaCommand, 'RunCommand', new=mock.Mock())
   def test_shim_translates_setmeta_set_and_clear_flags(self):

--- a/gslib/tests/test_shim_util.py
+++ b/gslib/tests/test_shim_util.py
@@ -392,7 +392,7 @@ class TestGetGCloudStorageArgs(testcase.GsUtilUnitTestCase):
       fake_with_subcommand.get_gcloud_storage_args()
 
 
-class TestTranslateToGcloudStorageIfRequested(testcase.GsUtilUnitTestCase):
+class TestTranslateToGcloudStorageIfRequested(testcase.ShimUnitTestBase):
   """Test Command.translate_to_gcloud_storage_if_requested method."""
 
   def setUp(self):
@@ -406,20 +406,6 @@ class TestTranslateToGcloudStorageIfRequested(testcase.GsUtilUnitTestCase):
         parallel_operations=True,
         bucket_storage_uri_class=mock.ANY,
         gsutil_api_class_map_factory=mock.MagicMock())
-    
-    # Translator calls `gcloud config get account` to check active account
-    # using subprocess.run().
-    # We don't care about this call for most of the tests below, so we are
-    # simply patching this here.
-    # There are separate tests to check this call is being made.
-    self._subprocess_run_patcher = mock.patch.object(
-      subprocess, 'run', autospec=True)
-    self._mock_subprocess_run = self._subprocess_run_patcher.start()
-    self._mock_subprocess_run.return_value.returncode = 0
-
-  def tearDown(self):
-    if self._subprocess_run_patcher is not None:
-      self._subprocess_run_patcher.stop()
 
   def test_gets_gcloud_binary_path_on_non_windows(self):
     with mock.patch.object(system_util, 'IS_WINDOWS', new=False):

--- a/gslib/tests/test_shim_util.py
+++ b/gslib/tests/test_shim_util.py
@@ -1451,7 +1451,7 @@ class TestBotoTranslation(testcase.GsUtilUnitTestCase):
       self.assertEqual(env_vars, {})
 
   def test_truthy_https_validate_certificates(self):
-    """Should not set CLOUDSDK_AUTH_DISABLE_SSL_VALIDATION"""
+    """Should not set CLOUDSDK_AUTH_DISABLE_SSL_VALIDATION."""
     with _mock_boto_config({'GSUtil': {'https_validate_certificates': True}}):
       flags, env_vars = self._fake_command._translate_boto_config()
       self.assertEqual(flags, [])

--- a/gslib/tests/test_shim_util.py
+++ b/gslib/tests/test_shim_util.py
@@ -678,7 +678,7 @@ class TestTranslateToGcloudStorageIfRequested(testcase.ShimUnitTestBase):
             })
 
   def test_anonymous_credentials_sets_disable_credentials_env_variable(self):
-    self._mock_subprocess_run.return_value.stdout = b''
+    self._mock_subprocess_run.return_value.stdout = ''
 
     boto_config = {
         'GSUtil': {
@@ -692,7 +692,7 @@ class TestTranslateToGcloudStorageIfRequested(testcase.ShimUnitTestBase):
           'CLOUDSDK_ROOT_DIR': 'fake_dir',
       }):
         self.assertTrue(
-          self._fake_command.translate_to_gcloud_storage_if_requested())
+            self._fake_command.translate_to_gcloud_storage_if_requested())
         # Verify translation.
         expected_gcloud_path = shim_util._get_gcloud_binary_path('fake_dir')
         self.assertCountEqual(
@@ -702,8 +702,10 @@ class TestTranslateToGcloudStorageIfRequested(testcase.ShimUnitTestBase):
                 'CLOUDSDK_AUTH_DISABLE_CREDENTIALS': 'True',
             })
     self._mock_subprocess_run.assert_called_once_with(
-      ['fake_dir/bin/gcloud', 'config', 'get', 'account'], stdout=-1, stderr=-1
-    )
+        ['fake_dir/bin/gcloud', 'config', 'get', 'account'],
+        stdout=-1,
+        stderr=-1,
+        encoding='utf-8')
 
   def test_gcloud_config_get_account_nonzero_returncode_raises_error(self):
     self._mock_subprocess_run.return_value.stdout = b''
@@ -727,7 +729,10 @@ class TestTranslateToGcloudStorageIfRequested(testcase.ShimUnitTestBase):
             " Error: b'fake error message"):
           self._fake_command.translate_to_gcloud_storage_if_requested()
     self._mock_subprocess_run.assert_called_once_with(
-      ['fake_dir/bin/gcloud', 'config', 'get', 'account'], stdout=-1, stderr=-1
+        ['fake_dir/bin/gcloud', 'config', 'get', 'account'],
+        stdout=-1,
+        stderr=-1,
+        encoding='utf-8',
     )
 
   def test_parallel_operations_true_does_not_add_process_count_env_vars(self):
@@ -914,7 +919,7 @@ class TestHeaderTranslation(testcase.GsUtilUnitTestCase):
                      new={'fake_shim'})
   @mock.patch.object(subprocess, 'run', autospec=True)
   def test_translated_headers_get_added_to_final_command(
-    self, mock_subprocess_run):
+      self, mock_subprocess_run):
     mock_subprocess_run.return_value.returncode = 0
 
     with _mock_boto_config({

--- a/gslib/tests/test_shim_util.py
+++ b/gslib/tests/test_shim_util.py
@@ -702,7 +702,7 @@ class TestTranslateToGcloudStorageIfRequested(testcase.ShimUnitTestBase):
                 'CLOUDSDK_AUTH_DISABLE_CREDENTIALS': 'True',
             })
     self._mock_subprocess_run.assert_called_once_with(
-        ['fake_dir/bin/gcloud', 'config', 'get', 'account'],
+        [os.path.join('fake_dir','bin', 'gcloud'), 'config', 'get', 'account'],
         stdout=-1,
         stderr=-1,
         encoding='utf-8')
@@ -729,7 +729,7 @@ class TestTranslateToGcloudStorageIfRequested(testcase.ShimUnitTestBase):
             " Error: b'fake error message"):
           self._fake_command.translate_to_gcloud_storage_if_requested()
     self._mock_subprocess_run.assert_called_once_with(
-        ['fake_dir/bin/gcloud', 'config', 'get', 'account'],
+        [os.path.join('fake_dir','bin', 'gcloud'), 'config', 'get', 'account'],
         stdout=-1,
         stderr=-1,
         encoding='utf-8',

--- a/gslib/tests/test_shim_util.py
+++ b/gslib/tests/test_shim_util.py
@@ -702,7 +702,7 @@ class TestTranslateToGcloudStorageIfRequested(testcase.ShimUnitTestBase):
                 'CLOUDSDK_AUTH_DISABLE_CREDENTIALS': 'True',
             })
     self._mock_subprocess_run.assert_called_once_with(
-        [os.path.join('fake_dir','bin', 'gcloud'), 'config', 'get', 'account'],
+        [expected_gcloud_path, 'config', 'get', 'account'],
         stdout=-1,
         stderr=-1,
         encoding='utf-8')
@@ -711,6 +711,8 @@ class TestTranslateToGcloudStorageIfRequested(testcase.ShimUnitTestBase):
     self._mock_subprocess_run.return_value.stdout = b''
     self._mock_subprocess_run.return_value.stderr = b'fake error message'
     self._mock_subprocess_run.return_value.returncode = 1
+
+    expected_gcloud_path = shim_util._get_gcloud_binary_path('fake_dir')
 
     boto_config = {
         'GSUtil': {
@@ -729,7 +731,7 @@ class TestTranslateToGcloudStorageIfRequested(testcase.ShimUnitTestBase):
             " Error: b'fake error message"):
           self._fake_command.translate_to_gcloud_storage_if_requested()
     self._mock_subprocess_run.assert_called_once_with(
-        [os.path.join('fake_dir','bin', 'gcloud'), 'config', 'get', 'account'],
+        [expected_gcloud_path, 'config', 'get', 'account'],
         stdout=-1,
         stderr=-1,
         encoding='utf-8',

--- a/gslib/tests/test_signurl.py
+++ b/gslib/tests/test_signurl.py
@@ -562,7 +562,7 @@ class UnitTestSignUrl(testcase.GsUtilUnitTestCase):
     self.assertEqual(expected, signed_url)
 
 
-# @unittest.skipUnless(HAVE_OPENSSL, 'signurl requires pyopenssl.')
+@unittest.skipUnless(HAVE_OPENSSL, 'signurl requires pyopenssl.')
 class UnitTestSignUrlWithShim(testcase.ShimUnitTestBase):
 
   def testShimTranslatesFlags(self):

--- a/gslib/tests/test_signurl.py
+++ b/gslib/tests/test_signurl.py
@@ -561,6 +561,10 @@ class UnitTestSignUrl(testcase.GsUtilUnitTestCase):
           billing_project='myproject')
     self.assertEqual(expected, signed_url)
 
+
+# @unittest.skipUnless(HAVE_OPENSSL, 'signurl requires pyopenssl.')
+class UnitTestSignUrlWithShim(testcase.ShimUnitTestBase):
+
   def testShimTranslatesFlags(self):
     key_contents = pkgutil.get_data('gslib', 'tests/test_data/test.json')
     key_path = self.CreateTempFile(contents=key_contents)

--- a/gslib/tests/test_ui.py
+++ b/gslib/tests/test_ui.py
@@ -930,7 +930,7 @@ class TestUi(testcase.GsUtilIntegrationTestCase):
       listing2 = TailSet(suri(bucket2_uri), self.FlatListBucket(bucket2_uri))
       # First bucket should have un-altered content.
       self.assertEqual(listing1,
-                        set(['/obj1', '/.obj2', '/subdir/obj3', '/obj6']))
+                       set(['/obj1', '/.obj2', '/subdir/obj3', '/obj6']))
       # Second bucket should have new objects added from source bucket (without
       # removing extraneeous object found in dest bucket), and without the
       # subdir objects synchronized.
@@ -1285,7 +1285,7 @@ class TestUiUnitTests(testcase.GsUtilUnitTestCase):
       average_progress = BytesToFixedWidthString(
           (file1_progress + file2_progress) / 2)
       self.assertEqual(content.count(average_progress + '/s'),
-                        2 * progress_calls_number - 1)
+                       2 * progress_calls_number - 1)
 
   def test_ui_throughput_calculation_with_no_components(self):
     """Tests throughput calculation in the UI.
@@ -1397,7 +1397,7 @@ class TestUiUnitTests(testcase.GsUtilUnitTestCase):
       average_progress = BytesToFixedWidthString(
           (file1_progress + file2_progress) / 2)
       self.assertEqual(content.count(average_progress + '/s'),
-                        2 * progress_calls_number - 1)
+                       2 * progress_calls_number - 1)
 
   def test_ui_metadata_message_passing(self):
     """Tests that MetadataMessages are being correctly received and processed.
@@ -1507,13 +1507,13 @@ class TestUiUnitTests(testcase.GsUtilUnitTestCase):
     self.assertEqual('    0.0 B', BytesToFixedWidthString(0, decimal_places=1))
     self.assertEqual('   0.00 B', BytesToFixedWidthString(0, decimal_places=2))
     self.assertEqual('  2.3 KiB',
-                      BytesToFixedWidthString(2.27 * 1024, decimal_places=1))
+                     BytesToFixedWidthString(2.27 * 1024, decimal_places=1))
     self.assertEqual(' 1023 KiB',
-                      BytesToFixedWidthString(1023.2 * 1024, decimal_places=1))
+                     BytesToFixedWidthString(1023.2 * 1024, decimal_places=1))
     self.assertEqual('  1.0 MiB',
-                      BytesToFixedWidthString(1024**2, decimal_places=1))
-    self.assertEqual(
-        '999.1 MiB', BytesToFixedWidthString(999.1 * 1024**2, decimal_places=1))
+                     BytesToFixedWidthString(1024**2, decimal_places=1))
+    self.assertEqual('999.1 MiB',
+                     BytesToFixedWidthString(999.1 * 1024**2, decimal_places=1))
 
   def test_ui_spinner(self):
     stream = six.StringIO()

--- a/gslib/tests/test_user_agent_helper.py
+++ b/gslib/tests/test_user_agent_helper.py
@@ -49,8 +49,8 @@ class TestUserAgentHelper(testcase.GsUtilUnitTestCase):
   @mock.patch.object(system_util, 'InvokedViaCloudSdk')
   def testCp(self, mock_invoked):
     mock_invoked.return_value = False
-    self.assertRegex(
-        GetUserAgent(['cp', '-r', '-Z', '1.txt', 'gs://dst']), r"command/cp$")
+    self.assertRegex(GetUserAgent(['cp', '-r', '-Z', '1.txt', 'gs://dst']),
+                     r"command/cp$")
 
   @mock.patch.object(system_util, 'InvokedViaCloudSdk')
   def testCpNotEnoughArgs(self, mock_invoked):
@@ -68,62 +68,57 @@ class TestUserAgentHelper(testcase.GsUtilUnitTestCase):
   def testRsync(self, mock_invoked):
     mock_invoked.return_value = False
     self.assertRegex(GetUserAgent(['rsync', '1.txt', 'gs://dst']),
-                             r"command/rsync$")
+                     r"command/rsync$")
 
   @mock.patch.object(system_util, 'InvokedViaCloudSdk')
   def testMv(self, mock_invoked):
     mock_invoked.return_value = False
-    self.assertRegex(
-        GetUserAgent(['mv', 'gs://src/1.txt', 'gs://dst/1.txt']),
-        r"command/mv$")
+    self.assertRegex(GetUserAgent(['mv', 'gs://src/1.txt', 'gs://dst/1.txt']),
+                     r"command/mv$")
 
   @mock.patch.object(system_util, 'InvokedViaCloudSdk')
   def testCpCloudToCloud(self, mock_invoked):
     mock_invoked.return_value = False
     self.assertRegex(GetUserAgent(['cp', '-r', 'gs://src', 'gs://dst']),
-                             r"command/cp$")
+                     r"command/cp$")
 
   @mock.patch.object(system_util, 'InvokedViaCloudSdk')
   def testCpForcedDaisyChain(self, mock_invoked):
     mock_invoked.return_value = False
     self.assertRegex(GetUserAgent(['cp', '-D', 'gs://src', 'gs://dst']),
-                             r"command/cp$")
+                     r"command/cp$")
 
   def testCpDaisyChain(self):
-    self.assertRegex(
-        GetUserAgent(['cp', '-r', '-Z', 'gs://src', 's3://dst']),
-        r"command/cp-DaisyChain")
-    self.assertRegex(
-        GetUserAgent(['mv', 'gs://src/1.txt', 's3://dst/1.txt']),
-        r"command/mv-DaisyChain")
-    self.assertRegex(
-        GetUserAgent(['rsync', '-r', 'gs://src', 's3://dst']),
-        r"command/rsync-DaisyChain")
+    self.assertRegex(GetUserAgent(['cp', '-r', '-Z', 'gs://src', 's3://dst']),
+                     r"command/cp-DaisyChain")
+    self.assertRegex(GetUserAgent(['mv', 'gs://src/1.txt', 's3://dst/1.txt']),
+                     r"command/mv-DaisyChain")
+    self.assertRegex(GetUserAgent(['rsync', '-r', 'gs://src', 's3://dst']),
+                     r"command/rsync-DaisyChain")
 
   @mock.patch.object(system_util, 'InvokedViaCloudSdk')
   def testPassOnInvalidUrlError(self, mock_invoked):
     mock_invoked.return_value = False
-    self.assertRegex(
-        GetUserAgent(['cp', '-r', '-Z', 'bad://src', 's3://dst']),
-        r"command/cp$")
+    self.assertRegex(GetUserAgent(['cp', '-r', '-Z', 'bad://src', 's3://dst']),
+                     r"command/cp$")
 
   @mock.patch.object(system_util, 'InvokedViaCloudSdk')
   def testRewriteEncryptionKey(self, mock_invoked):
     mock_invoked.return_value = False
     self.assertRegex(GetUserAgent(['rewrite', '-k', 'gs://dst']),
-                             r"command/rewrite-k$")
+                     r"command/rewrite-k$")
 
   @mock.patch.object(system_util, 'InvokedViaCloudSdk')
   def testRewriteStorageClass(self, mock_invoked):
     mock_invoked.return_value = False
     self.assertRegex(GetUserAgent(['rewrite', '-s', 'gs://dst']),
-                             r"command/rewrite-s$")
+                     r"command/rewrite-s$")
 
   @mock.patch.object(system_util, 'InvokedViaCloudSdk')
   def testRewriteEncryptionKeyAndStorageClass(self, mock_invoked):
     mock_invoked.return_value = False
     self.assertRegex(GetUserAgent(['rewrite', '-k', '-s', 'gs://dst']),
-                             r"command/rewrite-k-s$")
+                     r"command/rewrite-k-s$")
 
   @mock.patch.object(system_util, 'CloudSdkVersion')
   @mock.patch.object(system_util, 'InvokedViaCloudSdk')

--- a/gslib/tests/test_web.py
+++ b/gslib/tests/test_web.py
@@ -106,7 +106,7 @@ class TestWeb(testcase.GsUtilIntegrationTestCase):
     self.assertIn('command requires at least', stderr)
 
 
-class TestWebShim(testcase.GsUtilUnitTestCase):
+class TestWebShim(testcase.ShimUnitTestBase):
 
   @mock.patch.object(web.WebCommand, '_GetWeb', new=mock.Mock())
   def test_shim_translates_get_command(self):

--- a/gslib/tests/test_wrapped_credentials.py
+++ b/gslib/tests/test_wrapped_credentials.py
@@ -115,9 +115,9 @@ class TestWrappedCredentials(testcase.GsUtilUnitTestCase):
     self.assertEqual(json_values["_base"]["audience"], "foo")
     self.assertEqual(json_values["_base"]["subject_token_type"], "bar")
     self.assertEqual(json_values["_base"]["token_url"],
-                      "https://sts.googleapis.com")
+                     "https://sts.googleapis.com")
     self.assertEqual(json_values["_base"]["credential_source"]["url"],
-                      "google.com")
+                     "google.com")
 
     creds2 = WrappedCredentials.from_json(creds_json)
     self.assertIsInstance(creds2, WrappedCredentials)

--- a/gslib/tests/testcase/__init__.py
+++ b/gslib/tests/testcase/__init__.py
@@ -22,3 +22,4 @@ from __future__ import unicode_literals
 from gslib.tests.testcase.integration_testcase import GsUtilIntegrationTestCase
 from gslib.tests.util import KmsTestingResources
 from gslib.tests.testcase.unit_testcase import GsUtilUnitTestCase
+from gslib.tests.testcase.shim_unit_test_base import ShimUnitTestBase

--- a/gslib/tests/testcase/shim_unit_test_base.py
+++ b/gslib/tests/testcase/shim_unit_test_base.py
@@ -44,3 +44,4 @@ class ShimUnitTestBase(GsUtilUnitTestCase):
   def tearDown(self):
     if self._subprocess_run_patcher is not None:
       self._subprocess_run_patcher.stop()
+    super().tearDown()

--- a/gslib/tests/testcase/shim_unit_test_base.py
+++ b/gslib/tests/testcase/shim_unit_test_base.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# Copyright 2023 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Contains base class to be used for shim unit tests."""
+
+import subprocess
+from unittest import mock
+
+from gslib.tests.testcase.unit_testcase import GsUtilUnitTestCase
+
+
+class ShimUnitTestBase(GsUtilUnitTestCase):
+  """Base class for unit testing shim behavior.
+  
+  This class mocks the `subprocess.run()` method because it gets called
+  for all shim operations to check if there is an active account configured
+  for gcloud.
+  """
+
+  def setUp(self):
+    super().setUp()
+    # Translator calls `gcloud config get account` to check active account
+    # using subprocess.run().
+    # We don't care about this call for most of the tests below, so we are
+    # simply patching this here.
+    # There are separate tests to check this call is being made.
+    self._subprocess_run_patcher = mock.patch.object(subprocess,
+                                                     'run',
+                                                     autospec=True)
+    self._mock_subprocess_run = self._subprocess_run_patcher.start()
+    self._mock_subprocess_run.return_value.returncode = 0
+
+  def tearDown(self):
+    if self._subprocess_run_patcher is not None:
+      self._subprocess_run_patcher.stop()

--- a/gslib/utils/shim_util.py
+++ b/gslib/utils/shim_util.py
@@ -362,6 +362,11 @@ class GcloudStorageCommandMixin(object):
         [gcloud_path, 'config', 'get', 'account'],
         stdout=subprocess.PIPE, stderr=subprocess.PIPE
       )
+      if process.returncode:
+        raise exception.GcloudStorageTranslationError(
+          "Error occurred while trying to retrieve gcloud's active account."
+          " Error: {}".format(process.stderr)
+        )
       # stdout will have the name of the account if active account is available.
       # Empty string indicates no active account available.
       self._gcloud_has_active_account = process.stdout.strip() !=  b''

--- a/gslib/utils/shim_util.py
+++ b/gslib/utils/shim_util.py
@@ -242,6 +242,7 @@ class GcloudStorageMap(object):
     self.flag_map = flag_map
     self.supports_output_translation = supports_output_translation
 
+
 def _get_gcloud_binary_path(cloudsdk_root):
   return os.path.join(cloudsdk_root, 'bin',
                       'gcloud.cmd' if system_util.IS_WINDOWS else 'gcloud')
@@ -355,24 +356,24 @@ class GcloudStorageCommandMixin(object):
     self._translated_env_variables = None
     self._gcloud_has_active_account = None
 
-  def gcloud_has_active_account(self, gcloud_path):
+  def gcloud_has_active_account(self):
     """Returns True if gcloud has an active account configured."""
+    gcloud_path = _get_validated_gcloud_binary_path()
     if self._gcloud_has_active_account is None:
-      process = subprocess.run(
-        [gcloud_path, 'config', 'get', 'account'],
-        stdout=subprocess.PIPE, stderr=subprocess.PIPE
-      )
+      process = subprocess.run([gcloud_path, 'config', 'get', 'account'],
+                               stdout=subprocess.PIPE,
+                               stderr=subprocess.PIPE,
+                               encoding='utf-8')
       if process.returncode:
         raise exception.GcloudStorageTranslationError(
-          "Error occurred while trying to retrieve gcloud's active account."
-          " Error: {}".format(process.stderr)
-        )
+            "Error occurred while trying to retrieve gcloud's active account."
+            " Error: {}".format(process.stderr))
       # stdout will have the name of the account if active account is available.
       # Empty string indicates no active account available.
-      self._gcloud_has_active_account = process.stdout.strip() !=  b''
-      self.logger.debug(
-        'Result for "gcloud config get account" command:\n'
-        ' STDOUT: {}.\n STDERR: {}'.format(process.stdout, process.stderr))
+      self._gcloud_has_active_account = process.stdout.strip() != ''
+      self.logger.debug('Result for "gcloud config get account" command:\n'
+                        ' STDOUT: {}.\n STDERR: {}'.format(
+                            process.stdout, process.stderr))
     return self._gcloud_has_active_account
 
   def _get_gcloud_storage_args(self, sub_opts, gsutil_args, gcloud_storage_map):
@@ -593,10 +594,6 @@ class GcloudStorageCommandMixin(object):
 
     gcloud_binary_path = _get_validated_gcloud_binary_path()
 
-    if not self.gcloud_has_active_account(gcloud_binary_path):
-      # Allow running gcloud with anonymous credentials.
-      env_variables['CLOUDSDK_AUTH_DISABLE_CREDENTIALS'] = 'True'
-
     gcloud_storage_command = ([gcloud_binary_path] + args + top_level_flags +
                               header_flags + flags_from_boto)
     return env_variables, gcloud_storage_command
@@ -632,6 +629,9 @@ class GcloudStorageCommandMixin(object):
       try:
         env_variables, gcloud_storage_command = self._get_full_gcloud_storage_execution_information(
             self.get_gcloud_storage_args())
+        if not self.gcloud_has_active_account():
+          # Allow running gcloud with anonymous credentials.
+          env_variables['CLOUDSDK_AUTH_DISABLE_CREDENTIALS'] = 'True'
         if hidden_shim_mode == HIDDEN_SHIM_MODE.DRY_RUN:
           self._print_gcloud_storage_command_info(gcloud_storage_command,
                                                   env_variables,

--- a/gslib/utils/shim_util.py
+++ b/gslib/utils/shim_util.py
@@ -590,7 +590,7 @@ class GcloudStorageCommandMixin(object):
 
     if not self.gcloud_has_active_account(gcloud_binary_path):
       # Allow running gcloud with anonymous credentials.
-      env_variables['CLOUDSDK_AUTH_DISABLE_CREDENTIALS'] = True
+      env_variables['CLOUDSDK_AUTH_DISABLE_CREDENTIALS'] = 'True'
 
     gcloud_storage_command = ([gcloud_binary_path] + args + top_level_flags +
                               header_flags + flags_from_boto)


### PR DESCRIPTION
Accessing public data does not require authentication. In gsutil, this works out-of-the-box. In `gcloud storage`, the user has to set `auth/disable_credentials` property to use it without authentication (i.e without setting up an active account). For the shim, in order to not break the workflow of existing users who rely on the gsutil behavior, we will set the `auth/disable_credentials` property automatically if we detect that `gcloud` doesn't have any active account configured.

The change has been tested manually

### Before:
```
$ CLOUDSDK_CORE_PASS_CREDENTIALS_TO_GSUTIL=1 GCLOUD_BINARY_PATH=/usr/bin/gcloud python3 gsutil.py -o "GSUtil:use_gcloud_storage=True"  ls  gs://pub/test.txt
ERROR: (gcloud.storage.ls) You do not currently have an active account selected.
Please run:

  $ gcloud auth login

to obtain new credentials.

If you have already logged in with a different account, run:

  $ gcloud config set account ACCOUNT

to select an already authenticated account to use.

```

### After:
```
$ CLOUDSDK_CORE_PASS_CREDENTIALS_TO_GSUTIL=1 GCLOUD_BINARY_PATH=/usr/bin/gcloud python3 gsutil.py -o "GSUtil:use_gcloud_storage=True"  ls  gs://pub/test.txt
gs://pub/test.txt
```