### PR TITLE
Fix Spacing inconsistency in hmac list

### DIFF
--- a/gslib/commands/hmac.py
+++ b/gslib/commands/hmac.py
@@ -226,8 +226,8 @@ _DESCRIBE_COMMAND_FORMAT = (
     'format("\tEtag:                  {}", etag))')
 
 _LIST_COMMAND_SHORT_FORMAT = (
-    '--format=table[no-heading](format("{} ", accessId),'
-    'state:width=11, serviceAccountEmail)')
+    '--format=table[no-heading](format("{}\t{:<12} {}",'
+    'accessId, state, serviceAccountEmail))')
 
 _PROJECT_FLAG = GcloudStorageFlag('--project')
 


### PR DESCRIPTION
Fixes the spacing inconsistency in hmac list command.

Sample output of gsutil hmac list:

```
+ GOOG1E3BL2EDSOK4PIMAHSDLLEGX33GDQ5YTDCOEHYKPUO24I4RHBZXSCGCWS ACTIVE       sa-hmac2@bigstore-gsutil-testing.iam.gserviceaccount.com
?                                                              ^
```

Sample output of gsutil shim hmac list:
```
- GOOG1E3BL2EDSOK4PIMAHSDLLEGX33GDQ5YTDCOEHYKPUO24I4RHBZXSCGCWS   ACTIVE       sa-hmac2@bigstore-gsutil-testing.iam.gserviceaccount.com
?                                                              ^^^
```

Making the gsutil shim output similar to gsutil output by formatting shim as: `short_list_format = '%s\t%-12s %s'`