### PR TITLE
Update ubuntu version for github workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         python-version: [3.8.x, 3.9.x, 3.10.x, 3.11.x, 3.12.x]


### PR DESCRIPTION
Updates the ubuntu version to 24.04 as suggested here https://github.com/actions/runner-images/issues/11101