### PR TITLE
Added py313 kokoro test configs

### DIFF
--- a/test/ci/kokoro/linux/py313_json.cfg
+++ b/test/ci/kokoro/linux/py313_json.cfg
@@ -1,0 +1,61 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "/src/gsutil/test/ci/kokoro/run_integ_tests.sh"
+timeout_mins: 60
+
+# Get access keys from Keystore
+# go/kokoro-keystore
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "gsutil_kokoro_service_key"
+    }
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "mtls_test_account_refresh_token"
+    }
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "mtls_test_account_client_id"
+    }
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "mtls_test_account_client_secret"
+    }
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "mtls_test_cert"
+    }
+  }
+}
+
+# Environment variables to specify interpreter version.
+# go/kokoro-env-vars
+env_vars {
+  key: "PYMAJOR"
+  value: "3"
+}
+
+env_vars {
+  key: "PYMINOR"
+  value: "13"
+}
+
+env_vars {
+  key: "API"
+  value: "json"
+}

--- a/test/ci/kokoro/linux/py313_xml.cfg
+++ b/test/ci/kokoro/linux/py313_xml.cfg
@@ -1,0 +1,45 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "/src/gsutil/test/ci/kokoro/run_integ_tests.sh"
+timeout_mins: 60
+
+# Get access keys from Keystore
+# go/kokoro-keystore
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "gsutil_kokoro_service_key"
+    }
+  }
+}
+
+# Environment variables to specify interpreter version.
+# go/kokoro-env-vars
+env_vars {
+  key: "PYMAJOR"
+  value: "3"
+}
+
+env_vars {
+  key: "PYMINOR"
+  value: "13"
+}
+
+env_vars {
+  key: "API"
+  value: "xml"
+}

--- a/test/ci/kokoro/macos/py313_json.cfg
+++ b/test/ci/kokoro/macos/py313_json.cfg
@@ -1,0 +1,62 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "/src/gsutil/test/ci/kokoro/run_integ_tests.sh"
+timeout_mins: 60
+
+
+# Get access keys from Keystore
+# go/kokoro-keystore
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "gsutil_kokoro_service_key"
+    }
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "mtls_test_account_refresh_token"
+    }
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "mtls_test_account_client_id"
+    }
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "mtls_test_account_client_secret"
+    }
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "mtls_test_cert"
+    }
+  }
+}
+
+# Environment variables to specify interpreter version.
+# go/kokoro-env-vars
+env_vars {
+  key: "PYMAJOR"
+  value: "3"
+}
+
+env_vars {
+  key: "PYMINOR"
+  value: "13"
+}
+
+env_vars {
+  key: "API"
+  value: "json"
+}

--- a/test/ci/kokoro/macos/py313_xml.cfg
+++ b/test/ci/kokoro/macos/py313_xml.cfg
@@ -1,0 +1,46 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "/src/gsutil/test/ci/kokoro/run_integ_tests.sh"
+timeout_mins: 60
+
+
+# Get access keys from Keystore
+# go/kokoro-keystore
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "gsutil_kokoro_service_key"
+    }
+  }
+}
+
+# Environment variables to specify interpreter version.
+# go/kokoro-env-vars
+env_vars {
+  key: "PYMAJOR"
+  value: "3"
+}
+
+env_vars {
+  key: "PYMINOR"
+  value: "13"
+}
+
+env_vars {
+  key: "API"
+  value: "xml"
+}

--- a/test/ci/kokoro/windows/py313_json.cfg
+++ b/test/ci/kokoro/windows/py313_json.cfg
@@ -1,0 +1,74 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "src/gsutil/test/ci/kokoro/windows/run_integ_tests.bat"
+timeout_mins: 60
+
+
+# Get access keys from Keystore
+# go/kokoro-keystore
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "gsutil_kokoro_service_key"
+    }
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "mtls_test_account_refresh_token"
+    }
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "mtls_test_account_client_id"
+    }
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "mtls_test_account_client_secret"
+    }
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "mtls_test_cert"
+    }
+  }
+}
+
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L15
+build_params {
+  key: "GsutilRepoDir"
+  value: "C:\\src\\gsutil"
+}
+
+# Environment variables to specify interpreter version.
+# go/kokoro-env-vars
+env_vars {
+  key: "PYMAJOR"
+  value: "3"
+}
+
+env_vars {
+  key: "PYMINOR"
+  value: "13"
+}
+
+env_vars {
+  key: "API"
+  value: "json"
+}
+
+env_vars {
+  key: "BOTO_CONFIG"
+  value: "C:\\tmpfs\\src\\.boto"
+}
+

--- a/test/ci/kokoro/windows/py313_xml.cfg
+++ b/test/ci/kokoro/windows/py313_xml.cfg
@@ -1,0 +1,58 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "src/gsutil/test/ci/kokoro/windows/run_integ_tests.bat"
+timeout_mins: 60
+
+
+# Get access keys from Keystore
+# go/kokoro-keystore
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 74008
+      keyname: "gsutil_kokoro_service_key"
+    }
+  }
+}
+
+# Param doc: https://github.com/GoogleCloudPlatform/gsutil/blob/master/test/ci/kokoro/windows/run_integ_tests.ps1#L15
+build_params {
+  key: "GsutilRepoDir"
+  value: "C:\\src\\gsutil"
+}
+
+# Environment variables to specify interpreter version.
+# go/kokoro-env-vars
+env_vars {
+  key: "PYMAJOR"
+  value: "3"
+}
+
+env_vars {
+  key: "PYMINOR"
+  value: "13"
+}
+
+env_vars {
+  key: "API"
+  value: "xml"
+}
+
+env_vars {
+  key: "BOTO_CONFIG"
+  value: "C:\\tmpfs\\src\\.boto"
+}
+


### PR DESCRIPTION
This update adds `Python 3.13` test configurations to the Kokoro CI pipeline for macOS, Linux, and Windows. These changes ensure comprehensive testing across all major platforms.