### PR TITLE
Add invocation id to Gsutil user agent

### DIFF
--- a/gslib/tests/test_Doption.py
+++ b/gslib/tests/test_Doption.py
@@ -189,8 +189,8 @@ class TestDOption(testcase.GsUtilIntegrationTestCase):
       self.assertIn('Content-Length: 0', request_fields_str)
       self.assertRegex(
           request_fields_str,
-          'User-Agent: .*gsutil/%s.*interactive/False command/cat' %
-          gslib.VERSION)
+          'User-Agent: .*gsutil/%s.*interactive/False invocation-id/[a-z0-9-].+ command/cat'
+          % gslib.VERSION)
     elif self.test_api == ApiSelector.JSON:
       if six.PY2:
         self.assertIn("md5Hash: u'eB5eJF1ptWaXm4bijSPyxw=='", stderr)
@@ -203,8 +203,9 @@ class TestDOption(testcase.GsUtilIntegrationTestCase):
           stderr,
           '.*GET.*b/%s/o/%s' % (key_uri.bucket_name, key_uri.object_name))
       self.assertRegex(
-          stderr, 'Python/%s.gsutil/%s.*interactive/False command/cat' %
-          (platform.python_version(), gslib.VERSION))
+          stderr,
+          'Python/%s.gsutil/%s.*interactive/False invocation-id/[a-z0-9-].+ command/cat'
+          % (platform.python_version(), gslib.VERSION))
 
     if gslib.IS_PACKAGE_INSTALL:
       self.assertIn('PACKAGED_GSUTIL_INSTALLS_DO_NOT_HAVE_CHECKSUMS', stdout)

--- a/gslib/utils/user_agent_helper.py
+++ b/gslib/utils/user_agent_helper.py
@@ -16,6 +16,7 @@
 
 import six
 import sys
+import uuid
 import gslib
 from gslib.utils import system_util
 from gslib.storage_url import StorageUrlFromString
@@ -36,6 +37,7 @@ def GetUserAgent(args, metrics_off=True):
   user_agent += ' (%s)' % sys.platform
   user_agent += ' analytics/%s' % ('disabled' if metrics_off else 'enabled')
   user_agent += ' interactive/%s' % system_util.IsRunningInteractively()
+  user_agent += ' invocation-id/%s' % uuid.uuid4().hex
 
   if len(args) > 0:
     user_agent += ' command/%s' % args[0]


### PR DESCRIPTION
Adding an invocation id to UserAgent in order to ensure that we can distinguish between each command invocation.