### PR TITLE
Add -m option when it is used to user agent to track usage

### DIFF
--- a/gslib/tests/test_user_agent_helper.py
+++ b/gslib/tests/test_user_agent_helper.py
@@ -53,6 +53,12 @@ class TestUserAgentHelper(testcase.GsUtilUnitTestCase):
                      r"command/cp$")
 
   @mock.patch.object(system_util, 'InvokedViaCloudSdk')
+  def testCpWithMultiprocessing(self, mock_invoked):
+    mock_invoked.return_value = False
+    self.assertRegex(GetUserAgent(['cp', '-m', '1.txt', 'gs://dst']),
+                     r"command/cp-m$")
+
+  @mock.patch.object(system_util, 'InvokedViaCloudSdk')
   def testCpNotEnoughArgs(self, mock_invoked):
     mock_invoked.return_value = False
     self.assertRegex(GetUserAgent(['cp']), r"command/cp$")
@@ -95,6 +101,11 @@ class TestUserAgentHelper(testcase.GsUtilUnitTestCase):
                      r"command/mv-DaisyChain")
     self.assertRegex(GetUserAgent(['rsync', '-r', 'gs://src', 's3://dst']),
                      r"command/rsync-DaisyChain")
+
+  def testCpDaisyChainWithMultiprocessing(self):
+    self.assertRegex(
+        GetUserAgent(['cp', '-r', '-Z', '-m', 'gs://src', 's3://dst']),
+        r"command/cp-DaisyChain-m")
 
   @mock.patch.object(system_util, 'InvokedViaCloudSdk')
   def testPassOnInvalidUrlError(self, mock_invoked):

--- a/gslib/utils/user_agent_helper.py
+++ b/gslib/utils/user_agent_helper.py
@@ -62,6 +62,10 @@ def GetUserAgent(args, metrics_off=True):
           # Rewrite storage class.
           user_agent += '-s'
 
+    if '-m' in args:
+      # Use of multi processing
+      user_agent += '-m'
+
   if system_util.InvokedViaCloudSdk():
     user_agent += ' google-cloud-sdk'
     if system_util.CloudSdkVersion():


### PR DESCRIPTION
This change appends an addition `-m` to the command information set in UserAgent.

This is being added to understand the usage of the `-m` option across commands.