### PR TITLE
Fixes Parity Tests for rm and requesterpays commands.

### DIFF
--- a/gslib/commands/requesterpays.py
+++ b/gslib/commands/requesterpays.py
@@ -71,7 +71,7 @@ _set_help_text = CreateHelpText(_SET_SYNOPSIS, _SET_DESCRIPTION)
 
 _GCLOUD_FORMAT_STRING = ('--format=value[separator=": "](' + 'name.sub("' +
                          shim_util.get_format_flag_caret() + '", "gs://"),' +
-                         'billing.requesterPays.yesno("Enabled", "Disabled"))')
+                         'requester_pays.yesno("Enabled", "Disabled"))')
 
 
 class RequesterPaysCommand(Command):

--- a/gslib/tests/test_rm.py
+++ b/gslib/tests/test_rm.py
@@ -138,7 +138,11 @@ class TestRm(testcase.GsUtilIntegrationTestCase):
         stderr_set.remove('')  # Avoid groups represented by an empty string.
       if MACOS_WARNING in stderr_set:
         stderr_set.remove(MACOS_WARNING)
-      self.assertEqual(stderr_set, expected_stderr_lines)
+      if self._use_gcloud_storage:
+        for to_check in expected_stderr_lines:
+          self.assertIn(to_check, stderr)
+      else:
+        self.assertEqual(stderr_set, expected_stderr_lines)
     else:
       cumulative_stderr_lines = set()
 


### PR DESCRIPTION
* requesterpays - Changing Format key according to `gcloud storage buckets describe` output.
* rm: Changing validation for shimmed rm command as shimmed rm command prints more logs line including `Removing buckets:` and `Removing objects`,etc. 