### PR TITLE
update version check to 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        python-version: [3.8.x, 3.9.x, 3.10.x, 3.11.x, 3.12.x]
+        python-version: [3.9.x, 3.10.x, 3.11.x, 3.12.x, 3.13.x]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
       env:
@@ -26,14 +26,6 @@ jobs:
       run: |
         set -x
         git submodule update --init --recursive
-    - name: Lint
-      if: ${{ matrix.python-version  == 3.6 }}
-      run: |
-        set -x
-        pip install pylint
-        pip install yapf
-        test/run_pylint.sh
-        yapf -dr .
     - name: Test
       run: |
         set -x

--- a/gsutil.py
+++ b/gsutil.py
@@ -27,12 +27,12 @@ import warnings
 # TODO: gsutil-beta: Distribute a pylint rc file.
 
 ver = sys.version_info
-if ver.major != 3 or ver.minor < 8 or ver.minor > 12:
+if ver.major != 3 or ver.minor < 9 or ver.minor > 13:
   sys.exit(
-    "Error: gsutil requires Python version 3.8-3.12, but a different version is installed.\n"
+    "Error: gsutil requires Python version 3.9-3.13, but a different version is installed.\n"
     "You are currently running Python {}.{}\n"
     "Follow the steps below to resolve this issue:\n"
-    "\t1. Switch to Python 3.8-3.12 using your Python version manager or install an appropriate version.\n"
+    "\t1. Switch to Python 3.9-3.13 using your Python version manager or install an appropriate version.\n"
     "\t2. If you are unsure how to manage Python versions, visit [https://cloud.google.com/storage/docs/gsutil_install#specifications] for detailed instructions.".format(ver.major, ver.minor)
   )
 

--- a/setup.py
+++ b/setup.py
@@ -126,16 +126,16 @@ setup(
         'Natural Language :: English',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
         'Topic :: System :: Filesystems',
         'Topic :: Utilities',
     ],
-    # Gsutil supports Python 3.8 to 3.12
-    python_requires='>=3.8, <3.13',
+    # Gsutil supports Python 3.9 to 3.13
+    python_requires='>=3.9, <3.14',
     platforms='any',
     packages=find_packages(
         exclude=[


### PR DESCRIPTION
Updating version check to allow users with `python 3.13` to use `gsutil`.
Drop `python 3.8` from usage.