### PR TITLE
Fixes GitHub Workflow build issue.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+      env:
+        PIP_TRUSTED_HOST: "pypi.python.org pypi.org files.pythonhosted.org"
     - name: Install dependencies
       run: |
         set -x


### PR DESCRIPTION
This PR fixes Python 3.5 Build failure by adding pip known hosts in the env variables.
Workaround Reference: https://github.com/actions/setup-python/issues/866