### PR TITLE
Github CI Build only for 3.8 to 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [pypy3, 3.5.x, 3.6.x, 3.7.x, 3.8.x, 3.9.x, 3.10.x, 3.11.x]
+        python-version: [3.8.x, 3.9.x, 3.10.x, 3.11.x, 3.12.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This update is part of the process of transitioning to Python 3.12 while dropping support for Python 3.5, 3.6, and 3.7. The GitHub CI configuration has been modified to test against Python versions 3.8 through 3.12, ensuring compatibility across supported versions.