### PR TITLE
Fixes parity tests failures in windows machines.

### DIFF
--- a/gslib/tests/test_rsync.py
+++ b/gslib/tests/test_rsync.py
@@ -2999,7 +2999,13 @@ class TestRsync(testcase.GsUtilIntegrationTestCase):
 
     def _Check2():
       """Tests that a regex with a pipe works as expected."""
-      _check_exclude_regex('^data|[bc]$', set(['/a']))
+      if self._use_gcloud_storage and IS_WINDOWS:
+        # Pipe character should be escaped for windows cmd.
+        # It appears that ^ is not escaping | as expected but ^^^ does So
+        # changing input for windows shim mode gsutil test.
+        _check_exclude_regex('^data^^^|[bc]$', set(['/a']))
+      else:
+        _check_exclude_regex('^data|[bc]$', set(['/a']))
 
     _Check2()
 


### PR DESCRIPTION
`gsutil rsync` parity tests are failing in windows machine because of pipe character. Pipe character, `|`, is a special character for winodws cmd and it should escaped while being used in command input. Windows cmd treats `^` character as escape character and can be used to escape pipe character as well but it works only for internal windows commands and fails to escape for external commands. 

It appears that `^^^` string is correctly escaping pipe character even though there is no official windows documentation related to this. 

This PR modifies rsync test check which is testing pipe character in regex input. Since it needs to be escaped for windows machines, I have added a separate condition to format input incase of windows shim only mode. 