### PR TITLE
Skip Tab Complete Tests for python > 3.11.8

### DIFF
--- a/gslib/tests/test_tabcomplete.py
+++ b/gslib/tests/test_tabcomplete.py
@@ -21,6 +21,7 @@ from __future__ import unicode_literals
 
 import os
 import time
+import sys
 
 from gslib.command import CreateOrGetGsutilLogger
 from gslib.tab_complete import CloudObjectCompleter
@@ -36,6 +37,8 @@ from gslib.utils.boto_util import GetTabCompletionCacheFilename
 
 @unittest.skipUnless(ARGCOMPLETE_AVAILABLE,
                      'Tab completion requires argcomplete')
+@unittest.skipUnless(sys.version_info < (3, 11, 9),
+                     'Tab completion is only supported on Python < 3.11.9')
 class TestTabComplete(testcase.GsUtilIntegrationTestCase):
   """Integration tests for tab completion."""
 


### PR DESCRIPTION
Tab completion in gsutil is currently failing for Python versions greater than 3.11.8, which has been traced back to an upgrade in the argcomplete dependency. This issue is associated with the [v3.3.0 release](https://github.com/kislyuk/argcomplete/releases/tag/v3.3.0).