### PR TITLE
Fixes label command shim translation issue.

### DIFF
--- a/gslib/commands/label.py
+++ b/gslib/commands/label.py
@@ -184,8 +184,8 @@ class LabelCommand(Command):
           GcloudStorageMap(
               gcloud_command=[
                   'storage', 'buckets', 'describe',
-                  '--format="gsutiljson[key=labels,empty=\' has no label '
-                  'configuration.\',empty_prefix_key=storage_url]"', '--raw'
+                  '--format=gsutiljson[key=labels,empty=\' has no label '
+                  'configuration.\',empty_prefix_key=storage_url,indent=2]'
               ],
               flag_map={},
           ),


### PR DESCRIPTION
Currently, Shim is broken for gsutil label command and also requires pretty printed json in the output. 
This PR fixes the broken shim translation and add indent in the formatter to format shim output.