### PR TITLE
Change python_requires from <=3.12 to <3.13

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -135,7 +135,7 @@ setup(
         'Topic :: Utilities',
     ],
     # Gsutil supports Python 3.8 to 3.12
-    python_requires='>=3.8, <=3.12',
+    python_requires='>=3.8, <3.13',
     platforms='any',
     packages=find_packages(
         exclude=[


### PR DESCRIPTION
This pull request updates the `python_requires` field in the `setup.py` file to `<3.13`, addressing an issue in the `v5.32` release where the constraint was incorrectly set to `<=3.12`. This fix ensures that `gsutil` can be installed via `pip` on `Python` versions `3.12.1` and above.