### PR TITLE
Fixes parity failures of cat and rm commands.

### DIFF
--- a/gslib/tests/test_cat.py
+++ b/gslib/tests/test_cat.py
@@ -136,7 +136,7 @@ class TestCat(testcase.GsUtilIntegrationTestCase):
                               expected_status=1)
       if self._use_gcloud_storage:
         self.assertIn(
-            'The following URLs matched no objects or files:\n-{}23\n'.format(
+            'The following URLs matched no objects or files:\n{}23\n'.format(
                 uri2.version_specific_uri), stderr)
       else:
         self.assertIn(NO_URLS_MATCHED_TARGET % uri2.version_specific_uri + '23',

--- a/gslib/tests/test_rm.py
+++ b/gslib/tests/test_rm.py
@@ -745,7 +745,7 @@ class TestRm(testcase.GsUtilIntegrationTestCase):
         expected_status=1)
     if self._use_gcloud_storage:
       self.assertIn(
-          'The following URLs matched no objects or files:\n{}\n-{}'.format(
+          'The following URLs matched no objects or files:\n{}\n{}'.format(
               nonexistent_object1, nonexistent_object2), stderr)
     else:
       self.assertIn('2 files/objects could not be removed.', stderr)

--- a/gslib/tests/test_rm.py
+++ b/gslib/tests/test_rm.py
@@ -246,7 +246,7 @@ class TestRm(testcase.GsUtilIntegrationTestCase):
         expected_status=1)
     if self._use_gcloud_storage:
       no_url_matched_target = no_url_matched_target = (
-          'The following URLs matched no objects or files:\n-%s')
+          'The following URLs matched no objects or files:\n%s')
     else:
       no_url_matched_target = NO_URLS_MATCHED_TARGET
     self.assertIn(no_url_matched_target % suri(bucket_uri, 'foo'), stderr)
@@ -389,7 +389,7 @@ class TestRm(testcase.GsUtilIntegrationTestCase):
     self.assertEqual(stderr.count('Removing %s://' % self.default_provider), 1)
     if self._use_gcloud_storage:
       self.assertIn(
-          'The following URLs matched no objects or files:\n-%s' %
+          'The following URLs matched no objects or files:\n%s' %
           suri(bucket_uri, 'missing'), stderr)
     else:
       self.assertIn(NO_URLS_MATCHED_TARGET % suri(bucket_uri, 'missing'),
@@ -741,7 +741,7 @@ class TestRm(testcase.GsUtilIntegrationTestCase):
         expected_status=1)
     if self._use_gcloud_storage:
       self.assertIn(
-          'The following URLs matched no objects or files:\n-{}\n-{}'.format(
+          'The following URLs matched no objects or files:\n{}\n-{}'.format(
               nonexistent_object1, nonexistent_object2), stderr)
     else:
       self.assertIn('2 files/objects could not be removed.', stderr)


### PR DESCRIPTION
Recently, Error message for non-matching URLs has been modified in `gcloud storage` tool. This change caused failures in parity tests. 
This PR fixes the failures for `gcloud` validation only and doesn't affect any `gsutil` command implementation or gsutil specific validations.