### PR TITLE
Ignore invalid escape sequence SyntaxWarning

### DIFF
--- a/gsutil.py
+++ b/gsutil.py
@@ -89,6 +89,10 @@ warnings.filterwarnings('ignore',
 warnings.filterwarnings('ignore',
                         category=UserWarning,
                         message=r'.* oauth2client was already imported from')
+warnings.filterwarnings("ignore",
+                        category=SyntaxWarning,
+                        message=r"invalid escape sequence",
+                        module=r".*third_party/pyparsing/")
 
 # List of third-party libraries. The first element of the tuple is the name of
 # the directory under third_party and the second element is the subdirectory


### PR DESCRIPTION
`Python 3.12` introduced a new `Syntax warning for invalid escape sequence`. Reference: [Python 3.12 Documentation](https://docs.python.org/dev/whatsnew/3.12.html#other-language-changes).

Most instances were fixed in [pull/1818](https://github.com/GoogleCloudPlatform/gsutil/pull/1818), except one occurrence in `pyparsing` submodule.

Fix was submitted in upstream as [commit](https://github.com/pyparsing/pyparsing/commit/e26dff1759eecaa81805632d455535a30ce8b495), To upgrade this submodule `gsutil` needs to drop support of `Python 3.8` which is planned for `June 2025`.

This PR silents the warnings temporarily till the original fix is submitted.