### PR TITLE
Fix Date formatting parity issue in hmac get command

### DIFF
--- a/gslib/commands/hmac.py
+++ b/gslib/commands/hmac.py
@@ -220,9 +220,9 @@ _DESCRIBE_COMMAND_FORMAT = (
     'format("\tService Account:       {}", serviceAccountEmail),' +
     'format("\tProject:               {}", projectId),' +
     'format("\tTime Created:          {}",' +
-    ' timeCreated.date(format="%a %d %b %Y %H:%M:%S GMT")),' +
+    ' timeCreated.date(format="%a\',\' %d %b %Y %H:%M:%S GMT")),' +
     'format("\tTime Last Updated:     {}",' +
-    ' updated.date(format="%a %d %b %Y %H:%M:%S GMT")),' +
+    ' updated.date(format="%a\',\' %d %b %Y %H:%M:%S GMT")),' +
     'format("\tEtag:                  {}", etag))')
 
 _LIST_COMMAND_SHORT_FORMAT = (


### PR DESCRIPTION
Fixes the output mismatch in gsutil hmac get command.

Sample Output of gsutil hmac get:
```
Time Created:          Wed, 25 Sep 2024 09:04:40 GMT
```

Sample Output of gsutil shim hmac get:
```
Time Created:          Wed 25 Sep 2024 09:04:40 GMT
```

Adding extra comma (`,`) in gsutil shim formatter to maintain consistency.