### PR TITLE
Updates gsutil test command to execute tests in in parallel from any directory.

### DIFF
--- a/gslib/tests/util.py
+++ b/gslib/tests/util.py
@@ -721,11 +721,12 @@ def _SetBotoConfigFileForTest(boto_config_path):
       os.environ.pop('BOTO_CONFIG', None)
 
 
-def GetTestNames():
+def GetTestNames(test_path=None):
   """Returns a list of the names of the test modules in gslib.tests."""
   matcher = re.compile(r'^test_(?P<name>.*)$')
   names = []
-  for _, modname, _ in pkgutil.iter_modules(gslib_tests.__path__):
+  test_path = [test_path] if test_path else gslib_tests.__path__
+  for _, modname, _ in pkgutil.iter_modules(test_path):
     m = matcher.match(modname)
     if m:
       names.append(m.group('name'))


### PR DESCRIPTION
You can specify `gsutil test -d TEST_DIR` to execute all tests matching the pattern `test_*.py` within the `TEST_DIR`. If you want to run an individual test, use `gsutil test -d TEST_DIR acl`.

Note that this command should not be combined with other flags such as `-c`, `-s`, etc., if the tests are written outside the `gsutil` repository, as these flags will not function in that context.