### PR TITLE
Updated setup.py to use the >=3.2 version of gcs-oauth2-boto-plugin, and the submodule gcs-oauth2-boto-plugin in third_party directory, and changes.md file

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@ New Features
 
 Other Changes
 ------------------
-- Upgraded gcs-oauth2-boto-plugin for users with versions greater than 5.29 to authenticate via google-auth for .p12 keys.
+- Upgraded gcs-oauth2-boto-plugin for users to authenticate via google-auth (instead of oauth2client) for .p12 keys.
 
 Release 5.28 (release date: 2024-04-30)
 ======================================

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+Release 5.29 (release date: 2024-05-07)
+======================================
+New Features
+------------------
+
+Other Changes
+------------------
+- Upgraded gcs-oauth2-boto-plugin for users with versions greater than 5.29 to authenticate via google-auth for .p12 keys.
+
 Release 5.28 (release date: 2024-04-30)
 ======================================
 New Features

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ requires = [
     'argcomplete>=1.9.4',
     'crcmod>=1.7',
     'fasteners>=0.14.1',
-    'gcs-oauth2-boto-plugin>=3.0',
+    'gcs-oauth2-boto-plugin>=3.2',
     'google-apitools>=0.5.32',
     'httplib2==0.20.4',
     'google-reauth>=0.1.0',


### PR DESCRIPTION
Updated setup.py to use the >=3.2 version of gcs-oauth2-boto-plugin, and the submodule gcs-oauth2-boto-plugin in third_party directory.