### PR TITLE
Migrates p12 service account authentication flow from oauth2client to google-auth.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -82,3 +82,6 @@
 [submodule "third_party/certifi"]
 	path = third_party/certifi
 	url = https://github.com/certifi/python-certifi.git
+[submodule "third_party/google-auth-library-python-httplib2"]
+	path = third_party/google-auth-library-python-httplib2
+	url = https://github.com/googleapis/google-auth-library-python-httplib2.git

--- a/gslib/__main__.py
+++ b/gslib/__main__.py
@@ -704,7 +704,8 @@ def _RunNamedCommandAndHandleExceptions(command_runner,
   except ServiceException as e:
     _OutputAndExit(message=e, exception=e)
   except (oauth2client.client.HttpAccessTokenRefreshError,
-          google_auth_exceptions.OAuthError) as e:
+          google_auth_exceptions.OAuthError,
+          google_auth_exceptions.RefreshError) as e:
     if system_util.InvokedViaCloudSdk():
       _OutputAndExit(
           'Your credentials are invalid. '

--- a/gslib/__main__.py
+++ b/gslib/__main__.py
@@ -783,6 +783,8 @@ def _RunNamedCommandAndHandleExceptions(command_runner,
           'gs_service_key_file field in your config file(s),\n%s, is correct.' %
           config_paths,
           exception=e)
+    elif 'Invalid password or PKCS12' in str(e):
+      _OutputAndExit('Unable to load the keyfile, Invalid password or PKCS12 data.', exception=e)
     _HandleUnknownFailure(e)
 
 

--- a/gslib/__main__.py
+++ b/gslib/__main__.py
@@ -783,8 +783,6 @@ def _RunNamedCommandAndHandleExceptions(command_runner,
           'gs_service_key_file field in your config file(s),\n%s, is correct.' %
           config_paths,
           exception=e)
-    elif 'Invalid password or PKCS12' in str(e):
-      _OutputAndExit('Unable to load the keyfile, Invalid password or PKCS12 data.', exception=e)
     _HandleUnknownFailure(e)
 
 

--- a/gslib/gcs_json_credentials.py
+++ b/gslib/gcs_json_credentials.py
@@ -48,6 +48,10 @@ from gslib.utils.boto_util import GetGceCredentialCacheFilename
 from gslib.utils.boto_util import GetGcsJsonApiVersion
 from gslib.utils.constants import UTF8
 from gslib.utils.wrapped_credentials import WrappedCredentials
+from google.auth import _helpers
+from google.auth.crypt import base as crypt_base
+from google_auth_httplib2 import AuthorizedHttp
+from google.oauth2 import service_account
 import oauth2client
 from oauth2client.client import HAS_CRYPTO
 from oauth2client.contrib import devshell
@@ -72,6 +76,75 @@ DEFAULT_SCOPES = [
 
 GOOGLE_OAUTH2_DEFAULT_FILE_PASSWORD = 'notasecret'
 
+
+class PKCS12Signer(crypt_base.Signer, crypt_base.FromServiceAccountMixin):
+  """Signer for a p12 service account key."""
+
+  def __init__(self, key):
+    self._key = key
+
+  # Defined in crypt_base.Signer interface.
+  # It is not used by p12 service account keys.
+  @property
+  def key_id(self):
+    return None
+
+  def sign(self, message):
+    message = _helpers.to_bytes(message)
+    from google.auth.crypt import _cryptography_rsa  # pylint: disable=g-import-not-at-top
+    return self._key.sign(
+        message,
+        _cryptography_rsa._PADDING,  # pylint: disable=protected-access
+        _cryptography_rsa._SHA256)  # pylint: disable=protected-access
+
+  @classmethod
+  def from_string(cls, key_strings, key_id=None):
+    del key_id
+    key_string, password = (_helpers.to_bytes(k) for k in key_strings)
+    from cryptography.hazmat.primitives.serialization import pkcs12  # pylint: disable=g-import-not-at-top
+    key, _, _ = pkcs12.load_key_and_certificates(key_string, password)
+    return cls(key)
+
+
+class P12Credentials(service_account.Credentials):
+  """google-auth service account credentials  for p12 keys.
+  p12 keys are not supported by the google-auth service account credentials.
+  gcloud uses oauth2client to support p12 key users. Since oauth2client was
+  deprecated and bundling it is security concern, we decided to support p12
+  in gcloud codebase. We prefer not adding it to the google-auth library
+  because p12 is not supported from the beginning by google-auth. GCP strongly
+  suggests users to use the JSON format. gsutil has to support it to not
+  break users.
+  """
+
+  _REQUIRED_FIELDS = ('service_account_email', 'token_uri', 'scopes')
+
+  def authorize(self, http):
+    return AuthorizedHttp(self, http=http)
+
+  @classmethod
+  def from_service_account_pkcs12_keystring(cls,
+                                            key_string,
+                                            password=None,
+                                            **kwargs):
+    password = password or GOOGLE_OAUTH2_DEFAULT_FILE_PASSWORD
+    signer = PKCS12Signer.from_string((key_string, password))
+
+    missing_fields = [f for f in cls._REQUIRED_FIELDS if f not in kwargs]
+    if missing_fields:
+      raise MissingRequiredFieldsError('Missing fields: {}.'.format(
+          ', '.join(missing_fields)))
+    creds = cls(signer, **kwargs)
+    return creds
+
+def CreateP12ServiceAccount(key_string, password=None, **kwargs):
+  """Creates a service account from a p12 key and handles import errors."""
+  try:
+    return P12Credentials.from_service_account_pkcs12_keystring(
+        key_string, password, **kwargs)
+  except ImportError:
+      raise MissingDependencyError(
+          ('pyca/cryptography is not available. Either install it, or please consider using the .json keyfile'))
 
 def GetCredentialStoreKey(credentials, api_version):
   """Disambiguates a credential for caching in a credential store.
@@ -145,33 +218,35 @@ def SetUpJsonCredentialsAndCache(api, logger, credentials=None):
         'WARNING: This command is using service account impersonation. All '
         'API calls will be executed as [%s].', _GetImpersonateServiceAccount())
 
-  # Set credential cache so that we don't have to get a new access token for
-  # every call we make. All GCS APIs use the same credentials as the JSON API,
-  # so we use its version in the key for caching access tokens.
-  credential_store_key = (GetCredentialStoreKey(api.credentials,
-                                                GetGcsJsonApiVersion()))
-  api.credentials.set_store(
-      multiprocess_file_storage.MultiprocessFileStorage(
-          GetCredentialStoreFilename(), credential_store_key))
-  # The cached entry for this credential often contains more context than what
-  # we can construct from boto config attributes (e.g. for a user credential,
-  # the cached version might also contain a RAPT token and expiry info).
-  # Prefer the cached credential if present.
-  cached_cred = None
-  if not isinstance(api.credentials, NoOpCredentials):
-    # A NoOpCredentials object doesn't actually have a store attribute.
-    cached_cred = api.credentials.store.get()
-  # As of gsutil 4.31, we never use the OAuth2Credentials class for
-  # credentials directly; rather, we use subclasses (user credentials were
-  # the only ones left using it, but they now use
-  # Oauth2WithReauthCredentials).  If we detect that a cached credential is
-  # an instance of OAuth2Credentials and not a subclass of it (as might
-  # happen when transitioning to version v4.31+), we don't fetch it from the
-  # cache. This results in our new-style credential being refreshed and
-  # overwriting the old credential cache entry in our credstore.
-  if (cached_cred and
-      type(cached_cred) != oauth2client.client.OAuth2Credentials):
-    api.credentials = cached_cred
+  # Do not store p12 credentials (Supported by google-auth), as google-auth does not support storing service account credentials.
+  if not isinstance(api.credentials, P12Credentials):
+    # Set credential cache so that we don't have to get a new access token for
+    # every call we make. All GCS APIs use the same credentials as the JSON API,
+    # so we use its version in the key for caching access tokens.
+    credential_store_key = (GetCredentialStoreKey(api.credentials,
+                                                  GetGcsJsonApiVersion()))
+    api.credentials.set_store(
+        multiprocess_file_storage.MultiprocessFileStorage(
+            GetCredentialStoreFilename(), credential_store_key))
+    # The cached entry for this credential often contains more context than what
+    # we can construct from boto config attributes (e.g. for a user credential,
+    # the cached version might also contain a RAPT token and expiry info).
+    # Prefer the cached credential if present.
+    cached_cred = None
+    if not isinstance(api.credentials, NoOpCredentials):
+      # A NoOpCredentials object doesn't actually have a store attribute.
+      cached_cred = api.credentials.store.get()
+    # As of gsutil 4.31, we never use the OAuth2Credentials class for
+    # credentials directly; rather, we use subclasses (user credentials were
+    # the only ones left using it, but they now use
+    # Oauth2WithReauthCredentials).  If we detect that a cached credential is
+    # an instance of OAuth2Credentials and not a subclass of it (as might
+    # happen when transitioning to version v4.31+), we don't fetch it from the
+    # cache. This results in our new-style credential being refreshed and
+    # overwriting the old credential cache entry in our credstore.
+    if (cached_cred and
+        type(cached_cred) != oauth2client.client.OAuth2Credentials):
+      api.credentials = cached_cred
 
 
 def _CheckAndGetCredentials(logger):
@@ -340,26 +415,9 @@ def _GetOauth2ServiceAccountCredentials():
         json_key_dict, scopes=DEFAULT_SCOPES, token_uri=provider_token_uri)
   else:
     # Key file is in P12 format.
-    if HAS_CRYPTO:
-      if not service_client_id:
-        raise Exception('gs_service_client_id must be set if '
-                        'gs_service_key_file is set to a .p12 key file')
-      key_file_pass = config.get('Credentials', 'gs_service_key_file_password',
+    key_file_pass = config.get('Credentials', 'gs_service_key_file_password',
                                  GOOGLE_OAUTH2_DEFAULT_FILE_PASSWORD)
-      # We use _from_p12_keyfile_contents to avoid reading the key file
-      # again unnecessarily.
-      try:
-        return ServiceAccountCredentials.from_p12_keyfile_buffer(
-            service_client_id,
-            BytesIO(private_key),
-            private_key_password=key_file_pass,
-            scopes=DEFAULT_SCOPES,
-            token_uri=provider_token_uri)
-      except Exception as e:
-        raise Exception(
-            'OpenSSL unable to parse PKCS 12 key {}.'
-            'Please verify key integrity. Error message:\n{}'.format(
-                private_key_filename, str(e)))
+    return CreateP12ServiceAccount(private_key, key_file_pass, scopes=DEFAULT_SCOPES, service_account_email=service_client_id, token_uri=provider_token_uri)
 
 
 def _GetOauth2UserAccountCredentials():

--- a/gslib/gcs_json_credentials.py
+++ b/gslib/gcs_json_credentials.py
@@ -102,8 +102,11 @@ class PKCS12Signer(crypt_base.Signer, crypt_base.FromServiceAccountMixin):
     del key_id
     key_string, password = (_helpers.to_bytes(k) for k in key_strings)
     from cryptography.hazmat.primitives.serialization import pkcs12  # pylint: disable=g-import-not-at-top
-    key, _, _ = pkcs12.load_key_and_certificates(key_string, password)
-    return cls(key)
+    try:
+      key, _, _ = pkcs12.load_key_and_certificates(key_string, password)
+      return cls(key)
+    except:
+      raise Exception('Unable to load the keyfile, Invalid password or PKCS12 data.')
 
 
 class P12Credentials(service_account.Credentials):

--- a/gslib/tests/test_gcs_json_credentials.py
+++ b/gslib/tests/test_gcs_json_credentials.py
@@ -44,6 +44,12 @@ try:
 except ImportError:
   HAS_OPENSSL = False
 
+try:
+  import cryptography
+  HAS_CRYPTO = True
+except ImportError:
+  HAS_CRYPTO = False
+
 ERROR_MESSAGE = "This is the error message"
 
 
@@ -74,7 +80,7 @@ def getBotoCredentialsConfig(
 class TestGcsJsonCredentials(testcase.GsUtilUnitTestCase):
   """Test logic for interacting with GCS JSON Credentials."""
 
-  @unittest.skipUnless(HAS_OPENSSL, 'signurl requires pyopenssl.')
+  @unittest.skipUnless(HAS_CRYPTO, 'p12credentials requires cryptography.')
   def testOauth2ServiceAccountCredential(self):
     contents = pkgutil.get_data("gslib", "tests/test_data/test.p12")
     tmpfile = self.CreateTempFile(contents=contents)
@@ -85,10 +91,10 @@ class TestGcsJsonCredentials(testcase.GsUtilUnitTestCase):
         })):
       self.assertTrue(gcs_json_credentials._HasOauth2ServiceAccountCreds())
       client = gcs_json_api.GcsJsonApi(None, None, None, None)
-      self.assertIsInstance(client.credentials, ServiceAccountCredentials)
+      self.assertIsInstance(client.credentials, gcs_json_credentials.P12Credentials)
 
-  @unittest.skipUnless(HAS_OPENSSL, 'signurl requires pyopenssl.')
-  @mock.patch.object(ServiceAccountCredentials,
+  @unittest.skipUnless(HAS_CRYPTO, 'p12credentials requires cryptography.')
+  @mock.patch.object(gcs_json_credentials.P12Credentials,
                      "__init__",
                      side_effect=ValueError(ERROR_MESSAGE))
   def testOauth2ServiceAccountFailure(self, _):

--- a/gsutil.py
+++ b/gsutil.py
@@ -112,6 +112,7 @@ THIRD_PARTY_LIBS = [
     ('idna', ''),  # requests dependency
     ('requests', ''),  # google auth dependency
     ('google-auth-library-python', ''),
+    ('google-auth-library-python-httplib2', ''), #Package name: google-auth-httplib2
 ]
 
 # The wrapper script adds all third_party libraries to the Python path, since

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ requires = [
     'six>=1.16.0',
     # aiohttp is the extra dependency that contains requests lib.
     'google-auth[aiohttp]>=2.5.0',
+    'google-auth-httplib2>=0.2.0',
 ]
 
 CURDIR = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
This change migrates p12 service account authentication flow from oauth2client to google-auth. The change is required, as oauth2client depends upon openSSL for understanding .p12 format keyfiles, in newer version of openSSL they've deprecated the support for .p12 files, due to which oauth2client would throw an error as described in bug b/330533641.

Fixes b/330533641.