### PR TITLE
updating version check to 3.12

### DIFF
--- a/gsutil.py
+++ b/gsutil.py
@@ -27,12 +27,12 @@ import warnings
 # TODO: gsutil-beta: Distribute a pylint rc file.
 
 ver = sys.version_info
-if (ver.major == 2 and ver.minor < 7) or (ver.major == 3 and (ver.minor < 5 or ver.minor > 11)):
+if ver.major != 3 or ver.minor < 8 or ver.minor > 12:
   sys.exit(
-    "Error: gsutil requires Python version 2.7 or 3.5-3.11, but a different version is installed.\n"
+    "Error: gsutil requires Python version 3.8-3.12, but a different version is installed.\n"
     "You are currently running Python {}.{}\n"
     "Follow the steps below to resolve this issue:\n"
-    "\t1. Switch to Python 3.5-3.11 using your Python version manager or install an appropriate version.\n"
+    "\t1. Switch to Python 3.8-3.12 using your Python version manager or install an appropriate version.\n"
     "\t2. If you are unsure how to manage Python versions, visit [https://cloud.google.com/storage/docs/gsutil_install#specifications] for detailed instructions.".format(ver.major, ver.minor)
   )
 

--- a/setup.py
+++ b/setup.py
@@ -126,16 +126,16 @@ setup(
         'Natural Language :: English',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Topic :: System :: Filesystems',
         'Topic :: Utilities',
     ],
-    # Gsutil supports Python 3.5+
-    python_requires='!=2.*, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4',
+    # Gsutil supports Python 3.8 to 3.12
+    python_requires='>=3.8, <=3.12',
     platforms='any',
     packages=find_packages(
         exclude=[


### PR DESCRIPTION
This PR updates the Python version compatibility for gsutil to support Python 3.8 through 3.12, while dropping support for older versions (3.5, 3.6, and 3.7). The following changes have been made:

- Updated version check in `gsutil.py` to `3.8-3.12`.
- Updated the `python_requires` and `classifiers` in `setup.py` to specify compatibility with Python versions 3.8 to 3.12, removing references to unsupported versions (3.5, 3.6, and 3.7).

These updates align the project with the ongoing effort to support the latest Python versions while ensuring compatibility across all tested platforms.