### PR TITLE
skipping test metrics posting

### DIFF
--- a/gslib/tests/test_metrics.py
+++ b/gslib/tests/test_metrics.py
@@ -722,6 +722,7 @@ class TestMetricsIntegrationTests(testcase.GsUtilIntegrationTestCase):
       reported_metrics = pickle.load(metrics_file)
     self.assertEqual(COMMAND_AND_ERROR_TEST_METRICS, set(reported_metrics))
 
+  @unittest.skip("example.com is currently not accepting post requests, tracking bug: b/369285587")
   @mock.patch('time.time', new=mock.MagicMock(return_value=0))
   def testMetricsPosting(self):
     """Tests the metrics posting process as performed in metrics_reporter.py."""


### PR DESCRIPTION
- Skipping this test as example.com gives 405 response on POST requests.
- A tracking bug to resolve this issue: [b/369285587](https://buganizer.corp.google.com/issues/369285587)