### PR TITLE
chore: remove unused code in command.py as upgraded to pyOpenSSL 26.0.0

### DIFF
--- a/gslib/command.py
+++ b/gslib/command.py
@@ -102,13 +102,6 @@ from gslib.utils.translation_helper import PRIVATE_DEFAULT_OBJ_ACL
 from gslib.wildcard_iterator import CreateWildcardIterator
 from six.moves import queue as Queue
 
-# pylint: disable=g-import-not-at-top
-try:
-  from Crypto import Random as CryptoRandom
-except ImportError:
-  CryptoRandom = None
-# pylint: enable=g-import-not-at-top
-
 OFFER_GSUTIL_M_SUGGESTION_THRESHOLD = 5
 OFFER_GSUTIL_M_SUGGESTION_FREQUENCY = 1000
 
@@ -185,15 +178,6 @@ def SetAclExceptionHandler(cls, e):
 # Python exit function cleanup) under the impression that they are non-empty.
 # However, this also lets us shut down somewhat more cleanly when interrupted.
 queues = []
-
-
-def _CryptoRandomAtFork():
-  if CryptoRandom and getattr(CryptoRandom, 'atfork', None):
-    # Fixes https://github.com/GoogleCloudPlatform/gsutil/issues/390. The
-    # oauth2client module uses Python's Crypto library when pyOpenSSL isn't
-    # present; that module requires calling atfork() in both the parent and
-    # child process after a new process is forked.
-    CryptoRandom.atfork()
 
 
 def _NewMultiprocessingQueue():
@@ -1441,7 +1425,6 @@ class Command(HelpProvider, GcloudStorageCommandMixin):
                                                 status_queue))
       p.daemon = True
       processes.append(p)
-      _CryptoRandomAtFork()
       p.start()
     consumer_pool = _ConsumerPool(processes, task_queue)
     consumer_pools.append(consumer_pool)
@@ -1933,7 +1916,6 @@ class Command(HelpProvider, GcloudStorageCommandMixin):
     assert process_count > 1, (
         'Invalid state, calling command._ApplyThreads with only one process.')
 
-    _CryptoRandomAtFork()
     # Separate processes should exit on a terminating signal,
     # but to avoid race conditions only the main process should handle
     # multiprocessing cleanup. Override child processes to use a single signal


### PR DESCRIPTION
The original code in gslib/command.py was wrapped in a try...except ImportError: block. Because we removed pycrypto from the dependencies, if gsutil ran that code today, it would simply fail to find the library, catch the ImportError gracefully, and move on. It wouldn't crash the application.

Even though it is "dead code" now, leaving from Crypto import Random in gslib/command.py is a huge risk for security scanners. If a scanner sees from Crypto ..., it will flag gsutil for using pycrypto (CVE-2018-6594), causing false positives and blocking customer deployments.

By physically deleting the _CryptoRandomAtFork function and its imports, we guarantee a clean audit and completely sever gsutil's ties to the deprecated library. Furthermore, modern cryptographic libraries (like cryptography) handle process forking natively and securely, so the workaround is completely obsolete anyway.