### PR TITLE
Py3.12 changes

### DIFF
--- a/gslib/commands/perfdiag.py
+++ b/gslib/commands/perfdiag.py
@@ -42,7 +42,7 @@ import boto.gs.connection
 import six
 from six.moves import cStringIO
 from six.moves import http_client
-from six.moves import xrange
+from six.moves import range
 from six.moves import range
 
 import gslib
@@ -1222,7 +1222,7 @@ class PerfDiagCommand(Command):
         [random.choice(string.ascii_lowercase) for _ in range(10)])
     list_prefix = 'gsutil-perfdiag-list-' + random_id + '-'
 
-    for _ in xrange(self.num_objects):
+    for _ in range(self.num_objects):
       fpath = self._MakeTempFile(0,
                                  mem_data=True,
                                  mem_metadata=True,

--- a/gslib/commands/signurl.py
+++ b/gslib/commands/signurl.py
@@ -26,6 +26,7 @@ import calendar
 import copy
 from datetime import datetime
 from datetime import timedelta
+from datetime import timezone
 import getpass
 import json
 import re
@@ -214,7 +215,7 @@ _DETAILED_HELP_TEXT = ("""
 
 def _NowUTC():
   """Returns the current utc time as a datetime object."""
-  return datetime.utcnow()
+  return datetime.now(tz=timezone.utc).replace(tzinfo=None)
 
 
 def _DurationToTimeDelta(duration):
@@ -697,7 +698,7 @@ class UrlSignCommand(Command):
                                 billing_project=billing_project,
                                 string_to_sign_debug=True)
 
-      expiration = calendar.timegm((datetime.utcnow() + delta).utctimetuple())
+      expiration = calendar.timegm((datetime.now(tz=timezone.utc).replace(tzinfo=None) + delta).utctimetuple())
       expiration_dt = datetime.fromtimestamp(expiration)
 
       time_str = expiration_dt.strftime('%Y-%m-%d %H:%M:%S')

--- a/gslib/tests/test_compose.py
+++ b/gslib/tests/test_compose.py
@@ -19,7 +19,7 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import unicode_literals
 
-from six.moves import xrange
+from six.moves import range
 from six.moves import range
 
 from gslib.commands.compose import MAX_COMPOSE_ARITY
@@ -45,7 +45,7 @@ class TestCompose(testcase.GsUtilIntegrationTestCase):
     bucket_uri = self.CreateBucket()
 
     data_list = [
-        ('data-%d,' % i).encode('ascii') for i in xrange(num_components)
+        ('data-%d,' % i).encode('ascii') for i in range(num_components)
     ]
     components = [
         self.CreateObject(bucket_uri=bucket_uri, contents=data).uri

--- a/gslib/tests/test_cp.py
+++ b/gslib/tests/test_cp.py
@@ -128,7 +128,7 @@ from gslib.utils import shim_util
 import six
 from six.moves import http_client
 from six.moves import range
-from six.moves import xrange
+from six.moves import range
 
 if six.PY3:
   long = int  # pylint: disable=redefined-builtin,invalid-name
@@ -3829,7 +3829,7 @@ class TestCp(testcase.GsUtilIntegrationTestCase):
     object_uri = self.CreateObject()
     random.seed(0)
     contents = str([
-        random.choice(string.ascii_letters) for _ in xrange(self.halt_size)
+        random.choice(string.ascii_letters) for _ in range(self.halt_size)
     ]).encode('ascii')
     random.seed()  # Reset the seed for any other tests.
     fpath1 = self.CreateTempFile(file_name='unzipped.txt', contents=contents)

--- a/gslib/tests/test_retention.py
+++ b/gslib/tests/test_retention.py
@@ -273,7 +273,7 @@ class TestRetention(testcase.GsUtilIntegrationTestCase):
         ['retention', 'get', suri(bucket_uri)], return_stdout=True)
     if self._use_gcloud_storage:
       # Sometimes the field is absent if isLocked is false.
-      self.assertNotRegexpMatches(stdout, r'isLocked \: true')
+      self.assertNotRegex(stdout, r'isLocked \: true')
       self.assertRegex(stdout, r'retentionPeriod\: \'86400\'')
       self.assertRegex(stdout, r'effectiveTime\: \'.*\'')
     else:

--- a/gslib/tests/test_rsync.py
+++ b/gslib/tests/test_rsync.py
@@ -2929,7 +2929,7 @@ class TestRsync(testcase.GsUtilIntegrationTestCase):
                                            'b.txt'), ('data3', 'data4', 'c.txt')
     ])
     self.RunGsUtil(
-        ['rsync', '-r', flag, '^(?!.*\.txt$).*', tmpdir,
+        ['rsync', '-r', flag, r'^(?!.*\.txt$).*', tmpdir,
          suri(bucket_uri)],
         return_stderr=True)
     listing = TailSet(tmpdir, self.FlatListDir(tmpdir))

--- a/gslib/tests/test_shim_util.py
+++ b/gslib/tests/test_shim_util.py
@@ -1185,7 +1185,7 @@ class TestFormatFlagUtils(testcase.GsUtilUnitTestCase):
 
   def test_gets_format_flag_escaped_newline_on_windows(self):
     with mock.patch.object(system_util, 'IS_WINDOWS', new=True):
-      self.assertEqual(shim_util.get_format_flag_newline(), '^\^n')
+      self.assertEqual(shim_util.get_format_flag_newline(), r'^\^n')
 
 
 class TestBotoTranslation(testcase.GsUtilUnitTestCase):

--- a/gslib/utils/copy_helper.py
+++ b/gslib/utils/copy_helper.py
@@ -45,7 +45,7 @@ import time
 import traceback
 
 import six
-from six.moves import xrange
+from six.moves import range
 from six.moves import range
 
 from apitools.base.protorpclite import protojson
@@ -4138,13 +4138,13 @@ class Manifest(object):
     # Always use the source_url as the key for the item. This is unique.
     self.Set(source_url, 'source_uri', source_url)
     self.Set(source_url, 'destination_uri', destination_url)
-    self.Set(source_url, 'start_time', datetime.datetime.utcnow())
+    self.Set(source_url, 'start_time', datetime.datetime.now(tz=datetime.timezone.utc).replace(tzinfo=None))
 
   def SetResult(self, source_url, bytes_transferred, result, description=''):
     self.Set(source_url, 'bytes', bytes_transferred)
     self.Set(source_url, 'result', result)
     self.Set(source_url, 'description', description)
-    self.Set(source_url, 'end_time', datetime.datetime.utcnow())
+    self.Set(source_url, 'end_time', datetime.datetime.now(tz=datetime.timezone.utc).replace(tzinfo=None))
     self._WriteRowToManifestFile(source_url)
     self._RemoveItemFromManifest(source_url)
 
@@ -4270,7 +4270,7 @@ def ResolveWildcardsInPathBeforeFinalDir(src_url_path_sans_final_dir,
   wildcarded_src_obj_path = StorageUrlFromString(
       src_url_path_sans_final_dir).object_name.split('/')
   expanded_src_obj_path = exp_src_url.object_name.split('/')
-  for path_segment_index in xrange(len(wildcarded_src_obj_path)):
+  for path_segment_index in range(len(wildcarded_src_obj_path)):
     if ContainsWildcard(wildcarded_src_obj_path[path_segment_index]):
       # The expanded path is guaranteed to be have at least as many path
       # segments as the wildcarded path.

--- a/gslib/utils/signurl_helper.py
+++ b/gslib/utils/signurl_helper.py
@@ -16,6 +16,7 @@
 
 import base64
 from datetime import datetime
+from datetime import timezone
 import hashlib
 
 from gslib.utils.constants import UTF8
@@ -33,7 +34,7 @@ _UNSIGNED_PAYLOAD = 'UNSIGNED-PAYLOAD'
 
 
 def _NowUTC():
-  return datetime.utcnow()
+  return datetime.now(tz=timezone.utc).replace(tzinfo=None)
 
 
 def CreatePayload(client_id,


### PR DESCRIPTION
Added Support for python 3.12

python 3.12 documentation reference: [documentation](https://docs.python.org/dev/whatsnew/3.12.html)

Changes:

- Invalid escape sequence - A backslash-character pair that is not a valid escape sequence now generates a [SyntaxWarning](https://docs.python.org/dev/library/exceptions.html#SyntaxWarning), instead of [DeprecationWarning](https://docs.python.org/dev/library/exceptions.html#DeprecationWarning). For example, re.compile("\d+.\d+") now emits a [SyntaxWarning](https://docs.python.org/dev/library/exceptions.html#SyntaxWarning) ("\d" is an invalid escape sequence, use raw strings for regular expression: re.compile(r"\d+.\d+")). In a future Python version, [SyntaxError](https://docs.python.org/dev/library/exceptions.html#SyntaxError) will eventually be raised, instead of [SyntaxWarning](https://docs.python.org/dev/library/exceptions.html#SyntaxWarning).
- `datetime.utcnow()` change - [datetime](https://docs.python.org/dev/library/datetime.html#module-datetime): [datetime.datetime](https://docs.python.org/dev/library/datetime.html#datetime.datetime)’s [utcnow()](https://docs.python.org/dev/library/datetime.html#datetime.datetime.utcnow) and [utcfromtimestamp()](https://docs.python.org/dev/library/datetime.html#datetime.datetime.utcfromtimestamp) are deprecated and will be removed in a future version. Instead, use timezone-aware objects to represent datetimes in UTC: respectively, call [now()](https://docs.python.org/dev/library/datetime.html#datetime.datetime.now) and [fromtimestamp()](https://docs.python.org/dev/library/datetime.html#datetime.datetime.fromtimestamp) with the tz parameter set to [datetime.UTC](https://docs.python.org/dev/library/datetime.html#datetime.UTC). (Contributed by Paul Ganssle in https://github.com/python/cpython/issues/103857.)
- Replaced a long-deprecated [unittest](https://docs.python.org/dev/library/unittest.html#module-unittest) features: (`assertNotRegexpMatches`). Reference - [unittest features doc](https://docs.python.org/dev/whatsnew/3.12.html#id3).
- Replaced `xrange()` with `range()` as xrange is depricated since `python3`